### PR TITLE
Integrate DryWetMidi

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: 🔨 set up .net
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.0
+        dotnet-version: 8.0.x
 
     - name: ⚗ restore dependencies
       run: dotnet restore src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: 🔨 set up .net
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 8.0.0
 
     - name: ⚗ restore dependencies
       run: dotnet restore src

--- a/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
+++ b/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="LazyCart" Version="0.4.5" />
+    <PackageReference Include="Melanchall.DryWetMidi" Version="7.0.2" />
     <PackageReference Include="Meziantou.Analyzer" Version="2.0.141">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/BaroquenMelody.Library/Compositions/Choices/NoteChoice.cs
+++ b/src/BaroquenMelody.Library/Compositions/Choices/NoteChoice.cs
@@ -7,9 +7,9 @@ namespace BaroquenMelody.Library.Compositions.Choices;
 /// </summary>
 /// <param name="Voice"> The voice associated with the note choice. </param>
 /// <param name="Motion"> The motion which will be used to arrive at the next note. </param>
-/// <param name="PitchChange"> The amount of pitch change which will be used to arrive at the next note. </param>
+/// <param name="ScaleStepChange"> The change in scale steps which will be used to arrive at the next note. </param>
 internal sealed record NoteChoice(
     Voice Voice,
     NoteMotion Motion,
-    byte PitchChange
+    byte ScaleStepChange
 );

--- a/src/BaroquenMelody.Library/Compositions/Choices/NoteChoice.cs
+++ b/src/BaroquenMelody.Library/Compositions/Choices/NoteChoice.cs
@@ -3,7 +3,7 @@
 namespace BaroquenMelody.Library.Compositions.Choices;
 
 /// <summary>
-///    Represents a choice of note motion and pitch change for a given voice to arrive at the next note.
+///    Represents a choice of note motion and scale step change for a given voice to arrive at the next note.
 /// </summary>
 /// <param name="Voice"> The voice associated with the note choice. </param>
 /// <param name="Motion"> The motion which will be used to arrive at the next note. </param>

--- a/src/BaroquenMelody.Library/Compositions/Choices/NoteChoiceGenerator.cs
+++ b/src/BaroquenMelody.Library/Compositions/Choices/NoteChoiceGenerator.cs
@@ -3,14 +3,14 @@
 namespace BaroquenMelody.Library.Compositions.Choices;
 
 /// <inheritdoc cref="INoteChoiceGenerator"/>
