### PR TITLE
Note and Chord Choices

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -35,6 +35,18 @@ dotnet_diagnostic.SA1407.severity = none
 # require that closing square brackets be followed by a space
 dotnet_diagnostic.SA1011.severity = none
 
+# require that parameter names start with a lowercase letter
+dotnet_diagnostic.SA1313.severity = none
+
+# require that get auto-properties begin with "get"
+dotnet_diagnostic.SA1623.severity = none
+
+# don't throw NotImplementedException
+dotnet_diagnostic.MA0025.severity = none
+
+# a constructor should not follow a property
+dotnet_diagnostic.SA1201.severity = none
+
 [*.csproj]
 indent_style = space
 indent_size = 2

--- a/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
+++ b/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="LazyCart" Version="0.4.1" />
     <PackageReference Include="Meziantou.Analyzer" Version="2.0.62">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/BaroquenMelody.Library/Composition/Choices/ChordChoice.cs
+++ b/src/BaroquenMelody.Library/Composition/Choices/ChordChoice.cs
@@ -1,0 +1,26 @@
+﻿namespace BaroquenMelody.Library.Composition.Choices;
+
+/// <summary>
+///     Represents the note choices for the voices in a given chord to arrive at the next chord.
+/// </summary>
+/// <param name="NoteChoices"> The note choices for the voices in a given chord to arrive at the next chord. </param>
+internal sealed record ChordChoice(ISet<NoteChoice> NoteChoices)
+{
+    public bool Equals(ChordChoice? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        return ReferenceEquals(this, other) || NoteChoices.SetEquals(other.NoteChoices);
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            return NoteChoices.Aggregate(1430287, (current, noteChoice) => current * 7302013 ^ noteChoice.GetHashCode());
+        }
+    }
+}

