### PR TITLE
Composition Strategy

### DIFF
--- a/src/BaroquenMelody.Library/Composition/Choices/IChordChoiceRepository.cs
+++ b/src/BaroquenMelody.Library/Composition/Choices/IChordChoiceRepository.cs
@@ -1,5 +1,4 @@
-﻿using BaroquenMelody.Library.Composition.Contexts;
-using System.Numerics;
+﻿using System.Numerics;
 
 namespace BaroquenMelody.Library.Composition.Choices;
 

--- a/src/BaroquenMelody.Library/Composition/Strategies/CompositionStrategy.cs
+++ b/src/BaroquenMelody.Library/Composition/Strategies/CompositionStrategy.cs
@@ -1,0 +1,48 @@
+﻿using BaroquenMelody.Library.Composition.Choices;
+using BaroquenMelody.Library.Composition.Contexts;
+using BaroquenMelody.Library.Random;
+using System.Collections;
+using System.Numerics;
+
+namespace BaroquenMelody.Library.Composition.Strategies;
+
+/// <inheritdoc cref="ICompositionStrategy"/>
+internal sealed class CompositionStrategy : ICompositionStrategy
+{
+    private readonly IChordChoiceRepository _chordChoiceRepository;
+
+    private readonly IChordContextRepository _chordContextRepository;
+
+    private readonly IRandomTrueIndexSelector _randomTrueIndexSelector;
+
+    private readonly IDictionary<BigInteger, BitArray> _chordContextToChordChoiceMap;
+
+    public CompositionStrategy(
+        IChordChoiceRepository chordChoiceRepository,
+        IChordContextRepository chordContextRepository,
+        IRandomTrueIndexSelector randomTrueIndexSelector,
+        IDictionary<BigInteger, BitArray> chordContextToChordChoiceMap)
+    {
+        _chordChoiceRepository = chordChoiceRepository;
+        _chordContextRepository = chordContextRepository;
+        _randomTrueIndexSelector = randomTrueIndexSelector;
+        _chordContextToChordChoiceMap = chordContextToChordChoiceMap;
+    }
+
+    public ChordChoice GetNextChordChoice(ChordContext chordContext)
+    {
+        var chordContextIndex = _chordContextRepository.GetChordContextIndex(chordContext);
+        var chordChoiceIndices = _chordContextToChordChoiceMap[chordContextIndex];
+        var chordChoiceIndex = _randomTrueIndexSelector.SelectRandomTrueIndex(chordChoiceIndices);
+
+        return _chordChoiceRepository.GetChordChoice(chordChoiceIndex);
+    }
+
+    public void InvalidateChordChoice(ChordContext chordContext, ChordChoice chordChoice)
+    {
+        var chordContextIndex = _chordContextRepository.GetChordContextIndex(chordContext);
+        var chordChoiceIndex = _chordChoiceRepository.GetChordChoiceIndex(chordChoice);
+
+        _chordContextToChordChoiceMap[chordContextIndex][(int)chordChoiceIndex] = false;
+    }
+}

--- a/src/BaroquenMelody.Library/Composition/Strategies/ICompositionStrategy.cs
+++ b/src/BaroquenMelody.Library/Composition/Strategies/ICompositionStrategy.cs
@@ -1,0 +1,27 @@
+﻿using BaroquenMelody.Library.Composition.Choices;
+using BaroquenMelody.Library.Composition.Contexts;
+
+namespace BaroquenMelody.Library.Composition.Strategies;
+
+/// <summary>
+///     Represents a strategy for composing a melody. When given a <see cref="ChordContext" />, it will return the
+///     next <see cref="ChordChoice" /> to be used to get to the next chord.
+///
+///     Can also be used to invalidate a <see cref="ChordChoice" /> if it is no longer valid for the given context.
+/// </summary>
+internal interface ICompositionStrategy
+{
+    /// <summary>
+    ///    Get the next <see cref="ChordChoice" /> to be used for the given <see cref="ChordContext" /> we are currently in.
+    /// </summary>
+    /// <param name="chordContext">The <see cref="ChordContext" /> we are currently in.</param>
+    /// <returns>The next <see cref="ChordChoice" /> to be used for the given <see cref="ChordContext" /> we are currently in.</returns>
+    ChordChoice GetNextChordChoice(ChordContext chordContext);
+
+    /// <summary>
+    ///    Invalidate the given <see cref="ChordChoice" /> for the given <see cref="ChordContext" />.
+    /// </summary>
+    /// <param name="chordContext"> The <see cref="ChordContext" /> we are currently in.</param>
+    /// <param name="chordChoice"> The <see cref="ChordChoice" /> to invalidate.</param>
+    void InvalidateChordChoice(ChordContext chordContext, ChordChoice chordChoice);
+}