-internal sealed class NoteChoiceGenerator(byte minPitchChange = 1, byte maxPitchChange = 6) : INoteChoiceGenerator
+internal sealed class NoteChoiceGenerator(byte minScaleStepChange = 1, byte maxScaleStepChange = 6) : INoteChoiceGenerator
 {
     public ISet<NoteChoice> GenerateNoteChoices(Voice voice) => Enumerable
-        .Range(minPitchChange, maxPitchChange - minPitchChange + 1)
-        .Select(pitchChange => (byte)pitchChange)
-        .SelectMany(pitchChange =>
+        .Range(minScaleStepChange, maxScaleStepChange - minScaleStepChange + 1)
+        .Select(scaleStepChange => (byte)scaleStepChange)
+        .SelectMany(scaleStepChange =>
             new[] { NoteMotion.Ascending, NoteMotion.Descending }.Select(noteMotion =>
-                new NoteChoice(voice, noteMotion, pitchChange)
+                new NoteChoice(voice, noteMotion, scaleStepChange)
             )
         )
         .Append(new NoteChoice(voice, NoteMotion.Oblique, 0))

--- a/src/BaroquenMelody.Library/Compositions/Chord.cs
+++ b/src/BaroquenMelody.Library/Compositions/Chord.cs
@@ -6,11 +6,11 @@ namespace BaroquenMelody.Library.Compositions;
 /// <summary>
 ///    Represents a chord in a composition.
 /// </summary>
-/// <param name="Notes"> The notes which make up the chord. </param>
+/// <param name="VoicedNotes"> The notes which make up the chord. </param>
 /// <param name="ChordContext"> The previous chord context from which this chord was generated. </param>
 /// <param name="ChordChoice"> The chord choice which was used to generate this chord. </param>
 internal sealed record Chord(
-    ISet<Note> Notes,
+    ISet<VoicedNote> VoicedNotes,
     ChordContext ChordContext,
     ChordChoice ChordChoice
 );

--- a/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using BaroquenMelody.Library.Compositions.Enums;
+using Melanchall.DryWetMidi.MusicTheory;
 
 namespace BaroquenMelody.Library.Compositions.Configurations;
 
@@ -6,11 +7,10 @@ namespace BaroquenMelody.Library.Compositions.Configurations;
 ///     The composition configuration.
 /// </summary>
 /// <param name="VoiceConfigurations"> The voice configurations to be used in the composition. </param>
-internal sealed record CompositionConfiguration(ISet<VoiceConfiguration> VoiceConfigurations)
+/// <param name="Scale"> The scale to be used in the composition. </param>
+internal sealed record CompositionConfiguration(ISet<VoiceConfiguration> VoiceConfigurations, Scale Scale)
 {
-    public bool IsPitchInVoiceRange(Voice voice, byte pitch) => pitch >= GetMinPitch(voice) && pitch <= GetMaxPitch(voice);
-
-    private byte GetMinPitch(Voice voice) => VoiceConfigurations.First(x => x.Voice == voice).MinPitch;
-
-    private byte GetMaxPitch(Voice voice) => VoiceConfigurations.First(x => x.Voice == voice).MaxPitch;
+    public bool IsNoteInVoiceRange(Voice voice, Note note) => VoiceConfigurations.First(
+        voiceConfiguration => voiceConfiguration.Voice == voice
+    ).IsNoteWithinVoiceRange(note);
 }

--- a/src/BaroquenMelody.Library/Compositions/Configurations/VoiceConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/VoiceConfiguration.cs
@@ -1,15 +1,20 @@
 ﻿using BaroquenMelody.Library.Compositions.Enums;
+using Melanchall.DryWetMidi.MusicTheory;
 
 namespace BaroquenMelody.Library.Compositions.Configurations;
 
 /// <summary>
-///    The voice configuration. Allowing for the configuration of the pitch range for a given voice.
+///    The voice configuration. Allowing for the configuration of the note range for a given voice.
 /// </summary>
 /// <param name="Voice"> The voice to be configured. </param>
-/// <param name="MinPitch"> The voice's minimum pitch value. </param>
-/// <param name="MaxPitch"> The voice's maximum pitch value. </param>
+/// <param name="MinNote"> The voice's minimum note value. </param>
+/// <param name="MaxNote"> The voice's maximum note value. </param>
 internal sealed record VoiceConfiguration(
     Voice Voice,
-    byte MinPitch,
-    byte MaxPitch
-);
+    Note MinNote,
+    Note MaxNote
+)
+{
+    public bool IsNoteWithinVoiceRange(Note note) => note.NoteNumber >= MinNote.NoteNumber &&
+                                                     note.NoteNumber <= MaxNote.NoteNumber;
+}

--- a/src/BaroquenMelody.Library/Compositions/Contexts/DuetChordContextRepository.cs
+++ b/src/BaroquenMelody.Library/Compositions/Contexts/DuetChordContextRepository.cs
@@ -26,7 +26,8 @@ internal sealed class DuetChordContextRepository : IChordContextRepository
 
         var noteContextsForVoices = configuration.VoiceConfigurations
             .OrderBy(voiceConfiguration => voiceConfiguration.Voice)
-            .Select(noteContextGenerator.GenerateNoteContexts).ToList();
+            .Select(voiceConfiguration => noteContextGenerator.GenerateNoteContexts(voiceConfiguration, configuration.Scale))
+            .ToList();
 
         _noteContexts = new LazyCartesianProduct<NoteContext, NoteContext>(
             noteContextsForVoices[0].ToList(),

--- a/src/BaroquenMelody.Library/Compositions/Contexts/INoteContextGenerator.cs
+++ b/src/BaroquenMelody.Library/Compositions/Contexts/INoteContextGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
+using Melanchall.DryWetMidi.MusicTheory;
 
 namespace BaroquenMelody.Library.Compositions.Contexts;
 
@@ -8,9 +9,10 @@ namespace BaroquenMelody.Library.Compositions.Contexts;
 internal interface INoteContextGenerator
 {
     /// <summary>
-    ///     Generate the possible note contexts for the given voice configuration.
+    ///     Generate the possible note contexts for the given voice configuration and scale.
     /// </summary>
     /// <param name="voiceConfiguration"> The voice configuration to generate note contexts for. </param>
-    /// <returns> The possible note contexts for the given voice configuration. </returns>
-    ISet<NoteContext> GenerateNoteContexts(VoiceConfiguration voiceConfiguration);
+    /// <param name ="scale"> The scale to be used in the generation of note contexts. </param>
+    /// <returns> The possible note contexts for the given voice configuration and scale. </returns>
+    ISet<NoteContext> GenerateNoteContexts(VoiceConfiguration voiceConfiguration, Scale scale);
 }

--- a/src/BaroquenMelody.Library/Compositions/Contexts/NoteContext.cs
+++ b/src/BaroquenMelody.Library/Compositions/Contexts/NoteContext.cs
@@ -1,4 +1,5 @@
 ﻿using BaroquenMelody.Library.Compositions.Enums;
+using Melanchall.DryWetMidi.MusicTheory;
 
 namespace BaroquenMelody.Library.Compositions.Contexts;
 
@@ -6,12 +7,12 @@ namespace BaroquenMelody.Library.Compositions.Contexts;
 ///     The context of a note in a composition.
 /// </summary>
 /// <param name="Voice"> The voice associated with the context. </param>
-/// <param name="Pitch"> The pitch of the note associated with the context. </param>
-/// <param name="NoteMotion"> The motion which was used to arrive at the pitch. </param>
-/// <param name="NoteSpan"> The note span which was used to arrive at the pitch. </param>
+/// <param name="Note"> The note associated with the context. </param>
+/// <param name="NoteMotion"> The motion which was used to arrive at the note. </param>
+/// <param name="NoteSpan"> The note span which was used to arrive at the note. </param>
 internal sealed record NoteContext(
     Voice Voice,
-    byte Pitch,
+    Note Note,
     NoteMotion NoteMotion,
     NoteSpan NoteSpan
 );

--- a/src/BaroquenMelody.Library/Compositions/Contexts/QuartetChordContextRepository.cs
+++ b/src/BaroquenMelody.Library/Compositions/Contexts/QuartetChordContextRepository.cs
@@ -26,7 +26,8 @@ internal sealed class QuartetChordContextRepository : IChordContextRepository
 
         var noteContextsForVoices = configuration.VoiceConfigurations
             .OrderBy(voiceConfiguration => voiceConfiguration.Voice)
-            .Select(noteContextGenerator.GenerateNoteContexts).ToList();
+            .Select(voiceConfiguration => noteContextGenerator.GenerateNoteContexts(voiceConfiguration, configuration.Scale))
+            .ToList();
 
         _noteContexts = new LazyCartesianProduct<NoteContext, NoteContext, NoteContext, NoteContext>(
             noteContextsForVoices[0].ToList(),

--- a/src/BaroquenMelody.Library/Compositions/Contexts/TrioChordContextRepository.cs
+++ b/src/BaroquenMelody.Library/Compositions/Contexts/TrioChordContextRepository.cs
@@ -26,7 +26,8 @@ internal sealed class TrioChordContextRepository : IChordContextRepository
 
         var noteContextsForVoices = configuration.VoiceConfigurations
             .OrderBy(voiceConfiguration => voiceConfiguration.Voice)
-            .Select(noteContextGenerator.GenerateNoteContexts).ToList();
+            .Select(voiceConfiguration => noteContextGenerator.GenerateNoteContexts(voiceConfiguration, configuration.Scale))
+            .ToList();
 
         _noteContexts = new LazyCartesianProduct<NoteContext, NoteContext, NoteContext>(
             noteContextsForVoices[0].ToList(),

--- a/src/BaroquenMelody.Library/Compositions/Enums/NoteMotion.cs
+++ b/src/BaroquenMelody.Library/Compositions/Enums/NoteMotion.cs
@@ -16,7 +16,7 @@ internal enum NoteMotion : byte
     Descending,
 
     /// <summary>
-    ///     Indicates that the note is arrived at by staying at the same pitch as the previous note.
+    ///     Indicates that the note is arrived at by staying at the same note as the previous note.
     /// </summary>
     Oblique
 }

--- a/src/BaroquenMelody.Library/Compositions/Strategies/CompositionStrategy.cs
+++ b/src/BaroquenMelody.Library/Compositions/Strategies/CompositionStrategy.cs
@@ -26,9 +26,9 @@ internal sealed class CompositionStrategy(
         {
             var chordChoiceIndex = randomTrueIndexSelector.SelectRandomTrueIndex(chordChoiceIndices);
             var chordChoice = chordChoiceRepository.GetChordChoice(chordChoiceIndex);
-            var chord = chordContext.ApplyChordChoice(chordChoice);
+            var chord = chordContext.ApplyChordChoice(chordChoice, compositionConfiguration.Scale);
 
-            if (chord.Notes.All(note => compositionConfiguration.IsPitchInVoiceRange(note.Voice, note.Pitch)))
+            if (chord.VoicedNotes.All(voicedNote => compositionConfiguration.IsNoteInVoiceRange(voicedNote.Voice, voicedNote.Note)))
             {
                 return chordChoice;
             }

--- a/src/BaroquenMelody.Library/Compositions/VoicedNote.cs
+++ b/src/BaroquenMelody.Library/Compositions/VoicedNote.cs
@@ -1,18 +1,19 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
 using BaroquenMelody.Library.Compositions.Contexts;
 using BaroquenMelody.Library.Compositions.Enums;
+using Melanchall.DryWetMidi.MusicTheory;
 
 namespace BaroquenMelody.Library.Compositions;
 
 /// <summary>
 ///     Represents a note in a composition.
 /// </summary>
-/// <param name="Pitch"> The pitch of the note. </param>
+/// <param name="Note"> The note. </param>
 /// <param name="Voice"> The voice of the note. </param>
 /// <param name="NoteContext"> The previous note context from which this note was generated. </param>
 /// <param name="NoteChoice"> The note choice which was used to generate this note. </param>
-internal sealed record Note(
-    byte Pitch,
+internal sealed record VoicedNote(
+    Note Note,
     Voice Voice,
     NoteContext NoteContext,
     NoteChoice NoteChoice

--- a/src/BaroquenMelody.Library/Extensions/ChordContextExtensions.cs
+++ b/src/BaroquenMelody.Library/Extensions/ChordContextExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using BaroquenMelody.Library.Compositions;
 using BaroquenMelody.Library.Compositions.Choices;
 using BaroquenMelody.Library.Compositions.Contexts;
+using Melanchall.DryWetMidi.MusicTheory;
+using Chord = BaroquenMelody.Library.Compositions.Chord;
 
 namespace BaroquenMelody.Library.Extensions;
 
@@ -11,16 +13,17 @@ internal static class ChordContextExtensions
     /// </summary>
     /// <param name="chordContext"> The chord context. </param>
     /// <param name="chordChoice"> The chord choice. </param>
+    /// <param name="scale"> The scale to be used in the generation of the next chord. </param>
     /// <returns> The next chord. </returns>
-    public static Chord ApplyChordChoice(this ChordContext chordContext, ChordChoice chordChoice)
+    public static Chord ApplyChordChoice(this ChordContext chordContext, ChordChoice chordChoice, Scale scale)
     {
-        var notes = new HashSet<Note>();
+        var notes = new HashSet<VoicedNote>();
 
         foreach (var noteChoice in chordChoice.NoteChoices)
         {
             var noteContext = chordContext[noteChoice.Voice];
 
-            notes.Add(noteContext.ApplyNoteChoice(noteChoice));
+            notes.Add(noteContext.ApplyNoteChoice(noteChoice, scale));
         }
 
         return new Chord(

--- a/src/BaroquenMelody.Library/Extensions/NoteContextExtensions.cs
+++ b/src/BaroquenMelody.Library/Extensions/NoteContextExtensions.cs
@@ -2,6 +2,7 @@
 using BaroquenMelody.Library.Compositions.Choices;
 using BaroquenMelody.Library.Compositions.Contexts;
 using BaroquenMelody.Library.Compositions.Enums;
+using Melanchall.DryWetMidi.MusicTheory;
 
 namespace BaroquenMelody.Library.Extensions;
 
@@ -12,20 +13,24 @@ internal static class NoteContextExtensions
     /// </summary>
     /// <param name="noteContext"> The note context. </param>
     /// <param name="noteChoice"> The note choice. </param>
+    /// <param name="scale"> The scale to be used in the generation of the next note. </param>
     /// <returns> The next note. </returns>
     /// <exception cref="ArgumentOutOfRangeException"> Thrown when the given <see cref="NoteChoice"/> has an invalid <see cref="NoteMotion"/>. </exception>
-    public static Note ApplyNoteChoice(this NoteContext noteContext, NoteChoice noteChoice)
+    public static VoicedNote ApplyNoteChoice(this NoteContext noteContext, NoteChoice noteChoice, Scale scale)
     {
-        var pitch = noteChoice.Motion switch
+        var notes = scale.GetDescendingNotes(noteContext.Note);
+        var ascendingNotes = scale.GetAscendingNotes(noteContext.Note);
+
+        var note = noteChoice.Motion switch
         {
-            NoteMotion.Ascending => noteContext.Pitch + noteChoice.PitchChange,
-            NoteMotion.Descending => noteContext.Pitch - noteChoice.PitchChange,
-            NoteMotion.Oblique => noteContext.Pitch,
+            NoteMotion.Ascending => scale.GetAscendingNotes(noteContext.Note).ElementAt(noteChoice.ScaleStepChange),
+            NoteMotion.Descending => scale.GetDescendingNotes(noteContext.Note).ElementAt(noteChoice.ScaleStepChange),
+            NoteMotion.Oblique => noteContext.Note,
             _ => throw new ArgumentOutOfRangeException(nameof(noteChoice))
         };
 
-        return new Note(
-            (byte)pitch,
+        return new VoicedNote(
+            note,
             noteChoice.Voice,
             noteContext,
             noteChoice

--- a/src/BaroquenMelody.Library/Extensions/NoteContextExtensions.cs
+++ b/src/BaroquenMelody.Library/Extensions/NoteContextExtensions.cs
@@ -18,9 +18,6 @@ internal static class NoteContextExtensions
     /// <exception cref="ArgumentOutOfRangeException"> Thrown when the given <see cref="NoteChoice"/> has an invalid <see cref="NoteMotion"/>. </exception>
     public static VoicedNote ApplyNoteChoice(this NoteContext noteContext, NoteChoice noteChoice, Scale scale)
     {
-        var notes = scale.GetDescendingNotes(noteContext.Note);
-        var ascendingNotes = scale.GetAscendingNotes(noteContext.Note);
-
         var note = noteChoice.Motion switch
         {
             NoteMotion.Ascending => scale.GetAscendingNotes(noteContext.Note).ElementAt(noteChoice.ScaleStepChange),

--- a/src/BaroquenMelody.Library/Extensions/NumericExtensions.cs
+++ b/src/BaroquenMelody.Library/Extensions/NumericExtensions.cs
@@ -1,0 +1,11 @@
+﻿using Melanchall.DryWetMidi.Common;
+using Melanchall.DryWetMidi.MusicTheory;
+
+namespace BaroquenMelody.Library.Extensions;
+
+internal static class NumericExtensions
+{
+    public static Note ToNote(this int noteNumber) => ((byte)noteNumber).ToNote();
+
+    public static Note ToNote(this byte noteNumber) => Note.Get(new SevenBitNumber(noteNumber));
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/ChordChoiceRepositoryFactoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/ChordChoiceRepositoryFactoryTests.cs
@@ -1,7 +1,9 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
 using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Extensions;
 using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -32,8 +34,9 @@ internal sealed class ChordChoiceRepositoryFactoryTests
         // arrange
         var compositionConfiguration = new CompositionConfiguration(
             Enumerable.Range(0, numberOfVoices)
-                .Select(index => new VoiceConfiguration(Voice.Soprano, (byte)index, (byte)(index + 1)))
-                .ToHashSet()
+                .Select(index => new VoiceConfiguration(Voice.Soprano, index.ToNote(), (index + 1).ToNote()))
+                .ToHashSet(),
+            Scale.Parse("C Major")
         );
 
         // act
@@ -51,8 +54,9 @@ internal sealed class ChordChoiceRepositoryFactoryTests
             new HashSet<VoiceConfiguration>
             {
                 // invalid configuration: only one voice
-                new(Voice.Soprano, 55, 90)
-            }
+                new(Voice.Soprano, 55.ToNote(), 90.ToNote())
+            },
+            Scale.Parse("C Major")
         );
 
         // act

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/DuetChordChoiceRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/DuetChordChoiceRepositoryTests.cs
@@ -1,7 +1,9 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
 using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Extensions;
 using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -47,9 +49,10 @@ internal sealed class DuetChordChoiceRepositoryTests
         var compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>
             {
-                new(Voice.Soprano, 55, 90),
-                new(Voice.Alto, 45, 80)
-            }
+                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
+                new(Voice.Alto, 45.ToNote(), 80.ToNote())
+            },
+            Scale.Parse("C Major")
         );
 
         var duetChordChoiceRepository = new DuetChordChoiceRepository(
@@ -84,10 +87,11 @@ internal sealed class DuetChordChoiceRepositoryTests
         var compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>
             {
-                new(Voice.Soprano, 55, 90),
-                new(Voice.Alto, 45, 80),
-                new(Voice.Tenor, 35, 70)
-            }
+                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
+                new(Voice.Alto, 45.ToNote(), 80.ToNote()),
+                new(Voice.Tenor, 35.ToNote(), 70.ToNote())
+            },
+            Scale.Parse("C Major")
         );
 
         // act
@@ -107,9 +111,10 @@ internal sealed class DuetChordChoiceRepositoryTests
         var compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>
             {
-                new(Voice.Soprano, 55, 90),
-                new(Voice.Alto, 45, 80)
-            }
+                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
+                new(Voice.Alto, 45.ToNote(), 80.ToNote())
+            },
+            Scale.Parse("C Major")
         );
 
         var duetChordChoiceRepository = new DuetChordChoiceRepository(

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/QuartetChordChoiceRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/QuartetChordChoiceRepositoryTests.cs
@@ -1,7 +1,9 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
 using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Extensions;
 using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -69,11 +71,12 @@ internal sealed class QuartetChordChoiceRepositoryTests
         var compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>
             {
-                new(Voice.Soprano, 55, 90),
-                new(Voice.Alto, 45, 80),
-                new(Voice.Tenor, 35, 70),
-                new(Voice.Bass, 25, 60)
-            }
+                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
+                new(Voice.Alto, 45.ToNote(), 80.ToNote()),
+                new(Voice.Tenor, 35.ToNote(), 70.ToNote()),
+                new(Voice.Bass, 25.ToNote(), 60.ToNote())
+            },
+            Scale.Parse("C Major")
         );
 
         var quartetChordChoiceRepository = new QuartetChordChoiceRepository(
@@ -110,9 +113,10 @@ internal sealed class QuartetChordChoiceRepositoryTests
         var compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>
             {
-                new(Voice.Soprano, 55, 90),
-                new(Voice.Alto, 45, 80)
-            }
+                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
+                new(Voice.Alto, 45.ToNote(), 80.ToNote())
+            },
+            Scale.Parse("C Major")
         );
 
         // act
@@ -132,11 +136,12 @@ internal sealed class QuartetChordChoiceRepositoryTests
         var compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>
             {
-                new(Voice.Soprano, 55, 90),
-                new(Voice.Alto, 45, 80),
-                new(Voice.Tenor, 35, 70),
-                new(Voice.Bass, 25, 60)
-            }
+                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
+                new(Voice.Alto, 45.ToNote(), 80.ToNote()),
+                new(Voice.Tenor, 35.ToNote(), 70.ToNote()),
+                new(Voice.Bass, 25.ToNote(), 60.ToNote())
+            },
+            Scale.Parse("C Major")
         );
 
         var quartetChordChoiceRepository = new QuartetChordChoiceRepository(

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/TrioChordChoiceRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/TrioChordChoiceRepositoryTests.cs
@@ -1,7 +1,9 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
 using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Extensions;
 using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -58,10 +60,11 @@ internal sealed class TrioChordChoiceRepositoryTests
         var compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>
             {
-                new(Voice.Soprano, 55, 90),
-                new(Voice.Alto, 45, 80),
-                new(Voice.Tenor, 35, 70)
-            }
+                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
+                new(Voice.Alto, 45.ToNote(), 80.ToNote()),
+                new(Voice.Tenor, 35.ToNote(), 70.ToNote())
+            },
+            Scale.Parse("C Major")
         );
 
         var trioChordChoiceRepository = new TrioChordChoiceRepository(
@@ -97,11 +100,12 @@ internal sealed class TrioChordChoiceRepositoryTests
         var compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>
             {
-                new(Voice.Soprano, 55, 90),
-                new(Voice.Alto, 45, 80),
-                new(Voice.Tenor, 35, 70),
-                new(Voice.Bass, 25, 60)
-            }
+                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
+                new(Voice.Alto, 45.ToNote(), 80.ToNote()),
+                new(Voice.Tenor, 35.ToNote(), 70.ToNote()),
+                new(Voice.Bass, 25.ToNote(), 60.ToNote())
+            },
+            Scale.Parse("C Major")
         );
 
         // act
@@ -121,10 +125,11 @@ internal sealed class TrioChordChoiceRepositoryTests
         var compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>
             {
-                new(Voice.Soprano, 55, 90),
-                new(Voice.Alto, 45, 80),
-                new(Voice.Tenor, 35, 70)
-            }
+                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
+                new(Voice.Alto, 45.ToNote(), 80.ToNote()),
+                new(Voice.Tenor, 35.ToNote(), 70.ToNote())
+            },
+            Scale.Parse("C Major")
         );
 
         var trioChordChoiceRepository = new TrioChordChoiceRepository(

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Contexts/ChordContextRepositoryFactoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Contexts/ChordContextRepositoryFactoryTests.cs
@@ -1,7 +1,9 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Contexts;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Extensions;
 using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -31,8 +33,9 @@ internal sealed class ChordContextRepositoryFactoryTests
         // arrange
         var compositionConfiguration = new CompositionConfiguration(
             Enumerable.Range(0, numberOfVoices)
-                .Select(index => new VoiceConfiguration((Voice)index, (byte)index, (byte)(index + 1)))
-                .ToHashSet()
+                .Select(index => new VoiceConfiguration((Voice)index, index.ToNote(), (index + 1).ToNote()))
+                .ToHashSet(),
+            Scale.Parse("C Major")
         );
 
         // act
@@ -50,8 +53,9 @@ internal sealed class ChordContextRepositoryFactoryTests
             new HashSet<VoiceConfiguration>
             {
                 // invalid configuration: only one voice
-                new(Voice.Soprano, 55, 90)
-            }
+                new(Voice.Soprano, 55.ToNote(), 90.ToNote())
+            },
+            Scale.Parse("C Major")
         );
 
         // act

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Contexts/ChordContextTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Contexts/ChordContextTests.cs
@@ -1,5 +1,6 @@
 ﻿using BaroquenMelody.Library.Compositions.Contexts;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Extensions;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -11,10 +12,10 @@ internal sealed class ChordContextTests
     [Test]
     public void WhenChordContextsAreSameReference_TheyAreEqual()
     {
-        var context1 = new NoteContext(Voice.Soprano, 60, NoteMotion.Oblique, NoteSpan.None);
-        var context2 = new NoteContext(Voice.Alto, 64, NoteMotion.Ascending, NoteSpan.Step);
-        var context3 = new NoteContext(Voice.Tenor, 67, NoteMotion.Descending, NoteSpan.Leap);
-        var context4 = new NoteContext(Voice.Bass, 72, NoteMotion.Ascending, NoteSpan.Step);
+        var context1 = new NoteContext(Voice.Soprano, 60.ToNote(), NoteMotion.Oblique, NoteSpan.None);
+        var context2 = new NoteContext(Voice.Alto, 64.ToNote(), NoteMotion.Ascending, NoteSpan.Step);
+        var context3 = new NoteContext(Voice.Tenor, 67.ToNote(), NoteMotion.Descending, NoteSpan.Leap);
+        var context4 = new NoteContext(Voice.Bass, 72.ToNote(), NoteMotion.Ascending, NoteSpan.Step);
 
         var chordContextA = new ChordContext(new List<NoteContext> { context1, context2, context3, context4 });
         var chordContextB = chordContextA;
@@ -38,10 +39,10 @@ internal sealed class ChordContextTests
     [Test]
     public void WhenChordContextsHaveSameNoteContexts_TheyAreEqual()
     {
-        var context1 = new NoteContext(Voice.Soprano, 60, NoteMotion.Oblique, NoteSpan.None);
-        var context2 = new NoteContext(Voice.Alto, 64, NoteMotion.Ascending, NoteSpan.Step);
-        var context3 = new NoteContext(Voice.Tenor, 67, NoteMotion.Descending, NoteSpan.Leap);
-        var context4 = new NoteContext(Voice.Bass, 72, NoteMotion.Ascending, NoteSpan.Step);
+        var context1 = new NoteContext(Voice.Soprano, 60.ToNote(), NoteMotion.Oblique, NoteSpan.None);
+        var context2 = new NoteContext(Voice.Alto, 64.ToNote(), NoteMotion.Ascending, NoteSpan.Step);
+        var context3 = new NoteContext(Voice.Tenor, 67.ToNote(), NoteMotion.Descending, NoteSpan.Leap);
+        var context4 = new NoteContext(Voice.Bass, 72.ToNote(), NoteMotion.Ascending, NoteSpan.Step);
 
         var chordContextA = new ChordContext(new List<NoteContext> { context1, context2, context3, context4 });
         var chordContextB = new ChordContext(new List<NoteContext> { context1, context2, context3, context4 });
@@ -65,10 +66,10 @@ internal sealed class ChordContextTests
     [Test]
     public void WhenOneChordContextIsNull_TheyAreNotEqual()
     {
-        var context1 = new NoteContext(Voice.Soprano, 60, NoteMotion.Oblique, NoteSpan.None);
-        var context2 = new NoteContext(Voice.Alto, 64, NoteMotion.Ascending, NoteSpan.Step);
-        var context3 = new NoteContext(Voice.Tenor, 67, NoteMotion.Descending, NoteSpan.Leap);
-        var context4 = new NoteContext(Voice.Bass, 72, NoteMotion.Ascending, NoteSpan.Step);
+        var context1 = new NoteContext(Voice.Soprano, 60.ToNote(), NoteMotion.Oblique, NoteSpan.None);
+        var context2 = new NoteContext(Voice.Alto, 64.ToNote(), NoteMotion.Ascending, NoteSpan.Step);
+        var context3 = new NoteContext(Voice.Tenor, 67.ToNote(), NoteMotion.Descending, NoteSpan.Leap);
+        var context4 = new NoteContext(Voice.Bass, 72.ToNote(), NoteMotion.Ascending, NoteSpan.Step);
 
         var chordContextA = new ChordContext(new List<NoteContext> { context1, context2, context3, context4 });
         ChordContext? chordContextB = null;
@@ -82,10 +83,10 @@ internal sealed class ChordContextTests
     [Test]
     public void WhenNonDestructiveMutationUsed_InitializerInvoked()
     {
-        var context1 = new NoteContext(Voice.Soprano, 60, NoteMotion.Oblique, NoteSpan.None);
-        var context2 = new NoteContext(Voice.Alto, 64, NoteMotion.Ascending, NoteSpan.Step);
-        var context3 = new NoteContext(Voice.Tenor, 67, NoteMotion.Descending, NoteSpan.Leap);
-        var context4 = new NoteContext(Voice.Bass, 72, NoteMotion.Ascending, NoteSpan.Step);
+        var context1 = new NoteContext(Voice.Soprano, 60.ToNote(), NoteMotion.Oblique, NoteSpan.None);
+        var context2 = new NoteContext(Voice.Alto, 64.ToNote(), NoteMotion.Ascending, NoteSpan.Step);
+        var context3 = new NoteContext(Voice.Tenor, 67.ToNote(), NoteMotion.Descending, NoteSpan.Leap);
+        var context4 = new NoteContext(Voice.Bass, 72.ToNote(), NoteMotion.Ascending, NoteSpan.Step);
 
         var chordContext = new ChordContext(new List<NoteContext> { context1, context2, context3, context4 });
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Contexts/DuetChordContextRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Contexts/DuetChordContextRepositoryTests.cs
@@ -1,7 +1,9 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Contexts;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Extensions;
 using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -22,24 +24,29 @@ internal sealed class DuetChordContextRepositoryTests
         var compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>
             {
-                new(Voice.Soprano, 55, 90),
-                new(Voice.Alto, 45, 80)
-            }
+                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
+                new(Voice.Alto, 45.ToNote(), 80.ToNote())
+            },
+            Scale.Parse("C Major")
         );
 
-        var noteContext1 = new NoteContext(Voice.Soprano, 60, NoteMotion.Oblique, NoteSpan.None);
-        var noteContext2 = new NoteContext(Voice.Alto, 70, NoteMotion.Oblique, NoteSpan.None);
-        var noteContext3 = new NoteContext(Voice.Soprano, 65, NoteMotion.Oblique, NoteSpan.None);
-        var noteContext4 = new NoteContext(Voice.Alto, 75, NoteMotion.Oblique, NoteSpan.None);
+        var noteContext1 = new NoteContext(Voice.Soprano, 60.ToNote(), NoteMotion.Oblique, NoteSpan.None);
+        var noteContext2 = new NoteContext(Voice.Alto, 70.ToNote(), NoteMotion.Oblique, NoteSpan.None);
+        var noteContext3 = new NoteContext(Voice.Soprano, 65.ToNote(), NoteMotion.Oblique, NoteSpan.None);
+        var noteContext4 = new NoteContext(Voice.Alto, 75.ToNote(), NoteMotion.Oblique, NoteSpan.None);
 
         _mockNoteContextGenerator
             .GenerateNoteContexts(
-                Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Soprano)
+                Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Soprano),
+                Arg.Any<Scale>()
             )
             .Returns(new HashSet<NoteContext> { noteContext1, noteContext3 });
 
         _mockNoteContextGenerator