--- a/src/BaroquenMelody.Library/Composition/Choices/ChordChoiceRepositoryFactory.cs
+++ b/src/BaroquenMelody.Library/Composition/Choices/ChordChoiceRepositoryFactory.cs
@@ -13,9 +13,9 @@ internal sealed class ChordChoiceRepositoryFactory : IChordChoiceRepositoryFacto
     public IChordChoiceRepository Create(CompositionConfiguration compositionConfiguration) =>
         compositionConfiguration.VoiceConfigurations.Count switch
         {
-            2 => new DuetChordChoiceRepository(compositionConfiguration, _noteChoiceGenerator),
-            3 => new TrioChordChoiceRepository(compositionConfiguration, _noteChoiceGenerator),
-            4 => new QuartetChordChoiceRepository(compositionConfiguration, _noteChoiceGenerator),
+            DuetChordChoiceRepository.NumberOfVoices => new DuetChordChoiceRepository(compositionConfiguration, _noteChoiceGenerator),
+            TrioChordChoiceRepository.NumberOfVoices => new TrioChordChoiceRepository(compositionConfiguration, _noteChoiceGenerator),
+            QuartetChordChoiceRepository.NumberOfVoices => new QuartetChordChoiceRepository(compositionConfiguration, _noteChoiceGenerator),
             _ => throw new ArgumentException(
                 "The composition configuration must contain between two and four voice configurations.",
                 nameof(compositionConfiguration)

--- a/src/BaroquenMelody.Library/Composition/Choices/ChordChoiceRepositoryFactory.cs
+++ b/src/BaroquenMelody.Library/Composition/Choices/ChordChoiceRepositoryFactory.cs
@@ -1,0 +1,24 @@
+﻿using BaroquenMelody.Library.Composition.Configurations;
+
+namespace BaroquenMelody.Library.Composition.Choices;
+
+/// <inheritdoc cref="IChordChoiceRepository"/>
+internal sealed class ChordChoiceRepositoryFactory : IChordChoiceRepositoryFactory
+{
+    private readonly INoteChoiceGenerator _noteChoiceGenerator;
+
+    public ChordChoiceRepositoryFactory(INoteChoiceGenerator noteChoiceGenerator) =>
+        _noteChoiceGenerator = noteChoiceGenerator;
+
+    public IChordChoiceRepository Create(CompositionConfiguration compositionConfiguration) =>
+        compositionConfiguration.VoiceConfigurations.Count switch
+        {
+            2 => new DuetChordChoiceRepository(compositionConfiguration, _noteChoiceGenerator),
+            3 => new TrioChordChoiceRepository(compositionConfiguration, _noteChoiceGenerator),
+            4 => new QuartetChordChoiceRepository(compositionConfiguration, _noteChoiceGenerator),
+            _ => throw new ArgumentException(
+                "The composition configuration must contain between two and four voice configurations.",
+                nameof(compositionConfiguration)
+            )
+        };
+}

--- a/src/BaroquenMelody.Library/Composition/Choices/DuetChordChoiceRepository.cs
+++ b/src/BaroquenMelody.Library/Composition/Choices/DuetChordChoiceRepository.cs
@@ -1,0 +1,38 @@
+﻿using BaroquenMelody.Library.Composition.Choices.Extensions;
+using BaroquenMelody.Library.Composition.Configurations;
+using LazyCart;
+using System.Numerics;
+
+namespace BaroquenMelody.Library.Composition.Choices;
+
+/// <inheritdoc cref="IChordChoiceRepository"/>
+internal sealed class DuetChordChoiceRepository : IChordChoiceRepository
+{
+    private const int ExpectedNumberOfVoices = 2;
+
+    private readonly ILazyCartesianProduct<NoteChoice, NoteChoice> _noteChoices;
+
+    public DuetChordChoiceRepository(CompositionConfiguration configuration, INoteChoiceGenerator noteChoiceGenerator)
+    {
+        if (configuration.VoiceConfigurations.Count != ExpectedNumberOfVoices)
+        {
+            throw new ArgumentException(
+                "The composition configuration must contain exactly two voice configurations.",
+                nameof(configuration)
+            );
+        }
+
+        var noteChoicesForVoices = configuration.VoiceConfigurations.Select(
+            voiceConfiguration => noteChoiceGenerator.GenerateNoteChoices(voiceConfiguration.Voice)
+        ).ToList();
+
+        _noteChoices = new LazyCartesianProduct<NoteChoice, NoteChoice>(
+            noteChoicesForVoices[0].ToList(),
+            noteChoicesForVoices[1].ToList()
+        );
+    }
+
+    public BigInteger Count => _noteChoices.Size;
+
+    public ChordChoice GetChordChoice(BigInteger index) => _noteChoices[index].ToChordChoice();
+}

--- a/src/BaroquenMelody.Library/Composition/Choices/DuetChordChoiceRepository.cs
+++ b/src/BaroquenMelody.Library/Composition/Choices/DuetChordChoiceRepository.cs
@@ -8,13 +8,13 @@ namespace BaroquenMelody.Library.Composition.Choices;
 /// <inheritdoc cref="IChordChoiceRepository"/>
 internal sealed class DuetChordChoiceRepository : IChordChoiceRepository
 {
-    private const int ExpectedNumberOfVoices = 2;
+    public const int NumberOfVoices = 2;
 
     private readonly ILazyCartesianProduct<NoteChoice, NoteChoice> _noteChoices;
 
     public DuetChordChoiceRepository(CompositionConfiguration configuration, INoteChoiceGenerator noteChoiceGenerator)
     {
-        if (configuration.VoiceConfigurations.Count != ExpectedNumberOfVoices)
+        if (configuration.VoiceConfigurations.Count != NumberOfVoices)
         {
             throw new ArgumentException(
                 "The composition configuration must contain exactly two voice configurations.",

--- a/src/BaroquenMelody.Library/Composition/Choices/Extensions/NoteChoiceExtensions.cs
+++ b/src/BaroquenMelody.Library/Composition/Choices/Extensions/NoteChoiceExtensions.cs
@@ -1,0 +1,31 @@
+﻿namespace BaroquenMelody.Library.Composition.Choices.Extensions;
+
+/// <summary>
+///    Extensions for <see cref="NoteChoice"/>.
+/// </summary>
+internal static class NoteChoiceExtensions
+{
+    /// <summary>
+    ///     Convert a tuple of <see cref="NoteChoice"/>s to a <see cref="ChordChoice"/>.
+    /// </summary>
+    /// <param name="source"> The tuple of <see cref="NoteChoice"/>s to convert. </param>
+    /// <returns> The <see cref="ChordChoice"/> representing the given tuple of <see cref="NoteChoice"/>s. </returns>
+    public static ChordChoice ToChordChoice(this (NoteChoice, NoteChoice) source) =>
+        new(new HashSet<NoteChoice> { source.Item1, source.Item2 });
+
+    /// <summary>
+    ///     Convert a tuple of <see cref="NoteChoice"/>s to a <see cref="ChordChoice"/>.
+    /// </summary>
+    /// <param name="source"> The tuple of <see cref="NoteChoice"/>s to convert. </param>
+    /// <returns> The <see cref="ChordChoice"/> representing the given tuple of <see cref="NoteChoice"/>s. </returns>
+    public static ChordChoice ToChordChoice(this (NoteChoice, NoteChoice, NoteChoice) source) =>
+        new(new HashSet<NoteChoice> { source.Item1, source.Item2, source.Item3 });
+
+    /// <summary>
+    ///     Convert a tuple of <see cref="NoteChoice"/>s to a <see cref="ChordChoice"/>.
+    /// </summary>
+    /// <param name="source"> The tuple of <see cref="NoteChoice"/>s to convert. </param>
+    /// <returns> The <see cref="ChordChoice"/> representing the given tuple of <see cref="NoteChoice"/>s. </returns>
+    public static ChordChoice ToChordChoice(this (NoteChoice, NoteChoice, NoteChoice, NoteChoice) source) =>
+        new(new HashSet<NoteChoice> { source.Item1, source.Item2, source.Item3, source.Item4 });
+}

--- a/src/BaroquenMelody.Library/Composition/Choices/IChordChoiceRepository.cs
+++ b/src/BaroquenMelody.Library/Composition/Choices/IChordChoiceRepository.cs
@@ -1,0 +1,21 @@
+﻿using System.Numerics;
+
+namespace BaroquenMelody.Library.Composition.Choices;
+
+/// <summary>
+///    Represents a repository of <see cref="ChordChoice"/>s.
+/// </summary>
+internal interface IChordChoiceRepository
+{
+    /// <summary>
+    ///   The number of available chord choices.
+    /// </summary>
+    public BigInteger Count { get; }
+
+    /// <summary>
+    ///   Gets the <see cref="ChordChoice"/> at the given index.
+    /// </summary>
+    /// <param name="index"> The index of the <see cref="ChordChoice"/> to get. </param>
+    /// <returns> The <see cref="ChordChoice"/> at the given index. </returns>
+    public ChordChoice GetChordChoice(BigInteger index);
+}

--- a/src/BaroquenMelody.Library/Composition/Choices/IChordChoiceRepositoryFactory.cs
+++ b/src/BaroquenMelody.Library/Composition/Choices/IChordChoiceRepositoryFactory.cs
@@ -1,0 +1,17 @@
+﻿using BaroquenMelody.Library.Composition.Configurations;
+
+namespace BaroquenMelody.Library.Composition.Choices;
+
+/// <summary>
+///     A factory for creating <see cref="IChordChoiceRepository"/>s.
+/// </summary>
+internal interface IChordChoiceRepositoryFactory
+{
+    /// <summary>
+    ///     Creates a <see cref="IChordChoiceRepository"/> for the given <see cref="CompositionConfiguration"/>. This is needed
+    ///     because the specific <see cref="IChordChoiceRepository"/> to use depends on how many voices are in the composition.
+    /// </summary>
+    /// <param name="compositionConfiguration"> The <see cref="CompositionConfiguration"/> to create the <see cref="IChordChoiceRepository"/> for. </param>
+    /// <returns> The created <see cref="IChordChoiceRepository"/>. </returns>
+    IChordChoiceRepository Create(CompositionConfiguration compositionConfiguration);
+}

--- a/src/BaroquenMelody.Library/Composition/Choices/INoteChoiceGenerator.cs
+++ b/src/BaroquenMelody.Library/Composition/Choices/INoteChoiceGenerator.cs
@@ -1,0 +1,16 @@
+﻿using BaroquenMelody.Library.Composition.Enums;
+
+namespace BaroquenMelody.Library.Composition.Choices;
+
+/// <summary>
+///     Generates the possible note choices for the given voice.
+/// </summary>
+internal interface INoteChoiceGenerator
+{
+    /// <summary>
+    ///    Generates the possible note choices for the given voice.
+    /// </summary>
+    /// <param name="voice"> The voice to generate note choices for. </param>
+    /// <returns> The possible note choices for the given voice. </returns>
+    ISet<NoteChoice> GenerateNoteChoices(Voice voice);
+}

--- a/src/BaroquenMelody.Library/Composition/Choices/NoteChoice.cs
+++ b/src/BaroquenMelody.Library/Composition/Choices/NoteChoice.cs
@@ -1,0 +1,15 @@
+﻿using BaroquenMelody.Library.Composition.Enums;
+
+namespace BaroquenMelody.Library.Composition.Choices;
+
+/// <summary>
+///    Represents a choice of note motion and pitch change for a given voice to arrive at the next note.
+/// </summary>
+/// <param name="Voice"> The voice associated with the note choice. </param>
+/// <param name="Motion"> The motion which will be used to arrive at the next note. </param>
+/// <param name="PitchChange"> The amount of pitch change which will be used to arrive at the next note. </param>
+internal sealed record NoteChoice(
+    Voice Voice,
+    NoteMotion Motion,
+    byte PitchChange
+);

--- a/src/BaroquenMelody.Library/Composition/Choices/NoteChoiceGenerator.cs
+++ b/src/BaroquenMelody.Library/Composition/Choices/NoteChoiceGenerator.cs
@@ -1,0 +1,27 @@
+﻿using BaroquenMelody.Library.Composition.Enums;
+
+namespace BaroquenMelody.Library.Composition.Choices;
+
+/// <inheritdoc cref="INoteChoiceGenerator"/>
+internal sealed class NoteChoiceGenerator : INoteChoiceGenerator
+{
+    private readonly byte _minPitchChange;
+    private readonly byte _maxPitchChange;
+
+    public NoteChoiceGenerator(byte minPitchChange = 1, byte maxPitchChange = 6)
+    {
+        _minPitchChange = minPitchChange;
+        _maxPitchChange = maxPitchChange;
+    }
+
+    public ISet<NoteChoice> GenerateNoteChoices(Voice voice) => Enumerable
+        .Range(_minPitchChange, _maxPitchChange - _minPitchChange + 1)
+        .Select(pitchChange => (byte)pitchChange)
+        .SelectMany(pitchChange =>
+            new[] { NoteMotion.Ascending, NoteMotion.Descending }.Select(noteMotion =>
+                new NoteChoice(voice, noteMotion, pitchChange)
+            )
+        )
+        .Append(new NoteChoice(voice, NoteMotion.Oblique, 0))
+        .ToHashSet();
+}

--- a/src/BaroquenMelody.Library/Composition/Choices/QuartetChordChoiceRepository.cs
+++ b/src/BaroquenMelody.Library/Composition/Choices/QuartetChordChoiceRepository.cs
@@ -1,0 +1,40 @@
+﻿using BaroquenMelody.Library.Composition.Choices.Extensions;
+using BaroquenMelody.Library.Composition.Configurations;
+using LazyCart;
+using System.Numerics;
+
+namespace BaroquenMelody.Library.Composition.Choices;
+
+/// <inheritdoc cref="IChordChoiceRepository"/>
+internal sealed class QuartetChordChoiceRepository : IChordChoiceRepository
+{
+    private const int ExpectedNumberOfVoices = 4;
+
+    private readonly ILazyCartesianProduct<NoteChoice, NoteChoice, NoteChoice, NoteChoice> _noteChoices;
+
+    public QuartetChordChoiceRepository(CompositionConfiguration configuration, INoteChoiceGenerator noteChoiceGenerator)
+    {
+        if (configuration.VoiceConfigurations.Count != ExpectedNumberOfVoices)
+        {
+            throw new ArgumentException(
+                "The composition configuration must contain exactly four voice configurations.",
+                nameof(configuration)
+            );
+        }
+
+        var noteChoicesForVoices = configuration.VoiceConfigurations.Select(
+            voiceConfiguration => noteChoiceGenerator.GenerateNoteChoices(voiceConfiguration.Voice)
+        ).ToList();
+
+        _noteChoices = new LazyCartesianProduct<NoteChoice, NoteChoice, NoteChoice, NoteChoice>(
+            noteChoicesForVoices[0].ToList(),
+            noteChoicesForVoices[1].ToList(),
+            noteChoicesForVoices[2].ToList(),
+            noteChoicesForVoices[3].ToList()
+        );
+    }
+
+    public BigInteger Count => _noteChoices.Size;
+
+    public ChordChoice GetChordChoice(BigInteger index) => _noteChoices[index].ToChordChoice();
+}

--- a/src/BaroquenMelody.Library/Composition/Choices/QuartetChordChoiceRepository.cs
+++ b/src/BaroquenMelody.Library/Composition/Choices/QuartetChordChoiceRepository.cs
@@ -8,13 +8,13 @@ namespace BaroquenMelody.Library.Composition.Choices;
 /// <inheritdoc cref="IChordChoiceRepository"/>
 internal sealed class QuartetChordChoiceRepository : IChordChoiceRepository
 {
-    private const int ExpectedNumberOfVoices = 4;
+    public const int NumberOfVoices = 4;
 
     private readonly ILazyCartesianProduct<NoteChoice, NoteChoice, NoteChoice, NoteChoice> _noteChoices;
 
     public QuartetChordChoiceRepository(CompositionConfiguration configuration, INoteChoiceGenerator noteChoiceGenerator)
     {
-        if (configuration.VoiceConfigurations.Count != ExpectedNumberOfVoices)
+        if (configuration.VoiceConfigurations.Count != NumberOfVoices)
         {
             throw new ArgumentException(
                 "The composition configuration must contain exactly four voice configurations.",

--- a/src/BaroquenMelody.Library/Composition/Choices/TrioChordChoiceRepository.cs
+++ b/src/BaroquenMelody.Library/Composition/Choices/TrioChordChoiceRepository.cs
@@ -8,13 +8,13 @@ namespace BaroquenMelody.Library.Composition.Choices;
 /// <inheritdoc cref="IChordChoiceRepository"/>
 internal sealed class TrioChordChoiceRepository : IChordChoiceRepository
 {
-    private const int ExpectedNumberOfVoices = 3;
+    public const int NumberOfVoices = 3;
 
     private readonly ILazyCartesianProduct<NoteChoice, NoteChoice, NoteChoice> _noteChoices;
 
     public TrioChordChoiceRepository(CompositionConfiguration configuration, INoteChoiceGenerator noteChoiceGenerator)
     {
-        if (configuration.VoiceConfigurations.Count != ExpectedNumberOfVoices)
+        if (configuration.VoiceConfigurations.Count != NumberOfVoices)
         {
             throw new ArgumentException(
                 "The composition configuration must contain exactly three voice configurations.",

--- a/src/BaroquenMelody.Library/Composition/Choices/TrioChordChoiceRepository.cs
+++ b/src/BaroquenMelody.Library/Composition/Choices/TrioChordChoiceRepository.cs
@@ -1,0 +1,39 @@
+﻿using BaroquenMelody.Library.Composition.Choices.Extensions;
+using BaroquenMelody.Library.Composition.Configurations;
+using LazyCart;
+using System.Numerics;
+
+namespace BaroquenMelody.Library.Composition.Choices;
+
+/// <inheritdoc cref="IChordChoiceRepository"/>
+internal sealed class TrioChordChoiceRepository : IChordChoiceRepository
+{
+    private const int ExpectedNumberOfVoices = 3;
+
+    private readonly ILazyCartesianProduct<NoteChoice, NoteChoice, NoteChoice> _noteChoices;
+
+    public TrioChordChoiceRepository(CompositionConfiguration configuration, INoteChoiceGenerator noteChoiceGenerator)
+    {
+        if (configuration.VoiceConfigurations.Count != ExpectedNumberOfVoices)
+        {
+            throw new ArgumentException(
+                "The composition configuration must contain exactly three voice configurations.",
+                nameof(configuration)
+            );
+        }
+
+        var noteChoicesForVoices = configuration.VoiceConfigurations.Select(
+            voiceConfiguration => noteChoiceGenerator.GenerateNoteChoices(voiceConfiguration.Voice)
+        ).ToList();
+
+        _noteChoices = new LazyCartesianProduct<NoteChoice, NoteChoice, NoteChoice>(
+            noteChoicesForVoices[0].ToList(),
+            noteChoicesForVoices[1].ToList(),
+            noteChoicesForVoices[2].ToList()
+        );
+    }
+
+    public BigInteger Count => _noteChoices.Size;
+
+    public ChordChoice GetChordChoice(BigInteger index) => _noteChoices[index].ToChordChoice();
+}

--- a/src/BaroquenMelody.Library/Composition/Configurations/CompositionConfiguration.cs
+++ b/src/BaroquenMelody.Library/Composition/Configurations/CompositionConfiguration.cs
@@ -1,0 +1,9 @@
+﻿namespace BaroquenMelody.Library.Composition.Configurations;
+
+/// <summary>
+///     The composition configuration.
+/// </summary>
+/// <param name="VoiceConfigurations"> The voice configurations to be used in the composition. </param>
+internal record CompositionConfiguration(
+    ISet<VoiceConfiguration> VoiceConfigurations
+);

--- a/src/BaroquenMelody.Library/Composition/Configurations/VoiceConfiguration.cs
+++ b/src/BaroquenMelody.Library/Composition/Configurations/VoiceConfiguration.cs
@@ -1,0 +1,15 @@
+﻿using BaroquenMelody.Library.Composition.Enums;
+
+namespace BaroquenMelody.Library.Composition.Configurations;
+
+/// <summary>
+///    The voice configuration. Allowing for the configuration of the pitch range for a given voice.
+/// </summary>
+/// <param name="Voice"> The voice to be configured. </param>
+/// <param name="MinPitch"> The voice's minimum pitch value. </param>
+/// <param name="MaxPitch"> The voice's maximum pitch value. </param>
+internal record VoiceConfiguration(
+    Voice Voice,
+    byte MinPitch,
+    byte MaxPitch
+);

--- a/src/BaroquenMelody.Library/Composition/Enums/NoteMotion.cs
+++ b/src/BaroquenMelody.Library/Composition/Enums/NoteMotion.cs
@@ -1,0 +1,22 @@
+﻿namespace BaroquenMelody.Library.Composition.Enums;
+
+/// <summary>
+///   Indicates the motion taken to arrive at a given note from the previous note.
+/// </summary>
+internal enum NoteMotion : byte
+{
+    /// <summary>
+    ///     Indicates that the note is arrived at by moving up from the previous note.
+    /// </summary>
+    Ascending,
+
+    /// <summary>
+    ///     Indicates that the note is arrived at by moving down from the previous note.
+    /// </summary>
+    Descending,
+
+    /// <summary>
+    ///     Indicates that the note is arrived at by staying at the same pitch as the previous note.
+    /// </summary>
+    Oblique
+}

--- a/src/BaroquenMelody.Library/Composition/Enums/NoteSpan.cs
+++ b/src/BaroquenMelody.Library/Composition/Enums/NoteSpan.cs
@@ -1,0 +1,17 @@
+﻿namespace BaroquenMelody.Library.Composition.Enums;
+
+/// <summary>
+///     Indicates whether a note is arrived at by moving one step or more than one step from the previous note.
+/// </summary>
+internal enum NoteSpan : byte
+{
+    /// <summary>
+    ///    Indicates that the note is arrived at by moving one step from the previous note.
+    /// </summary>
+    Step,
+
+    /// <summary>
+    ///   Indicates that the note is arrived at by moving more than one step from the previous note.
+    /// </summary>
+    Leap
+}

--- a/src/BaroquenMelody.Library/Composition/Enums/Voice.cs
+++ b/src/BaroquenMelody.Library/Composition/Enums/Voice.cs
@@ -1,0 +1,27 @@
+﻿namespace BaroquenMelody.Library.Composition.Enums;
+
+/// <summary>
+///    Indicates the voice being used to play a note.
+/// </summary>
+internal enum Voice : byte
+{
+    /// <summary>
+    ///     The highest voice.
+    /// </summary>
+    Soprano,
+
+    /// <summary>
+    ///    The second highest voice.
+    /// </summary>
+    Alto,
+
+    /// <summary>
+    ///   The second lowest voice.
+    /// </summary>
+    Tenor,
+
+    /// <summary>
+    ///  The lowest voice.
+    /// </summary>
+    Bass
+}

--- a/tests/BaroquenMelody.Library.Tests/Composition/Choices/ChordChoiceRepositoryFactoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Composition/Choices/ChordChoiceRepositoryFactoryTests.cs
@@ -1,0 +1,64 @@
+﻿using BaroquenMelody.Library.Composition.Choices;
+using BaroquenMelody.Library.Composition.Configurations;
+using BaroquenMelody.Library.Composition.Enums;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Composition.Choices;
+
+[TestFixture]
+internal sealed class ChordChoiceRepositoryFactoryTests
+{
+    private INoteChoiceGenerator _mockNoteChoiceGenerator = null!;
+
+    private IChordChoiceRepositoryFactory _chordChoiceRepositoryFactory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockNoteChoiceGenerator = Substitute.For<INoteChoiceGenerator>();
+        _chordChoiceRepositoryFactory = new ChordChoiceRepositoryFactory(_mockNoteChoiceGenerator);
+    }
+
+    [Test]
+    [TestCase(2, typeof(DuetChordChoiceRepository))]
+    [TestCase(3, typeof(TrioChordChoiceRepository))]
+    [TestCase(4, typeof(QuartetChordChoiceRepository))]
+    public void WhenChordChoiceRepositoryFactoryCreatesChordChoiceRepository_ItReturnsExpectedType(
+        int numberOfVoices,
+        Type expectedType)
+    {
+        // arrange
+        var compositionConfiguration = new CompositionConfiguration(
+            Enumerable.Range(0, numberOfVoices)
+                .Select(index => new VoiceConfiguration(Voice.Soprano, (byte)index, (byte)(index + 1)))
+                .ToHashSet()
+        );
+
+        // act
+        var chordChoiceRepository = _chordChoiceRepositoryFactory.Create(compositionConfiguration);
+
+        // assert
+        chordChoiceRepository.Should().BeOfType(expectedType);
+    }
+
+    [Test]
+    public void WhenChordChoiceRepositoryIsPassedInvalidConfiguration_ItThrows()
+    {
+        // arrange
+        var compositionConfiguration = new CompositionConfiguration(
+            new HashSet<VoiceConfiguration>
+            {
+                // invalid configuration: only one voice
+                new(Voice.Soprano, 55, 90)
+            }
+        );
+
+        // act
+        var act = () => _chordChoiceRepositoryFactory.Create(compositionConfiguration);
+
+        // assert
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Composition/Choices/ChordChoiceTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Composition/Choices/ChordChoiceTests.cs
@@ -9,6 +9,33 @@ namespace BaroquenMelody.Library.Tests.Composition.Choices;
 internal sealed class ChordChoiceTests
 {
     [Test]
+    public void WhenChordChoicesAreSameReference_TheyAreEqual()
+    {
+        var note1 = new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0);
+        var note2 = new NoteChoice(Voice.Alto, NoteMotion.Ascending, 2);
+        var note3 = new NoteChoice(Voice.Tenor, NoteMotion.Descending, 3);
+        var note4 = new NoteChoice(Voice.Bass, NoteMotion.Ascending, 5);
+
+        var chordChoiceA = new ChordChoice(new HashSet<NoteChoice> { note1, note2, note3, note4 });
+        var chordChoiceB = chordChoiceA;
+
+        chordChoiceA.Should().BeEquivalentTo(chordChoiceB);
+        chordChoiceB.Should().BeEquivalentTo(chordChoiceA);
+
+        chordChoiceA.Equals(chordChoiceB).Should().BeTrue();
+        chordChoiceB.Equals(chordChoiceA).Should().BeTrue();
+
+        chordChoiceA.GetHashCode().Should().Be(chordChoiceB.GetHashCode());
+        chordChoiceB.GetHashCode().Should().Be(chordChoiceA.GetHashCode());
+
+        (chordChoiceA == chordChoiceB).Should().BeTrue();
+        (chordChoiceB == chordChoiceA).Should().BeTrue();
+
+        (chordChoiceA != chordChoiceB).Should().BeFalse();
+        (chordChoiceB != chordChoiceA).Should().BeFalse();
+    }
+
+    [Test]
     public void WhenChordChoicesHaveSameNoteChoices_TheyAreEqual()
     {
         var note1 = new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0);
@@ -30,6 +57,9 @@ internal sealed class ChordChoiceTests
 
         (chordChoiceA == chordChoiceB).Should().BeTrue();
         (chordChoiceB == chordChoiceA).Should().BeTrue();
+
+        (chordChoiceA != chordChoiceB).Should().BeFalse();
+        (chordChoiceB != chordChoiceA).Should().BeFalse();
     }
 
     [Test]

--- a/tests/BaroquenMelody.Library.Tests/Composition/Choices/ChordChoiceTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Composition/Choices/ChordChoiceTests.cs
@@ -1,0 +1,51 @@
+﻿using BaroquenMelody.Library.Composition.Choices;
+using BaroquenMelody.Library.Composition.Enums;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Composition.Choices;
+
+[TestFixture]
+internal sealed class ChordChoiceTests
+{
+    [Test]
+    public void WhenChordChoicesHaveSameNoteChoices_TheyAreEqual()
+    {
+        var note1 = new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0);
+        var note2 = new NoteChoice(Voice.Alto, NoteMotion.Ascending, 2);
+        var note3 = new NoteChoice(Voice.Tenor, NoteMotion.Descending, 3);
+        var note4 = new NoteChoice(Voice.Bass, NoteMotion.Ascending, 5);
+
+        var chordChoiceA = new ChordChoice(new HashSet<NoteChoice> { note1, note2, note3, note4 });
+        var chordChoiceB = new ChordChoice(new HashSet<NoteChoice> { note1, note2, note3, note4 });
+
+        chordChoiceA.Should().BeEquivalentTo(chordChoiceB);
+        chordChoiceB.Should().BeEquivalentTo(chordChoiceA);
+
+        chordChoiceA.Equals(chordChoiceB).Should().BeTrue();
+        chordChoiceB.Equals(chordChoiceA).Should().BeTrue();
+
+        chordChoiceA.GetHashCode().Should().Be(chordChoiceB.GetHashCode());
+        chordChoiceB.GetHashCode().Should().Be(chordChoiceA.GetHashCode());
+
+        (chordChoiceA == chordChoiceB).Should().BeTrue();
+        (chordChoiceB == chordChoiceA).Should().BeTrue();
+    }
+
+    [Test]
+    public void WhenOneChordChoiceIsNull_TheyAreNotEqual()
+    {
+        var note1 = new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0);
+        var note2 = new NoteChoice(Voice.Alto, NoteMotion.Ascending, 2);
+        var note3 = new NoteChoice(Voice.Tenor, NoteMotion.Descending, 3);
+        var note4 = new NoteChoice(Voice.Bass, NoteMotion.Ascending, 5);
+
+        var chordChoiceA = new ChordChoice(new HashSet<NoteChoice> { note1, note2, note3, note4 });
+        ChordChoice? chordChoiceB = null;
+
+        chordChoiceA.Should().NotBeEquivalentTo(chordChoiceB);
+        chordChoiceB.Should().NotBeEquivalentTo(chordChoiceA);
+
+        chordChoiceA.Equals(chordChoiceB).Should().BeFalse();
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Composition/Choices/DuetChordChoiceRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Composition/Choices/DuetChordChoiceRepositoryTests.cs
@@ -1,0 +1,99 @@
+﻿using BaroquenMelody.Library.Composition.Choices;
+using BaroquenMelody.Library.Composition.Configurations;
+using BaroquenMelody.Library.Composition.Enums;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Composition.Choices;
+
+[TestFixture]
+internal sealed class DuetChordChoiceRepositoryTests
+{
+    private INoteChoiceGenerator _mockNoteChoiceGenerator = null!;
+
+    [SetUp]
+    public void SetUp() => _mockNoteChoiceGenerator = Substitute.For<INoteChoiceGenerator>();
+
+    [Test]
+    public void WhenDuetChordChoiceRepositoryIsConstructed_ItGeneratesNoteChoices()
+    {
+        // arrange
+        var compositionConfiguration = new CompositionConfiguration(
+            new HashSet<VoiceConfiguration>
+            {
+                new(Voice.Soprano, 55, 90),
+                new(Voice.Alto, 45, 80)
+            }
+        );
+
+        _mockNoteChoiceGenerator
+            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Soprano))
+            .Returns(
+                new HashSet<NoteChoice>
+                {
+                    new(Voice.Soprano, NoteMotion.Oblique, 0),
+                    new(Voice.Soprano, NoteMotion.Ascending, 2),
+                    new(Voice.Soprano, NoteMotion.Descending, 3)
+                }
+            );
+
+        _mockNoteChoiceGenerator
+            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Alto))
+            .Returns(
+                new HashSet<NoteChoice>
+                {
+                    new(Voice.Alto, NoteMotion.Oblique, 0),
+                    new(Voice.Alto, NoteMotion.Ascending, 2),
+                    new(Voice.Alto, NoteMotion.Descending, 3)
+                }
+            );
+
+        var duetChordChoiceRepository = new DuetChordChoiceRepository(
+            compositionConfiguration,
+            _mockNoteChoiceGenerator
+        );
+
+        // act
+        var noteChoiceCount = duetChordChoiceRepository.Count;
+        var noteChoice = duetChordChoiceRepository.GetChordChoice(5);
+
+        // assert
+        noteChoiceCount.Should().Be(9);
+
+        noteChoice.Should().BeEquivalentTo(
+            new ChordChoice(
+                new HashSet<NoteChoice>
+                {
+                    new(Voice.Soprano, NoteMotion.Ascending, 2),
+                    new(Voice.Alto, NoteMotion.Descending, 3)
+                }
+            )
+        );
+
+        _mockNoteChoiceGenerator.Received(2).GenerateNoteChoices(Arg.Any<Voice>());
+    }
+
+    [Test]
+    public void WhenInvalidCompositionConfigurationIsPassedToDuetChordChoiceRepository_ItThrows()
+    {
+        // arrange
+        var compositionConfiguration = new CompositionConfiguration(
+            new HashSet<VoiceConfiguration>
+            {
+                new(Voice.Soprano, 55, 90),
+                new(Voice.Alto, 45, 80),
+                new(Voice.Tenor, 35, 70)
+            }
+        );
+
+        // act
+        var act = () => _ = new DuetChordChoiceRepository(
+            compositionConfiguration,
+            _mockNoteChoiceGenerator
+        );
+
+        // assert
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Composition/Choices/Extensions/NoteChoiceExtensionsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Composition/Choices/Extensions/NoteChoiceExtensionsTests.cs
@@ -1,0 +1,62 @@
+﻿using BaroquenMelody.Library.Composition.Choices;
+using BaroquenMelody.Library.Composition.Choices.Extensions;
+using BaroquenMelody.Library.Composition.Enums;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Composition.Choices.Extensions;
+
+[TestFixture]
+internal sealed class NoteChoiceExtensionsTests
+{
+    [Test]
+    public void ToChordChoice_TwoNotes_CreatesExpectedChordChoice()
+    {
+        // arrange
+        var note1 = new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0);
+        var note2 = new NoteChoice(Voice.Alto, NoteMotion.Ascending, 2);
+
+        var source = (note1, note2);
+
+        // act
+        var result = source.ToChordChoice();
+
+        // assert
+        result.Should().BeEquivalentTo(new ChordChoice(new HashSet<NoteChoice> { note1, note2 }));
+    }
+
+    [Test]
+    public void ToChordChoice_ThreeNotes_CreatesExpectedChordChoice()
+    {
+        // arrange
+        var note1 = new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0);
+        var note2 = new NoteChoice(Voice.Alto, NoteMotion.Ascending, 2);
+        var note3 = new NoteChoice(Voice.Tenor, NoteMotion.Descending, 3);
+
+        var source = (note1, note2, note3);
+
+        // act
+        var result = source.ToChordChoice();
+
+        // assert
+        result.Should().BeEquivalentTo(new ChordChoice(new HashSet<NoteChoice> { note1, note2, note3 }));
+    }
+
+    [Test]
+    public void ToChordChoice_FourNotes_CreatesExpectedChordChoice()
+    {
+        // arrange
+        var note1 = new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0);
+        var note2 = new NoteChoice(Voice.Alto, NoteMotion.Ascending, 2);
+        var note3 = new NoteChoice(Voice.Tenor, NoteMotion.Descending, 3);
+        var note4 = new NoteChoice(Voice.Bass, NoteMotion.Ascending, 5);
+
+        var source = (note1, note2, note3, note4);
+
+        // act
+        var result = source.ToChordChoice();
+
+        // assert
+        result.Should().BeEquivalentTo(new ChordChoice(new HashSet<NoteChoice> { note1, note2, note3, note4 }));
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Composition/Choices/NoteChoiceGeneratorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Composition/Choices/NoteChoiceGeneratorTests.cs
@@ -1,0 +1,36 @@
+﻿using BaroquenMelody.Library.Composition.Choices;
+using BaroquenMelody.Library.Composition.Enums;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Composition.Choices;
+
+[TestFixture]
+internal sealed class NoteChoiceGeneratorTests
+{
+    private INoteChoiceGenerator _noteChoiceGenerator = null!;
+
+    [SetUp]
+    public void SetUp() => _noteChoiceGenerator = new NoteChoiceGenerator(1, 7);
+
+    [Test]
+    public void GenerateNoteChoices_GivenVoice_ReturnsNoteChoices()
+    {
+        var noteChoices = _noteChoiceGenerator.GenerateNoteChoices(Voice.Soprano);
+
+        noteChoices.Should().NotBeNull();
+        noteChoices.Should().NotBeEmpty();
+
+        noteChoices.Where(noteChoice => noteChoice.Motion == NoteMotion.Oblique)
+            .Should()
+            .HaveCount(1);
+
+        noteChoices.Where(noteChoice => noteChoice.Motion == NoteMotion.Ascending)
+            .Should()
+            .HaveCount(7);
+
+        noteChoices.Where(noteChoice => noteChoice.Motion == NoteMotion.Descending)
+            .Should()
+            .HaveCount(7);
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Composition/Choices/QuartetChordChoiceRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Composition/Choices/QuartetChordChoiceRepositoryTests.cs
@@ -1,0 +1,124 @@
+﻿using BaroquenMelody.Library.Composition.Choices;
+using BaroquenMelody.Library.Composition.Configurations;
+using BaroquenMelody.Library.Composition.Enums;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Composition.Choices;
+
+[TestFixture]
+internal sealed class QuartetChordChoiceRepositoryTests
+{
+    private INoteChoiceGenerator _mockNoteChoiceGenerator = null!;
+
+    [SetUp]
+    public void SetUp() => _mockNoteChoiceGenerator = Substitute.For<INoteChoiceGenerator>();
+
+    [Test]
+    public void WhenDuetChordChoiceRepositoryIsConstructed_ItGeneratesNoteChoices()
+    {
+        // arrange
+        var compositionConfiguration = new CompositionConfiguration(
+            new HashSet<VoiceConfiguration>
+            {
+                new(Voice.Soprano, 55, 90),
+                new(Voice.Alto, 45, 80),
+                new(Voice.Tenor, 35, 70),
+                new(Voice.Bass, 25, 60)
+            }
+        );
+
+        _mockNoteChoiceGenerator
+            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Soprano))
+            .Returns(
+                new HashSet<NoteChoice>
+                {
+                    new(Voice.Soprano, NoteMotion.Oblique, 0),
+                    new(Voice.Soprano, NoteMotion.Ascending, 2),
+                    new(Voice.Soprano, NoteMotion.Descending, 3)
+                }
+            );
+
+        _mockNoteChoiceGenerator
+            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Alto))
+            .Returns(
+                new HashSet<NoteChoice>
+                {
+                    new(Voice.Alto, NoteMotion.Oblique, 0),
+                    new(Voice.Alto, NoteMotion.Ascending, 2),
+                    new(Voice.Alto, NoteMotion.Descending, 3)
+                }
+            );
+
+        _mockNoteChoiceGenerator
+            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Tenor))
+            .Returns(
+                new HashSet<NoteChoice>
+                {
+                    new(Voice.Tenor, NoteMotion.Oblique, 0),
+                    new(Voice.Tenor, NoteMotion.Ascending, 2),
+                    new(Voice.Tenor, NoteMotion.Descending, 3)
+                }
+            );
+
+        _mockNoteChoiceGenerator
+            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Bass))
+            .Returns(
+                new HashSet<NoteChoice>
+                {
+                    new(Voice.Bass, NoteMotion.Oblique, 0),
+                    new(Voice.Bass, NoteMotion.Ascending, 2),
+                    new(Voice.Bass, NoteMotion.Descending, 3)
+                }
+            );
+
+        var quartetChordChoiceRepository = new QuartetChordChoiceRepository(
+            compositionConfiguration,
+            _mockNoteChoiceGenerator
+        );
+
+        // act
+        var noteChoiceCount = quartetChordChoiceRepository.Count;
+        var noteChoice = quartetChordChoiceRepository.GetChordChoice(1);
+
+        // assert
+        noteChoiceCount.Should().Be(81);
+
+        noteChoice.Should().BeEquivalentTo(
+            new ChordChoice(
+                new HashSet<NoteChoice>
+                {
+                    new(Voice.Soprano, NoteMotion.Oblique, 0),
+                    new(Voice.Alto, NoteMotion.Oblique, 0),
+                    new(Voice.Tenor, NoteMotion.Oblique, 0),
+                    new(Voice.Bass, NoteMotion.Ascending, 2)
+                }
+            )
+        );
+
+        _mockNoteChoiceGenerator.Received(4).GenerateNoteChoices(Arg.Any<Voice>());
+    }
+
+    [Test]
+    public void WhenInvalidCompositionConfigurationIsPassedToDuetChordChoiceRepository_ItThrows()
+    {
+        // arrange
+        var compositionConfiguration = new CompositionConfiguration(
+            new HashSet<VoiceConfiguration>
+            {
+                new(Voice.Soprano, 55, 90),
+                new(Voice.Alto, 45, 80)
+            }
+        );
+
+        // act
+        var act = () => _ = new QuartetChordChoiceRepository(
+            compositionConfiguration,
+            _mockNoteChoiceGenerator
+        );
+
+        // assert
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Composition/Choices/TrioChordChoiceRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Composition/Choices/TrioChordChoiceRepositoryTests.cs
@@ -1,0 +1,113 @@
+﻿using BaroquenMelody.Library.Composition.Choices;
+using BaroquenMelody.Library.Composition.Configurations;
+using BaroquenMelody.Library.Composition.Enums;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Composition.Choices;
+
+[TestFixture]
+internal sealed class TrioChordChoiceRepositoryTests
+{
+    private INoteChoiceGenerator _mockNoteChoiceGenerator = null!;
+
+    [SetUp]
+    public void SetUp() => _mockNoteChoiceGenerator = Substitute.For<INoteChoiceGenerator>();
+
+    [Test]
+    public void WhenDuetChordChoiceRepositoryIsConstructed_ItGeneratesNoteChoices()
+    {
+        // arrange
+        var compositionConfiguration = new CompositionConfiguration(
+            new HashSet<VoiceConfiguration>
+            {
+                new(Voice.Soprano, 55, 90),
+                new(Voice.Alto, 45, 80),
+                new(Voice.Tenor, 35, 70)
+            }
+        );
+
+        _mockNoteChoiceGenerator
+            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Soprano))
+            .Returns(
+                new HashSet<NoteChoice>
+                {
+                    new(Voice.Soprano, NoteMotion.Oblique, 0),
+                    new(Voice.Soprano, NoteMotion.Ascending, 2),
+                    new(Voice.Soprano, NoteMotion.Descending, 3)
+                }
+            );
+
+        _mockNoteChoiceGenerator
+            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Alto))
+            .Returns(
+                new HashSet<NoteChoice>
+                {
+                    new(Voice.Alto, NoteMotion.Oblique, 0),
+                    new(Voice.Alto, NoteMotion.Ascending, 2),
+                    new(Voice.Alto, NoteMotion.Descending, 3)
+                }
+            );
+
+        _mockNoteChoiceGenerator
+            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Tenor))
+            .Returns(
+                new HashSet<NoteChoice>
+                {
+                    new(Voice.Tenor, NoteMotion.Oblique, 0),
+                    new(Voice.Tenor, NoteMotion.Ascending, 2),
+                    new(Voice.Tenor, NoteMotion.Descending, 3)
+                }
+            );
+
+        var trioChordChoiceRepository = new TrioChordChoiceRepository(
+            compositionConfiguration,
+            _mockNoteChoiceGenerator
+        );
+
+        // act
+        var noteChoiceCount = trioChordChoiceRepository.Count;
+        var noteChoice = trioChordChoiceRepository.GetChordChoice(1);
+
+        // assert
+        noteChoiceCount.Should().Be(27);
+
+        noteChoice.Should().BeEquivalentTo(
+            new ChordChoice(
+                new HashSet<NoteChoice>
+                {
+                    new(Voice.Soprano, NoteMotion.Oblique, 0),
+                    new(Voice.Alto, NoteMotion.Oblique, 0),
+                    new(Voice.Tenor, NoteMotion.Ascending, 2)
+                }
+            )
+        );
+
+        _mockNoteChoiceGenerator.Received(3).GenerateNoteChoices(Arg.Any<Voice>());
+    }
+
+    [Test]
+    public void WhenInvalidCompositionConfigurationIsPassedToDuetChordChoiceRepository_ItThrows()
+    {
+        // arrange
+        var compositionConfiguration = new CompositionConfiguration(
+            new HashSet<VoiceConfiguration>
+            {
+                new(Voice.Soprano, 55, 90),
+                new(Voice.Alto, 45, 80),
+                new(Voice.Tenor, 35, 70),
+                new(Voice.Bass, 25, 60)
+            }
+        );
+
+        // act
+        var act = () => _ = new TrioChordChoiceRepository(
+            compositionConfiguration,
+            _mockNoteChoiceGenerator
+        );
+
+        // assert
+        act.Should().Throw<ArgumentException>();
+    }
+}


### PR DESCRIPTION
## Description

Add note and chord choice constructs. 

Use `LazyCart` to back repository classes in order to be able to retrieve choices by index without actually storing them on disk or in memory.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
