### PR TITLE
Smarter composition strategy

### DIFF
--- a/src/BaroquenMelody.Library/Composition/Configurations/CompositionConfiguration.cs
+++ b/src/BaroquenMelody.Library/Composition/Configurations/CompositionConfiguration.cs
@@ -1,9 +1,16 @@
-﻿namespace BaroquenMelody.Library.Composition.Configurations;
+﻿using BaroquenMelody.Library.Composition.Enums;
+
+namespace BaroquenMelody.Library.Composition.Configurations;
 
 /// <summary>
 ///     The composition configuration.
 /// </summary>
 /// <param name="VoiceConfigurations"> The voice configurations to be used in the composition. </param>
-internal record CompositionConfiguration(
-    ISet<VoiceConfiguration> VoiceConfigurations
-);
+internal record CompositionConfiguration(ISet<VoiceConfiguration> VoiceConfigurations)
+{
+    public bool IsPitchInVoiceRange(Voice voice, byte pitch) => pitch >= GetMinPitch(voice) && pitch <= GetMaxPitch(voice);
+
+    private byte GetMinPitch(Voice voice) => VoiceConfigurations.First(x => x.Voice == voice).MinPitch;
+
+    private byte GetMaxPitch(Voice voice) => VoiceConfigurations.First(x => x.Voice == voice).MaxPitch;
+}

--- a/src/BaroquenMelody.Library/Composition/Note.cs
+++ b/src/BaroquenMelody.Library/Composition/Note.cs
@@ -1,5 +1,6 @@
 ﻿using BaroquenMelody.Library.Composition.Choices;
 using BaroquenMelody.Library.Composition.Contexts;
+using BaroquenMelody.Library.Composition.Enums;
 
 namespace BaroquenMelody.Library.Composition;
 
@@ -7,10 +8,12 @@ namespace BaroquenMelody.Library.Composition;
 ///     Represents a note in a composition.
 /// </summary>
 /// <param name="Pitch"> The pitch of the note. </param>
+/// <param name="Voice"> The voice of the note. </param>
 /// <param name="NoteContext"> The previous note context from which this note was generated. </param>
 /// <param name="NoteChoice"> The note choice which was used to generate this note. </param>
 internal sealed record Note(
     byte Pitch,
+    Voice Voice,
     NoteContext NoteContext,
     NoteChoice NoteChoice
 );

--- a/src/BaroquenMelody.Library/Extensions/NoteContextExtensions.cs
+++ b/src/BaroquenMelody.Library/Extensions/NoteContextExtensions.cs
@@ -26,6 +26,7 @@ internal static class NoteContextExtensions
 
         return new Note(
             (byte)pitch,
+            noteChoice.Voice,
             noteContext,
             noteChoice
         );

--- a/tests/BaroquenMelody.Library.Tests/Configuration/CompositionConfigurationTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Configuration/CompositionConfigurationTests.cs
@@ -1,0 +1,45 @@
+﻿using BaroquenMelody.Library.Composition.Configurations;
+using BaroquenMelody.Library.Composition.Enums;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Configuration;
+
+[TestFixture]
+internal sealed class CompositionConfigurationTests
+{
+    private const byte MinSopranoPitch = 60;
+
+    private const byte MaxSopranoPitch = 72;
+
+    private CompositionConfiguration _compositionConfiguration = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _compositionConfiguration = new CompositionConfiguration(new HashSet<VoiceConfiguration>
+        {
+            new(Voice.Soprano, MinSopranoPitch, MaxSopranoPitch),
+            new(Voice.Alto, 48, 60),
+            new(Voice.Tenor, 36, 48),
+            new(Voice.Bass, 24, 36)
+        });
+    }
+
+    [Test]
+    [TestCase(Voice.Soprano, MaxSopranoPitch + 1, false)]
+    [TestCase(Voice.Soprano, MinSopranoPitch - 1, false)]
+    [TestCase(Voice.Soprano, MaxSopranoPitch, true)]
+    [TestCase(Voice.Soprano, MinSopranoPitch, true)]
+    [TestCase(Voice.Soprano, MaxSopranoPitch - 1, true)]
+    [TestCase(Voice.Soprano, MinSopranoPitch + 1, true)]
+    public void IsPitchInVoiceRange_returns_expected_result(
+        Voice voice,
+        byte pitch,
+        bool expectedPitchIsInVoiceRange)
+    {
+        var isPitchInVoiceRange = _compositionConfiguration.IsPitchInVoiceRange(voice, pitch);
+
+        isPitchInVoiceRange.Should().Be(expectedPitchIsInVoiceRange);
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Extensions/ChordContextExtensionsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Extensions/ChordContextExtensionsTests.cs
@@ -33,10 +33,10 @@ internal sealed class ChordContextExtensionsTests
 
         var expectedNotes = new HashSet<Note>
         {
-            new(62, chordContext[Voice.Soprano], chordChoice.NoteChoices.First(noteChoice => noteChoice.Voice == Voice.Soprano)),
-            new(54, chordContext[Voice.Alto], chordChoice.NoteChoices.First(noteChoice => noteChoice.Voice == Voice.Alto)),
-            new(50, chordContext[Voice.Tenor], chordChoice.NoteChoices.First(noteChoice => noteChoice.Voice == Voice.Tenor)),
-            new(48, chordContext[Voice.Bass], chordChoice.NoteChoices.First(noteChoice => noteChoice.Voice == Voice.Bass))
+            new(62, Voice.Soprano, chordContext[Voice.Soprano], chordChoice.NoteChoices.First(noteChoice => noteChoice.Voice == Voice.Soprano)),
+            new(54, Voice.Alto, chordContext[Voice.Alto], chordChoice.NoteChoices.First(noteChoice => noteChoice.Voice == Voice.Alto)),
+            new(50, Voice.Tenor, chordContext[Voice.Tenor], chordChoice.NoteChoices.First(noteChoice => noteChoice.Voice == Voice.Tenor)),
+            new(48, Voice.Bass, chordContext[Voice.Bass], chordChoice.NoteChoices.First(noteChoice => noteChoice.Voice == Voice.Bass))
         };
 
         // act


### PR DESCRIPTION
## Description

Update the composition strategy to automatically invalidate choices which would result in voices extending beyond their configured range.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