-            .GenerateNoteContexts(Arg.Is<VoiceConfiguration>(vc => vc.Voice == Voice.Alto))
+            .GenerateNoteContexts(
+                Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Alto),
+                Arg.Any<Scale>()
+            )
             .Returns(new HashSet<NoteContext> { noteContext2, noteContext4 });
 
         var duetChordContextRepository = new DuetChordContextRepository(
@@ -63,11 +70,13 @@ internal sealed class DuetChordContextRepositoryTests
         Received.InOrder(() =>
             {
                 _mockNoteContextGenerator.GenerateNoteContexts(
-                    Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Soprano)
+                    Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Soprano),
+                    Arg.Any<Scale>()
                 );
 
                 _mockNoteContextGenerator.GenerateNoteContexts(
-                    Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Alto)
+                    Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Alto),
+                    Arg.Any<Scale>()
                 );
             }
         );
@@ -80,10 +89,11 @@ internal sealed class DuetChordContextRepositoryTests
         var compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>
             {
-                new(Voice.Soprano, 55, 90),
-                new(Voice.Alto, 45, 80),
-                new(Voice.Tenor, 35, 70)
-            }
+                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
+                new(Voice.Alto, 45.ToNote(), 80.ToNote()),
+                new(Voice.Tenor, 35.ToNote(), 70.ToNote())
+            },
+            Scale.Parse("C Major")
         );
 
         // act

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Contexts/NoteContextGeneratorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Contexts/NoteContextGeneratorTests.cs
@@ -1,7 +1,9 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Contexts;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Extensions;
 using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
 using NUnit.Framework;
 
 namespace BaroquenMelody.Library.Tests.Compositions.Contexts;