--- a/tests/BaroquenMelody.Library.Tests/Composition/Strategies/CompositionStrategyTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Composition/Strategies/CompositionStrategyTests.cs
@@ -1,0 +1,147 @@
+﻿using BaroquenMelody.Library.Composition.Choices;
+using BaroquenMelody.Library.Composition.Contexts;
+using BaroquenMelody.Library.Composition.Enums;
+using BaroquenMelody.Library.Composition.Strategies;
+using BaroquenMelody.Library.Random;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using System.Collections;
+using System.Numerics;
+
+namespace BaroquenMelody.Library.Tests.Composition.Strategies;
+
+[TestFixture]
+internal sealed class CompositionStrategyTests
+{
+    private static readonly BigInteger MockChordContextCount = 5;
+
+    private static readonly BigInteger MockChordChoiceCount = 5;
+
+    private IChordChoiceRepository _mockChordChoiceRepository = default!;
+
+    private IChordContextRepository _mockChordContextRepository = default!;
+
+    private IRandomTrueIndexSelector _mockRandomTrueIndexSelector = default!;
+
+    private IDictionary<BigInteger, BitArray> _mockChordContextToChordChoiceMap = default!;
+
+    private CompositionStrategy _compositionStrategy = default!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockChordChoiceRepository = Substitute.For<IChordChoiceRepository>();
+        _mockChordContextRepository = Substitute.For<IChordContextRepository>();
+        _mockRandomTrueIndexSelector = Substitute.For<IRandomTrueIndexSelector>();
+        _mockChordContextToChordChoiceMap = Substitute.For<IDictionary<BigInteger, BitArray>>();
+
+        _mockChordChoiceRepository.Count.Returns(MockChordChoiceCount);
+        _mockChordContextRepository.Count.Returns(MockChordContextCount);
+
+        _compositionStrategy = new CompositionStrategy(
+            _mockChordChoiceRepository,
+            _mockChordContextRepository,
+            _mockRandomTrueIndexSelector,
+            _mockChordContextToChordChoiceMap
+        );
+    }
+
+    [Test]
+    public void GetNextChordChoice_returns_random_chord_choice()
+    {
+        // arrange
+        var chordContext = new ChordContext(
+            new List<NoteContext>
+            {
+                new(Voice.Soprano, 25, NoteMotion.Ascending, NoteSpan.Step),
+                new(Voice.Alto, 25, NoteMotion.Ascending, NoteSpan.Step),
+                new(Voice.Tenor, 25, NoteMotion.Ascending, NoteSpan.Step),
+                new(Voice.Bass, 25, NoteMotion.Ascending, NoteSpan.Step)
+            }
+        );
+
+        var chordChoice = new ChordChoice(
+            new List<NoteChoice>
+            {
+                new(Voice.Soprano, NoteMotion.Ascending, 5),
+                new(Voice.Alto, NoteMotion.Ascending, 5),
+                new(Voice.Tenor, NoteMotion.Ascending, 5),
+                new(Voice.Bass, NoteMotion.Ascending, 5)
+            }
+        );
+
+        const int chordContextIndex = 3;
+        const int chordChoiceIndex = 3;
+
+        var bitArray = new BitArray(new[] { true, false, false, true, false });
+
+        _mockChordContextRepository.GetChordContextIndex(chordContext).Returns(chordContextIndex);
+        _mockChordContextToChordChoiceMap[chordContextIndex].Returns(bitArray);
+        _mockRandomTrueIndexSelector.SelectRandomTrueIndex(bitArray).Returns(chordChoiceIndex);
+        _mockChordChoiceRepository.GetChordChoice(chordChoiceIndex).Returns(chordChoice);
+
+        // act
+        var result = _compositionStrategy.GetNextChordChoice(chordContext);
+
+        // assert
+        result.Should().BeEquivalentTo(chordChoice);
+
+        Received.InOrder(
+            () =>
+            {
+                _mockChordContextRepository.GetChordContextIndex(chordContext);
+                _mockRandomTrueIndexSelector.SelectRandomTrueIndex(Arg.Any<BitArray>());
+                _mockChordChoiceRepository.GetChordChoice(chordChoiceIndex);
+            }
+        );
+    }
+
+    [Test]
+    public void InvalidateChordChoice_sets_bit_to_false()
+    {
+        // arrange
+        var chordContext = new ChordContext(
+            new List<NoteContext>
+            {
+                new(Voice.Soprano, 25, NoteMotion.Ascending, NoteSpan.Step),
+                new(Voice.Alto, 25, NoteMotion.Ascending, NoteSpan.Step),
+                new(Voice.Tenor, 25, NoteMotion.Ascending, NoteSpan.Step),
+                new(Voice.Bass, 25, NoteMotion.Ascending, NoteSpan.Step)
+            }
+        );
+
+        var chordChoice = new ChordChoice(
+            new List<NoteChoice>
+            {
+                new(Voice.Soprano, NoteMotion.Ascending, 5),
+                new(Voice.Alto, NoteMotion.Ascending, 5),
+                new(Voice.Tenor, NoteMotion.Ascending, 5),
+                new(Voice.Bass, NoteMotion.Ascending, 5)
+            }
+        );
+
+        const int chordContextIndex = 3;
+        const int chordChoiceIndex = 3;
+
+        var bitArray = new BitArray(5, true);
+
+        _mockChordContextRepository.GetChordContextIndex(chordContext).Returns(chordContextIndex);
+        _mockChordChoiceRepository.GetChordChoiceIndex(chordChoice).Returns(chordChoiceIndex);
+        _mockChordContextToChordChoiceMap[chordContextIndex].Returns(bitArray);
+
+        // act
+        _compositionStrategy.InvalidateChordChoice(chordContext, chordChoice);
+
+        // assert
+        bitArray[chordChoiceIndex].Should().BeFalse();
+
+        Received.InOrder(
+            () =>
+            {
+                _mockChordContextRepository.GetChordContextIndex(chordContext);
+                _mockChordChoiceRepository.GetChordChoiceIndex(chordChoice);
+            }
+        );
+    }
+}


### PR DESCRIPTION
## Description

Implement composition strategy, which can select a randomized valid `ChordChoice` for a given `ChordContext` and can invalidate an invalid `ChoirdChoice` for a given `ChordContext`.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