@@ -18,7 +20,7 @@ internal sealed class NoteContextGeneratorTests
     [TestCaseSource(nameof(TestVoiceConfigurations))]
     public void TestGenerateNoteContexts(VoiceConfiguration voiceConfiguration, HashSet<NoteContext> expectedContexts)
     {
-        var generatedContexts = _noteContextGenerator.GenerateNoteContexts(voiceConfiguration);
+        var generatedContexts = _noteContextGenerator.GenerateNoteContexts(voiceConfiguration, Scale.Parse("C Major"));
 
         generatedContexts.Should().BeEquivalentTo(expectedContexts);
     }
@@ -27,33 +29,49 @@ internal sealed class NoteContextGeneratorTests
     {
         get
         {
-            return ((Voice[])Enum.GetValues(typeof(Voice))).Select(voice => new TestCaseData(
-                new VoiceConfiguration(voice, 1, 5),
-                new HashSet<NoteContext>
-                {
-                    new(voice, 1, NoteMotion.Descending, NoteSpan.Step),
-                    new(voice, 1, NoteMotion.Descending, NoteSpan.Leap),
-                    new(voice, 1, NoteMotion.Oblique, NoteSpan.None),
-                    new(voice, 2, NoteMotion.Ascending, NoteSpan.Step),
-                    new(voice, 2, NoteMotion.Ascending, NoteSpan.Leap),
-                    new(voice, 2, NoteMotion.Descending, NoteSpan.Step),
-                    new(voice, 2, NoteMotion.Descending, NoteSpan.Leap),
-                    new(voice, 2, NoteMotion.Oblique, NoteSpan.None),
-                    new(voice, 3, NoteMotion.Ascending, NoteSpan.Step),
-                    new(voice, 3, NoteMotion.Ascending, NoteSpan.Leap),
-                    new(voice, 3, NoteMotion.Descending, NoteSpan.Step),
-                    new(voice, 3, NoteMotion.Descending, NoteSpan.Leap),
-                    new(voice, 3, NoteMotion.Oblique, NoteSpan.None),
-                    new(voice, 4, NoteMotion.Ascending, NoteSpan.Step),
-                    new(voice, 4, NoteMotion.Ascending, NoteSpan.Leap),
-                    new(voice, 4, NoteMotion.Descending, NoteSpan.Step),
-                    new(voice, 4, NoteMotion.Descending, NoteSpan.Leap),
-                    new(voice, 4, NoteMotion.Oblique, NoteSpan.None),
-                    new(voice, 5, NoteMotion.Ascending, NoteSpan.Step),
-                    new(voice, 5, NoteMotion.Ascending, NoteSpan.Leap),
-                    new(voice, 5, NoteMotion.Oblique, NoteSpan.None)
-                }
-            ));
+            return ((Voice[])Enum.GetValues(typeof(Voice)))
+                .Select(voice => new TestCaseData(
+                    new VoiceConfiguration(voice, 0.ToNote(), 12.ToNote()),
+                    new HashSet<NoteContext>
+                    {
+                        new(voice, 0.ToNote(), NoteMotion.Descending, NoteSpan.Step),
+                        new(voice, 0.ToNote(), NoteMotion.Descending, NoteSpan.Leap),
+                        new(voice, 0.ToNote(), NoteMotion.Oblique, NoteSpan.None),
+                        new(voice, 2.ToNote(), NoteMotion.Ascending, NoteSpan.Step),
+                        new(voice, 2.ToNote(), NoteMotion.Ascending, NoteSpan.Leap),
+                        new(voice, 2.ToNote(), NoteMotion.Descending, NoteSpan.Step),
+                        new(voice, 2.ToNote(), NoteMotion.Descending, NoteSpan.Leap),
+                        new(voice, 2.ToNote(), NoteMotion.Oblique, NoteSpan.None),
+                        new(voice, 4.ToNote(), NoteMotion.Ascending, NoteSpan.Step),
+                        new(voice, 4.ToNote(), NoteMotion.Ascending, NoteSpan.Leap),
+                        new(voice, 4.ToNote(), NoteMotion.Descending, NoteSpan.Step),
+                        new(voice, 4.ToNote(), NoteMotion.Descending, NoteSpan.Leap),
+                        new(voice, 4.ToNote(), NoteMotion.Oblique, NoteSpan.None),
+                        new(voice, 5.ToNote(), NoteMotion.Ascending, NoteSpan.Step),
+                        new(voice, 5.ToNote(), NoteMotion.Ascending, NoteSpan.Leap),
+                        new(voice, 5.ToNote(), NoteMotion.Descending, NoteSpan.Step),
+                        new(voice, 5.ToNote(), NoteMotion.Descending, NoteSpan.Leap),
+                        new(voice, 5.ToNote(), NoteMotion.Oblique, NoteSpan.None),
+                        new(voice, 7.ToNote(), NoteMotion.Ascending, NoteSpan.Step),
+                        new(voice, 7.ToNote(), NoteMotion.Ascending, NoteSpan.Leap),
+                        new(voice, 7.ToNote(), NoteMotion.Descending, NoteSpan.Step),
+                        new(voice, 7.ToNote(), NoteMotion.Descending, NoteSpan.Leap),
+                        new(voice, 7.ToNote(), NoteMotion.Oblique, NoteSpan.None),
+                        new(voice, 9.ToNote(), NoteMotion.Ascending, NoteSpan.Step),
+                        new(voice, 9.ToNote(), NoteMotion.Ascending, NoteSpan.Leap),
+                        new(voice, 9.ToNote(), NoteMotion.Descending, NoteSpan.Step),
+                        new(voice, 9.ToNote(), NoteMotion.Descending, NoteSpan.Leap),
+                        new(voice, 9.ToNote(), NoteMotion.Oblique, NoteSpan.None),
+                        new(voice, 11.ToNote(), NoteMotion.Ascending, NoteSpan.Step),
+                        new(voice, 11.ToNote(), NoteMotion.Ascending, NoteSpan.Leap),
+                        new(voice, 11.ToNote(), NoteMotion.Descending, NoteSpan.Step),
+                        new(voice, 11.ToNote(), NoteMotion.Descending, NoteSpan.Leap),
+                        new(voice, 11.ToNote(), NoteMotion.Oblique, NoteSpan.None),
+                        new(voice, 12.ToNote(), NoteMotion.Ascending, NoteSpan.Step),
+                        new(voice, 12.ToNote(), NoteMotion.Ascending, NoteSpan.Leap),
+                        new(voice, 12.ToNote(), NoteMotion.Oblique, NoteSpan.None)
+                    }
+                ));
         }
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Contexts/QuartetContextRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Contexts/QuartetContextRepositoryTests.cs
@@ -1,7 +1,9 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Contexts;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Extensions;
 using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -22,46 +24,51 @@ internal sealed class QuartetChordContextRepositoryTests
         var compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>
             {
-                new(Voice.Soprano, 55, 90),
-                new(Voice.Alto, 45, 80),
-                new(Voice.Tenor, 35, 70),
-                new(Voice.Bass, 25, 60)
-            }
+                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
+                new(Voice.Alto, 45.ToNote(), 80.ToNote()),
+                new(Voice.Tenor, 35.ToNote(), 70.ToNote()),
+                new(Voice.Bass, 25.ToNote(), 60.ToNote())
+            },
+            Scale.Parse("C Major")
         );
 
-        var sopranoNoteContext1 = new NoteContext(Voice.Soprano, 60, NoteMotion.Oblique, NoteSpan.None);
-        var sopranoNoteContext2 = new NoteContext(Voice.Soprano, 65, NoteMotion.Oblique, NoteSpan.None);
+        var sopranoNoteContext1 = new NoteContext(Voice.Soprano, 60.ToNote(), NoteMotion.Oblique, NoteSpan.None);
+        var sopranoNoteContext2 = new NoteContext(Voice.Soprano, 65.ToNote(), NoteMotion.Oblique, NoteSpan.None);
 
-        var altoNoteContext1 = new NoteContext(Voice.Alto, 70, NoteMotion.Oblique, NoteSpan.None);
-        var altoNoteContext2 = new NoteContext(Voice.Alto, 75, NoteMotion.Oblique, NoteSpan.None);
+        var altoNoteContext1 = new NoteContext(Voice.Alto, 70.ToNote(), NoteMotion.Oblique, NoteSpan.None);
+        var altoNoteContext2 = new NoteContext(Voice.Alto, 75.ToNote(), NoteMotion.Oblique, NoteSpan.None);
 
-        var tenorNoteContext1 = new NoteContext(Voice.Tenor, 40, NoteMotion.Oblique, NoteSpan.None);
-        var tenorNoteContext2 = new NoteContext(Voice.Tenor, 45, NoteMotion.Oblique, NoteSpan.None);
+        var tenorNoteContext1 = new NoteContext(Voice.Tenor, 40.ToNote(), NoteMotion.Oblique, NoteSpan.None);
+        var tenorNoteContext2 = new NoteContext(Voice.Tenor, 45.ToNote(), NoteMotion.Oblique, NoteSpan.None);
 
-        var bassNoteContext1 = new NoteContext(Voice.Bass, 30, NoteMotion.Oblique, NoteSpan.None);
-        var bassNoteContext2 = new NoteContext(Voice.Bass, 35, NoteMotion.Oblique, NoteSpan.None);
+        var bassNoteContext1 = new NoteContext(Voice.Bass, 30.ToNote(), NoteMotion.Oblique, NoteSpan.None);
+        var bassNoteContext2 = new NoteContext(Voice.Bass, 35.ToNote(), NoteMotion.Oblique, NoteSpan.None);
 
         _mockNoteContextGenerator
             .GenerateNoteContexts(
-                Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Soprano)
+                Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Soprano),
+                Arg.Any<Scale>()
             )
             .Returns(new HashSet<NoteContext> { sopranoNoteContext1, sopranoNoteContext2 });
 
         _mockNoteContextGenerator
             .GenerateNoteContexts(
-                Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Alto)
+                Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Alto),
+                Arg.Any<Scale>()
             )
             .Returns(new HashSet<NoteContext> { altoNoteContext1, altoNoteContext2 });
 
         _mockNoteContextGenerator
             .GenerateNoteContexts(
-                Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Tenor)
+                Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Tenor),
+                Arg.Any<Scale>()
             )
             .Returns(new HashSet<NoteContext> { tenorNoteContext1, tenorNoteContext2 });
 
         _mockNoteContextGenerator
             .GenerateNoteContexts(
-                Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Bass)
+                Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Bass),
+                Arg.Any<Scale>()
             )
             .Returns(new HashSet<NoteContext> { bassNoteContext1, bassNoteContext2 });
 
@@ -88,19 +95,23 @@ internal sealed class QuartetChordContextRepositoryTests
         Received.InOrder(() =>
             {
                 _mockNoteContextGenerator.GenerateNoteContexts(
-                    Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Soprano)
+                    Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Soprano),
+                    Arg.Any<Scale>()
                 );
 
                 _mockNoteContextGenerator.GenerateNoteContexts(
-                    Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Alto)
+                    Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Alto),
+                    Arg.Any<Scale>()
                 );
 
                 _mockNoteContextGenerator.GenerateNoteContexts(
-                    Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Tenor)
+                    Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Tenor),
+                    Arg.Any<Scale>()
                 );
 
                 _mockNoteContextGenerator.GenerateNoteContexts(
-                    Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Bass)
+                    Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Bass),
+                    Arg.Any<Scale>()
                 );
             }
         );
@@ -113,10 +124,11 @@ internal sealed class QuartetChordContextRepositoryTests
         var compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>
             {
-                new(Voice.Soprano, 55, 90),
-                new(Voice.Alto, 45, 80),
-                new(Voice.Tenor, 35, 70)
-            }
+                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
+                new(Voice.Alto, 45.ToNote(), 80.ToNote()),
+                new(Voice.Tenor, 35.ToNote(), 70.ToNote())
+            },
+            Scale.Parse("C Major")
         );
 
         // act

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Contexts/TrioChordContextRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Contexts/TrioChordContextRepositoryTests.cs
@@ -1,7 +1,9 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Contexts;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Extensions;
 using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -22,36 +24,40 @@ internal sealed class TrioChordContextRepositoryTests
         var compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>
             {
-                new(Voice.Soprano, 55, 90),
-                new(Voice.Alto, 45, 80),
-                new(Voice.Tenor, 35, 70)
-            }
+                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
+                new(Voice.Alto, 45.ToNote(), 80.ToNote()),
+                new(Voice.Tenor, 35.ToNote(), 70.ToNote())
+            },
+            Scale.Parse("C Major")
         );
 
-        var sopranoNoteContext1 = new NoteContext(Voice.Soprano, 60, NoteMotion.Oblique, NoteSpan.None);
-        var sopranoNoteContext2 = new NoteContext(Voice.Soprano, 65, NoteMotion.Oblique, NoteSpan.None);
+        var sopranoNoteContext1 = new NoteContext(Voice.Soprano, 60.ToNote(), NoteMotion.Oblique, NoteSpan.None);
+        var sopranoNoteContext2 = new NoteContext(Voice.Soprano, 65.ToNote(), NoteMotion.Oblique, NoteSpan.None);
 
-        var altoNoteContext1 = new NoteContext(Voice.Alto, 70, NoteMotion.Oblique, NoteSpan.None);
-        var altoNoteContext2 = new NoteContext(Voice.Alto, 75, NoteMotion.Oblique, NoteSpan.None);
+        var altoNoteContext1 = new NoteContext(Voice.Alto, 70.ToNote(), NoteMotion.Oblique, NoteSpan.None);
+        var altoNoteContext2 = new NoteContext(Voice.Alto, 75.ToNote(), NoteMotion.Oblique, NoteSpan.None);
 
-        var tenorNoteContext1 = new NoteContext(Voice.Tenor, 40, NoteMotion.Oblique, NoteSpan.None);
-        var tenorNoteContext2 = new NoteContext(Voice.Tenor, 45, NoteMotion.Oblique, NoteSpan.None);
+        var tenorNoteContext1 = new NoteContext(Voice.Tenor, 40.ToNote(), NoteMotion.Oblique, NoteSpan.None);
+        var tenorNoteContext2 = new NoteContext(Voice.Tenor, 45.ToNote(), NoteMotion.Oblique, NoteSpan.None);
 
         _mockNoteContextGenerator
             .GenerateNoteContexts(
-                Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Soprano)
+                Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Soprano),
+                Arg.Any<Scale>()
             )
             .Returns(new HashSet<NoteContext> { sopranoNoteContext1, sopranoNoteContext2 });
 
         _mockNoteContextGenerator
             .GenerateNoteContexts(
-                Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Alto)
+                Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Alto),
+                Arg.Any<Scale>()
             )
             .Returns(new HashSet<NoteContext> { altoNoteContext1, altoNoteContext2 });
 
         _mockNoteContextGenerator
             .GenerateNoteContexts(
-                Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Tenor)
+                Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Tenor),
+                Arg.Any<Scale>()
             )
             .Returns(new HashSet<NoteContext> { tenorNoteContext1, tenorNoteContext2 });
 
@@ -78,15 +84,18 @@ internal sealed class TrioChordContextRepositoryTests
         Received.InOrder(() =>
             {
                 _mockNoteContextGenerator.GenerateNoteContexts(
-                    Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Soprano)
+                    Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Soprano),
+                    Arg.Any<Scale>()
                 );
 
                 _mockNoteContextGenerator.GenerateNoteContexts(
-                    Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Alto)
+                    Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Alto),
+                    Arg.Any<Scale>()
                 );
 
                 _mockNoteContextGenerator.GenerateNoteContexts(
-                    Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Tenor)
+                    Arg.Is<VoiceConfiguration>(voiceConfiguration => voiceConfiguration.Voice == Voice.Tenor),
+                    Arg.Any<Scale>()
                 );
             }
         );
@@ -99,9 +108,10 @@ internal sealed class TrioChordContextRepositoryTests
         var compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>
             {
-                new(Voice.Soprano, 55, 90),
-                new(Voice.Alto, 45, 80)
-            }
+                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
+                new(Voice.Alto, 45.ToNote(), 80.ToNote())
+            },
+            Scale.Parse("C Major")
         );
 
         // act

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Strategies/CompositionStrategyTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Strategies/CompositionStrategyTests.cs
@@ -3,8 +3,10 @@ using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Contexts;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Strategies;
+using BaroquenMelody.Library.Extensions;
 using BaroquenMelody.Library.Random;
 using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
 using NUnit.Framework;
 using System.Collections;
@@ -61,11 +63,12 @@ internal sealed class CompositionStrategyTests
         _compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>
             {
-                new(Voice.Soprano, MinSopranoPitch, MaxSopranoPitch),
-                new(Voice.Alto, MinAltoPitch, MaxAltoPitch),
-                new(Voice.Tenor, MinTenorPitch, MaxTenorPitch),
-                new(Voice.Bass, MinBassPitch, MaxBassPitch)
-            }
+                new(Voice.Soprano, MinSopranoPitch.ToNote(), MaxSopranoPitch.ToNote()),
+                new(Voice.Alto, MinAltoPitch.ToNote(), MaxAltoPitch.ToNote()),
+                new(Voice.Tenor, MinTenorPitch.ToNote(), MaxTenorPitch.ToNote()),
+                new(Voice.Bass, MinBassPitch.ToNote(), MaxBassPitch.ToNote())
+            },
+            Scale.Parse("C Major")
         );
 
         _compositionStrategy = new CompositionStrategy(
@@ -84,10 +87,10 @@ internal sealed class CompositionStrategyTests
         var chordContext = new ChordContext(
             new List<NoteContext>
             {
-                new(Voice.Soprano, MaxSopranoPitch - 2, NoteMotion.Ascending, NoteSpan.Step),
-                new(Voice.Alto, MinAltoPitch + 2, NoteMotion.Ascending, NoteSpan.Step),
-                new(Voice.Tenor, MaxTenorPitch - 2, NoteMotion.Ascending, NoteSpan.Step),
-                new(Voice.Bass, MinBassPitch + 2, NoteMotion.Ascending, NoteSpan.Step)
+                new(Voice.Soprano, (MaxSopranoPitch - 1).ToNote(), NoteMotion.Ascending, NoteSpan.Step),
+                new(Voice.Alto, (MinAltoPitch + 2).ToNote(), NoteMotion.Ascending, NoteSpan.Step),
+                new(Voice.Tenor, (MaxTenorPitch - 1).ToNote(), NoteMotion.Ascending, NoteSpan.Step),
+                new(Voice.Bass, (MinBassPitch + 2).ToNote(), NoteMotion.Ascending, NoteSpan.Step)
             }
         );
 
@@ -134,10 +137,10 @@ internal sealed class CompositionStrategyTests
         var chordContext = new ChordContext(
             new List<NoteContext>
             {
-                new(Voice.Soprano, MaxSopranoPitch - 2, NoteMotion.Ascending, NoteSpan.Step),
-                new(Voice.Alto, MinAltoPitch + 2, NoteMotion.Ascending, NoteSpan.Step),
-                new(Voice.Tenor, MaxTenorPitch - 2, NoteMotion.Ascending, NoteSpan.Step),
-                new(Voice.Bass, MinBassPitch + 2, NoteMotion.Ascending, NoteSpan.Step)
+                new(Voice.Soprano, (MaxSopranoPitch - 1).ToNote(), NoteMotion.Ascending, NoteSpan.Step),
+                new(Voice.Alto, (MinAltoPitch + 2).ToNote(), NoteMotion.Ascending, NoteSpan.Step),
+                new(Voice.Tenor, (MaxTenorPitch - 1).ToNote(), NoteMotion.Ascending, NoteSpan.Step),
+                new(Voice.Bass, (MinBassPitch + 2).ToNote(), NoteMotion.Ascending, NoteSpan.Step)
             }
         );
 
@@ -212,10 +215,10 @@ internal sealed class CompositionStrategyTests
         var chordContext = new ChordContext(
             new List<NoteContext>
             {
-                new(Voice.Soprano, 25, NoteMotion.Ascending, NoteSpan.Step),
-                new(Voice.Alto, 25, NoteMotion.Ascending, NoteSpan.Step),
-                new(Voice.Tenor, 25, NoteMotion.Ascending, NoteSpan.Step),
-                new(Voice.Bass, 25, NoteMotion.Ascending, NoteSpan.Step)
+                new(Voice.Soprano, 25.ToNote(), NoteMotion.Ascending, NoteSpan.Step),
+                new(Voice.Alto, 25.ToNote(), NoteMotion.Ascending, NoteSpan.Step),
+                new(Voice.Tenor, 25.ToNote(), NoteMotion.Ascending, NoteSpan.Step),
+                new(Voice.Bass, 25.ToNote(), NoteMotion.Ascending, NoteSpan.Step)
             }
         );
 

--- a/tests/BaroquenMelody.Library.Tests/Configuration/CompositionConfigurationTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Configuration/CompositionConfigurationTests.cs
@@ -1,6 +1,8 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Extensions;
 using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
 using NUnit.Framework;
 
 namespace BaroquenMelody.Library.Tests.Configuration;
@@ -17,13 +19,16 @@ internal sealed class CompositionConfigurationTests
     [SetUp]
     public void SetUp()
     {
-        _compositionConfiguration = new CompositionConfiguration(new HashSet<VoiceConfiguration>
-        {
-            new(Voice.Soprano, MinSopranoPitch, MaxSopranoPitch),
-            new(Voice.Alto, 48, 60),
-            new(Voice.Tenor, 36, 48),
-            new(Voice.Bass, 24, 36)
-        });
+        _compositionConfiguration = new CompositionConfiguration(
+            new HashSet<VoiceConfiguration>
+            {
+                new(Voice.Soprano, MinSopranoPitch.ToNote(), MaxSopranoPitch.ToNote()),
+                new(Voice.Alto, 48.ToNote(), 60.ToNote()),
+                new(Voice.Tenor, 36.ToNote(), 48.ToNote()),
+                new(Voice.Bass, 24.ToNote(), 36.ToNote())
+            },
+            Scale.Parse("C Major")
+        );
     }
 
     [Test]
@@ -38,7 +43,7 @@ internal sealed class CompositionConfigurationTests
         byte pitch,
         bool expectedPitchIsInVoiceRange)
     {
-        var isPitchInVoiceRange = _compositionConfiguration.IsPitchInVoiceRange(voice, pitch);
+        var isPitchInVoiceRange = _compositionConfiguration.IsNoteInVoiceRange(voice, pitch.ToNote());
 
         isPitchInVoiceRange.Should().Be(expectedPitchIsInVoiceRange);
     }

--- a/tests/BaroquenMelody.Library.Tests/Extensions/ChordContextExtensionsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Extensions/ChordContextExtensionsTests.cs
@@ -4,6 +4,7 @@ using BaroquenMelody.Library.Compositions.Contexts;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Extensions;
 using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
 using NUnit.Framework;
 
 namespace BaroquenMelody.Library.Tests.Extensions;
@@ -17,10 +18,10 @@ internal sealed class ChordContextExtensionsTests
         // arrange
         var chordContext = new ChordContext(new[]
         {
-            new NoteContext(Voice.Soprano, 60, NoteMotion.Oblique, NoteSpan.Leap),
-            new NoteContext(Voice.Alto, 55, NoteMotion.Oblique, NoteSpan.Leap),
-            new NoteContext(Voice.Tenor, 50, NoteMotion.Oblique, NoteSpan.Leap),
-            new NoteContext(Voice.Bass, 45, NoteMotion.Oblique, NoteSpan.Leap)
+            new NoteContext(Voice.Soprano, Note.Get(NoteName.C, 5), NoteMotion.Oblique, NoteSpan.Leap),
+            new NoteContext(Voice.Alto, Note.Get(NoteName.A, 4), NoteMotion.Oblique, NoteSpan.Leap),
+            new NoteContext(Voice.Tenor, Note.Get(NoteName.F, 4), NoteMotion.Oblique, NoteSpan.Leap),
+            new NoteContext(Voice.Bass, Note.Get(NoteName.F, 3), NoteMotion.Oblique, NoteSpan.Leap)
         });
 
         var chordChoice = new ChordChoice(new HashSet<NoteChoice>
@@ -31,19 +32,19 @@ internal sealed class ChordContextExtensionsTests
             new(Voice.Bass, NoteMotion.Ascending, 3)
         });
 
-        var expectedNotes = new HashSet<Note>
+        var expectedNotes = new HashSet<VoicedNote>
         {
-            new(62, Voice.Soprano, chordContext[Voice.Soprano], chordChoice.NoteChoices.First(noteChoice => noteChoice.Voice == Voice.Soprano)),
-            new(54, Voice.Alto, chordContext[Voice.Alto], chordChoice.NoteChoices.First(noteChoice => noteChoice.Voice == Voice.Alto)),
-            new(50, Voice.Tenor, chordContext[Voice.Tenor], chordChoice.NoteChoices.First(noteChoice => noteChoice.Voice == Voice.Tenor)),
-            new(48, Voice.Bass, chordContext[Voice.Bass], chordChoice.NoteChoices.First(noteChoice => noteChoice.Voice == Voice.Bass))
+            new(Note.Get(NoteName.E, 5), Voice.Soprano, chordContext[Voice.Soprano], chordChoice.NoteChoices.First(noteChoice => noteChoice.Voice == Voice.Soprano)),
+            new(Note.Get(NoteName.G, 4), Voice.Alto, chordContext[Voice.Alto], chordChoice.NoteChoices.First(noteChoice => noteChoice.Voice == Voice.Alto)),
+            new(Note.Get(NoteName.F, 4), Voice.Tenor, chordContext[Voice.Tenor], chordChoice.NoteChoices.First(noteChoice => noteChoice.Voice == Voice.Tenor)),
+            new(Note.Get(NoteName.B, 3), Voice.Bass, chordContext[Voice.Bass], chordChoice.NoteChoices.First(noteChoice => noteChoice.Voice == Voice.Bass))
         };
 
         // act
-        var resultChord = chordContext.ApplyChordChoice(chordChoice);
+        var resultChord = chordContext.ApplyChordChoice(chordChoice, Scale.Parse("C Major"));
 
         // assert
-        resultChord.Notes.Should().BeEquivalentTo(expectedNotes);
+        resultChord.VoicedNotes.Should().BeEquivalentTo(expectedNotes);
         resultChord.ChordContext.Should().Be(chordContext);
         resultChord.ChordChoice.Should().Be(chordChoice);
     }

--- a/tests/BaroquenMelody.Library.Tests/Extensions/NoteContextExtensionsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Extensions/NoteContextExtensionsTests.cs
@@ -3,6 +3,7 @@ using BaroquenMelody.Library.Compositions.Contexts;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Extensions;
 using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
 using NUnit.Framework;
 
 namespace BaroquenMelody.Library.Tests.Extensions;
@@ -11,24 +12,24 @@ namespace BaroquenMelody.Library.Tests.Extensions;
 internal sealed class NoteContextExtensionsTests
 {
     [Test]
-    [TestCase(60, 2, NoteMotion.Ascending, 62)]
-    [TestCase(60, 2, NoteMotion.Descending, 58)]
+    [TestCase(60, 2, NoteMotion.Ascending, 64)]
+    [TestCase(60, 2, NoteMotion.Descending, 57)]
     [TestCase(60, 0, NoteMotion.Oblique, 60)]
     public void ApplyNoteChoice_ShouldCalculateCorrectPitch(
         byte startPitch,
-        byte pitchChange,
+        byte scaleStepChange,
         NoteMotion noteMotion,
         byte expectedPitch)
     {
         // arrange
-        var noteContext = new NoteContext(Voice.Soprano, startPitch, NoteMotion.Oblique, NoteSpan.None);
-        var noteChoice = new NoteChoice(Voice.Soprano, noteMotion, pitchChange);
+        var noteContext = new NoteContext(Voice.Soprano, startPitch.ToNote(), NoteMotion.Oblique, NoteSpan.None);
+        var noteChoice = new NoteChoice(Voice.Soprano, noteMotion, scaleStepChange);
 
         // act
-        var resultNote = noteContext.ApplyNoteChoice(noteChoice);
+        var resultNote = noteContext.ApplyNoteChoice(noteChoice, Scale.Parse("C Major"));
 
         // assert
-        resultNote.Pitch.Should().Be(expectedPitch);
+        resultNote.Note.Should().Be(expectedPitch.ToNote());
         resultNote.NoteContext.Should().BeEquivalentTo(noteContext);
         resultNote.NoteChoice.Should().BeEquivalentTo(noteChoice);
     }
@@ -37,11 +38,11 @@ internal sealed class NoteContextExtensionsTests
     public void ApplyNoteChoice_WithUnsupportedMotion_ShouldThrowArgumentOutOfRangeException()
     {
         // arrange
-        var noteContext = new NoteContext(Voice.Soprano, 60, NoteMotion.Oblique, NoteSpan.None);
+        var noteContext = new NoteContext(Voice.Soprano, 60.ToNote(), NoteMotion.Oblique, NoteSpan.None);
         var noteChoice = new NoteChoice(Voice.Soprano, (NoteMotion)55, 5);
 
         // act
-        var act = () => noteContext.ApplyNoteChoice(noteChoice);
+        var act = () => noteContext.ApplyNoteChoice(noteChoice, Scale.Parse("C Major"));
 
         // assert
         act.Should().Throw<ArgumentOutOfRangeException>();

--- a/tests/BaroquenMelody.Library.Tests/Extensions/NumericExtensionsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Extensions/NumericExtensionsTests.cs
@@ -1,0 +1,58 @@
+﻿using BaroquenMelody.Library.Extensions;
+using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Extensions;
+
+[TestFixture]
+internal sealed class NumericExtensionsTests
+{
+    [Test]
+    [TestCase(60, NoteName.C, 4)]
+    [TestCase(61, NoteName.CSharp, 4)]
+    [TestCase(62, NoteName.D, 4)]
+    [TestCase(63, NoteName.DSharp, 4)]
+    [TestCase(64, NoteName.E, 4)]
+    [TestCase(65, NoteName.F, 4)]
+    [TestCase(66, NoteName.FSharp, 4)]
+    [TestCase(67, NoteName.G, 4)]
+    [TestCase(68, NoteName.GSharp, 4)]
+    [TestCase(69, NoteName.A, 4)]
+    [TestCase(70, NoteName.ASharp, 4)]
+    [TestCase(71, NoteName.B, 4)]
+    [TestCase(72, NoteName.C, 5)]
+    public void ToNoteWithInteger_GeneratesExpectedNote(int pitch, NoteName expectedNoteName, int expectedOctave)
+    {
+        // act
+        var note = pitch.ToNote();
+
+        // assert
+        note.NoteName.Should().Be(expectedNoteName);
+        note.Octave.Should().Be(expectedOctave);
+    }
+
+    [Test]
+    [TestCase((byte)60, NoteName.C, 4)]
+    [TestCase((byte)61, NoteName.CSharp, 4)]
+    [TestCase((byte)62, NoteName.D, 4)]
+    [TestCase((byte)63, NoteName.DSharp, 4)]
+    [TestCase((byte)64, NoteName.E, 4)]
+    [TestCase((byte)65, NoteName.F, 4)]
+    [TestCase((byte)66, NoteName.FSharp, 4)]
+    [TestCase((byte)67, NoteName.G, 4)]
+    [TestCase((byte)68, NoteName.GSharp, 4)]
+    [TestCase((byte)69, NoteName.A, 4)]
+    [TestCase((byte)70, NoteName.ASharp, 4)]
+    [TestCase((byte)71, NoteName.B, 4)]
+    [TestCase((byte)72, NoteName.C, 5)]
+    public void ToNoteWithByte_GeneratesExpectedNote(byte pitch, NoteName expectedNoteName, int expectedOctave)
+    {
+        // act
+        var note = pitch.ToNote();
+
+        // assert
+        note.NoteName.Should().Be(expectedNoteName);
+        note.Octave.Should().Be(expectedOctave);
+    }
+}


### PR DESCRIPTION
## Description

- Integrate the [DryWetMidi](https://github.com/melanchall/drywetmidi) package
- Leverage constructs from DryWetMidi, such as `Note` and `Scale` to better generate note contexts and note choices
- Add `Scale` as a configuration property of `CompositionConfiguration`
- Add `ToNote` extension methods for converting `int` and `byte` values to `Note` instances

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
