### PR TITLE
Ornamentation Framework

### DIFF
--- a/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
+++ b/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Atrea.PolicyEngine" Version="3.0.0" />
     <PackageReference Include="LazyCart" Version="0.4.5" />
     <PackageReference Include="Melanchall.DryWetMidi" Version="7.0.2" />
     <PackageReference Include="Meziantou.Analyzer" Version="2.0.146">

--- a/src/BaroquenMelody.Library/Compositions/Composers/Composer.cs
+++ b/src/BaroquenMelody.Library/Compositions/Composers/Composer.cs
@@ -2,6 +2,7 @@
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums.Extensions;
 using BaroquenMelody.Library.Compositions.Extensions;
+using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Strategies;
 using BaroquenMelody.Library.Infrastructure.Collections;
 using BaroquenMelody.Library.Infrastructure.Random;
@@ -12,9 +13,11 @@ namespace BaroquenMelody.Library.Compositions.Composers;
 ///     Represents a composer which can generate a <see cref="Composition"/>.
 /// </summary>
 /// <param name="compositionStrategy"> The strategy that the composer should use to generate the composition. </param>
+/// <param name="compositionDecorator"> The decorator that the composer should use to decorate the composition. </param>
 /// <param name="compositionConfiguration"> The configuration to use to generate the composition. </param>
 internal sealed class Composer(
     ICompositionStrategy compositionStrategy,
+    ICompositionDecorator compositionDecorator,
     CompositionConfiguration compositionConfiguration
 ) : IComposer
 {
@@ -45,7 +48,11 @@ internal sealed class Composer(
             measures.Add(new Measure(beats, compositionConfiguration.Meter));
         }
 
-        return new Composition(measures);
+        var composition = new Composition(measures);
+
+        compositionDecorator.Decorate(composition);
+
+        return composition;
     }
 
     private List<Measure> ComposeInitialMeasures()

--- a/src/BaroquenMelody.Library/Compositions/Domain/BaroquenNote.cs
+++ b/src/BaroquenMelody.Library/Compositions/Domain/BaroquenNote.cs
@@ -1,11 +1,38 @@
 ﻿using BaroquenMelody.Library.Compositions.Enums;
-using Melanchall.DryWetMidi.MusicTheory;
+using Melanchall.DryWetMidi.Interaction;
+using Note = Melanchall.DryWetMidi.MusicTheory.Note;
 
 namespace BaroquenMelody.Library.Compositions.Domain;
 
 /// <summary>
 ///    Represents a note in a composition.
 /// </summary>
-/// <param name="Voice">The voice that the note is played in.</param>
-/// <param name="Raw">The raw note that is played.</param>
-internal sealed record BaroquenNote(Voice Voice, Note Raw);
+/// <param name="voice">The voice that the note is played in.</param>
+/// <param name="raw">The raw note that is played.</param>
+internal sealed class BaroquenNote(Voice voice, Note raw)
+{
+    /// <summary>
+    ///     The voice that the note is played in.
+    /// </summary>
+    public Voice Voice { get; init; } = voice;
+
+    /// <summary>
+    ///     The raw note that is played.
+    /// </summary>
+    public Note Raw { get; init; } = raw;
+
+    /// <summary>
+    ///     The duration of the note. May be modified if the note is ornamented.
+    /// </summary>
+    public MusicalTimeSpan Duration { get; set; } = MusicalTimeSpan.Quarter;
+
+    /// <summary>
+    ///     The ornamentation notes that are played with this note.
+    /// </summary>
+    public IList<BaroquenNote> Ornamentations { get; } = [];
+
+    /// <summary>
+    ///     Whether or not this note has any ornamentations.
+    /// </summary>
+    public bool HasOrnamentations => Ornamentations.Any();
+}

--- a/src/BaroquenMelody.Library/Compositions/Domain/Beat.cs
+++ b/src/BaroquenMelody.Library/Compositions/Domain/Beat.cs
@@ -1,7 +1,12 @@
-﻿namespace BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Enums;
+
+namespace BaroquenMelody.Library.Compositions.Domain;
 
 /// <summary>
 ///     Represents a beat in a composition.
 /// </summary>
 /// <param name="Chord"> The chord that is played during the beat. </param>
-internal sealed record Beat(BaroquenChord Chord);
+internal sealed record Beat(BaroquenChord Chord)
+{
+    public BaroquenNote this[Voice voice] => Chord[voice];
+}

--- a/src/BaroquenMelody.Library/Compositions/Extensions/BaroquenNoteExtensions.cs
+++ b/src/BaroquenMelody.Library/Compositions/Extensions/BaroquenNoteExtensions.cs
@@ -20,6 +20,6 @@ internal static class BaroquenNoteExtensions
             _ => throw new ArgumentOutOfRangeException(nameof(noteChoice))
         };
 
-        return note with { Raw = nextNote };
+        return new BaroquenNote(note.Voice, nextNote);
     }
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/CompositionDecorator.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/CompositionDecorator.cs
@@ -1,0 +1,33 @@
+﻿using Atrea.PolicyEngine.Processors;
+using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Infrastructure.Collections;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation;
+
+internal sealed class CompositionDecorator(IProcessor<OrnamentationItem> decorationEngine, CompositionConfiguration configuration) : ICompositionDecorator
+{
+    public void Decorate(Composition composition)
+    {
+        var beats = composition.Measures.SelectMany(measure => measure.Beats).ToList();
+        var compositionContext = new FixedSizeList<Beat>(configuration.CompositionContextSize);
+        var voices = configuration.VoiceConfigurations.Select(voiceConfiguration => voiceConfiguration.Voice);
+
+        foreach (var voice in voices)
+        {
+            foreach (var currentBeat in beats)
+            {
+                var ornamentationItem = new OrnamentationItem(
+                    voice,
+                    compositionContext,
+                    currentBeat,
+                    beats.ElementAtOrDefault(beats.IndexOf(currentBeat) + 1)
+                );
+
+                decorationEngine.Process(ornamentationItem);
+
+                compositionContext.Add(currentBeat);
+            }
+        }
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/OrnamentationEngineBuilder.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/OrnamentationEngineBuilder.cs
@@ -1,0 +1,32 @@
+﻿using Atrea.PolicyEngine;
+using Atrea.PolicyEngine.Builders;
+using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies;
+using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
+using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
+using System.Diagnostics.CodeAnalysis;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Engine;
+
+[ExcludeFromCodeCoverage(Justification = "Trivial builder methods.")]
+internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compositionConfiguration, IMusicalTimeSpanCalculator musicalTimeSpanCalculator)
+{
+    public IPolicyEngine<OrnamentationItem> Build() => PolicyEngineBuilder<OrnamentationItem>.Configure()
+        .WithoutInputPolicies()
+        .WithProcessors(
+            BuildPassingToneEngine()
+        )
+        .WithoutOutputPolicies()
+        .Build();
+
+    private IPolicyEngine<OrnamentationItem> BuildPassingToneEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()
+        .WithInputPolicies(
+            new HasNoOrnamentation(),
+            new CanApplyPassingTone(compositionConfiguration)
+        )
+        .WithProcessors(
+            new PassingToneProcessor(musicalTimeSpanCalculator, compositionConfiguration)
+        )
+        .WithoutOutputPolicies()
+        .Build();
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Policies/CanApplyPassingTone.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Policies/CanApplyPassingTone.cs
@@ -1,0 +1,23 @@
+﻿using Atrea.PolicyEngine.Policies.Input;
+using BaroquenMelody.Library.Compositions.Configurations;
+using Melanchall.DryWetMidi.MusicTheory;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies;
+
+internal sealed class CanApplyPassingTone(CompositionConfiguration configuration) : IInputPolicy<OrnamentationItem>
+{
+    private const int PassingToneThreshold = 2;
+
+    public InputPolicyResult ShouldProcess(OrnamentationItem item)
+    {
+        var currentNote = item.CurrentBeat[item.Voice];
+        var nextNote = item.NextBeat?[item.Voice];
+
+        var scaleNotes = configuration.Scale.GetNotes().ToList();
+
+        var currentScaleIndex = scaleNotes.IndexOf(currentNote.Raw);
+        var nextScaleIndex = scaleNotes.IndexOf(nextNote?.Raw ?? currentNote.Raw);
+
+        return Math.Abs(nextScaleIndex - currentScaleIndex) == PassingToneThreshold ? InputPolicyResult.Continue : InputPolicyResult.Reject;
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Policies/HasNoOrnamentation.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Policies/HasNoOrnamentation.cs
@@ -1,0 +1,8 @@
+﻿using Atrea.PolicyEngine.Policies.Input;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies;
+
+internal sealed class HasNoOrnamentation : IInputPolicy<OrnamentationItem>
+{
+    public InputPolicyResult ShouldProcess(OrnamentationItem item) => item.CurrentBeat[item.Voice].HasOrnamentations ? InputPolicyResult.Reject : InputPolicyResult.Continue;
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/PassingToneProcessor.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/PassingToneProcessor.cs
@@ -1,0 +1,32 @@
+﻿using Atrea.PolicyEngine.Processors;
+using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
+using Melanchall.DryWetMidi.MusicTheory;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
+
+internal class PassingToneProcessor(IMusicalTimeSpanCalculator musicalTimeSpanCalculator, CompositionConfiguration configuration) : IProcessor<OrnamentationItem>
+{
+    public void Process(OrnamentationItem item)
+    {
+        var currentNote = item.CurrentBeat[item.Voice];
+        var nextNote = item.NextBeat?[item.Voice];
+
+        var notes = configuration.Scale.GetNotes().ToList();
+
+        var currentScaleIndex = notes.IndexOf(currentNote.Raw);
+        var nextScaleIndex = notes.IndexOf(nextNote?.Raw ?? currentNote.Raw);
+
+        var passingToneIndex = currentScaleIndex > nextScaleIndex ? currentScaleIndex - 1 : currentScaleIndex + 1;
+        var passingToneNote = notes[passingToneIndex];
+
+        currentNote.Duration = musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.PassingTone, configuration.Meter);
+
+        currentNote.Ornamentations.Add(new BaroquenNote(currentNote.Voice, passingToneNote)
+        {
+            Duration = musicalTimeSpanCalculator.CalculateOrnamentationTimeSpan(OrnamentationType.PassingTone, configuration.Meter)
+        });
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Enums/OrnamentationType.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Enums/OrnamentationType.cs
@@ -1,0 +1,9 @@
+﻿namespace BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+
+internal enum OrnamentationType
+{
+    /// <summary>
+    ///     A passing tone between two notes.
+    /// </summary>
+    PassingTone
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/ICompositionDecorator.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/ICompositionDecorator.cs
@@ -1,0 +1,15 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation;
+
+/// <summary>
+///     Represents something that can decorate a composition.
+/// </summary>
+internal interface ICompositionDecorator
+{
+    /// <summary>
+    ///     Decorate the composition.
+    /// </summary>
+    /// <param name="composition">The composition to decorate.</param>
+    void Decorate(Composition composition);
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/OrnamentationItem.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/OrnamentationItem.cs
@@ -1,0 +1,18 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation;
+
+/// <summary>
+///     Represents a piece of a composition that can be ornamented.
+/// </summary>
+/// <param name="Voice">The voice that the ornamentation is being applied to.</param>
+/// <param name="PrecedingBeats">The beats preceding the current beat to be ornamented.</param>
+/// <param name="CurrentBeat">The beat to be ornamented.</param>
+/// <param name="NextBeat">The beat following the current beat to be ornamented.</param>
+internal sealed record OrnamentationItem(
+    Voice Voice,
+    IReadOnlyList<Beat> PrecedingBeats,
+    Beat CurrentBeat,
+    Beat? NextBeat
+);

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Utilities/IMusicalTimeSpanCalculator.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Utilities/IMusicalTimeSpanCalculator.cs
@@ -1,0 +1,27 @@
+﻿using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using Melanchall.DryWetMidi.Interaction;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
+
+/// <summary>
+///    Represents a calculator that can calculate the time span of primary notes and their ornamentations.
+/// </summary>
+internal interface IMusicalTimeSpanCalculator
+{
+    /// <summary>
+    ///     Calculates the time span of the primary note based on the ornamentation type and the meter.
+    /// </summary>
+    /// <param name="ornamentationType">The type of ornamentation to calculate the time span for.</param>
+    /// <param name="meter">The meter of the composition. This can impact the time span, especially for non-common meters.</param>
+    /// <returns>The time span of the primary note.</returns>
+    MusicalTimeSpan CalculatePrimaryNoteTimeSpan(OrnamentationType ornamentationType, Meter meter);
+
+    /// <summary>
+    ///     Calculates the time span of a note based on the ornamentation type and the meter.
+    /// </summary>
+    /// <param name="ornamentationType">The type of ornamentation to calculate the time span for.</param>
+    /// <param name="meter">The meter of the composition. This can impact the time span, especially for non-common meters.</param>
+    /// <returns>The time span of the ornamentation.</returns>
+    MusicalTimeSpan CalculateOrnamentationTimeSpan(OrnamentationType ornamentationType, Meter meter);
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculator.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculator.cs
@@ -1,0 +1,20 @@
+﻿using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using Melanchall.DryWetMidi.Interaction;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
+
+internal sealed class MusicalTimeSpanCalculator : IMusicalTimeSpanCalculator
+{
+    public MusicalTimeSpan CalculatePrimaryNoteTimeSpan(OrnamentationType ornamentationType, Meter meter) => ornamentationType switch
+    {
+        OrnamentationType.PassingTone when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
+        _ => throw new ArgumentOutOfRangeException(nameof(ornamentationType), ornamentationType, null)
+    };
+
+    public MusicalTimeSpan CalculateOrnamentationTimeSpan(OrnamentationType ornamentationType, Meter meter) => ornamentationType switch
+    {
+        OrnamentationType.PassingTone when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
+        _ => throw new ArgumentOutOfRangeException(nameof(ornamentationType), ornamentationType, null)
+    };
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ComposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ComposerTests.cs
@@ -3,6 +3,7 @@ using BaroquenMelody.Library.Compositions.Composers;
 using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Strategies;
 using BaroquenMelody.Library.Tests.Compositions.Enums.Extensions;
 using FluentAssertions;
@@ -23,6 +24,8 @@ internal sealed class ComposerTests
 
     private ICompositionStrategy _mockCompositionStrategy = null!;
 
+    private ICompositionDecorator _mockCompositionDecorator = null!;
+
     private CompositionConfiguration _compositionConfiguration = null!;
 
     private Composer _composer = null!;
@@ -31,6 +34,7 @@ internal sealed class ComposerTests
     public void SetUp()
     {
         _mockCompositionStrategy = Substitute.For<ICompositionStrategy>();
+        _mockCompositionDecorator = Substitute.For<ICompositionDecorator>();
 
         _compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>
@@ -43,7 +47,7 @@ internal sealed class ComposerTests
             CompositionLength: 100
         );
 
-        _composer = new Composer(_mockCompositionStrategy, _compositionConfiguration);
+        _composer = new Composer(_mockCompositionStrategy, _mockCompositionDecorator, _compositionConfiguration);
     }
 
     [Test]
@@ -90,5 +94,7 @@ internal sealed class ComposerTests
         _mockCompositionStrategy
             .Received(_compositionConfiguration.CompositionLength * _compositionConfiguration.Meter.BeatsPerMeasure() - 1) // 1 less since the initial chord is generated separately
             .GetPossibleChordChoices(Arg.Any<IReadOnlyList<BaroquenChord>>());
+
+        _mockCompositionDecorator.Received(1).Decorate(composition);
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/CompositionDecoratorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/CompositionDecoratorTests.cs
@@ -1,0 +1,90 @@
+﻿using Atrea.PolicyEngine;
+using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation;
+using Melanchall.DryWetMidi.MusicTheory;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation;
+
+[TestFixture]
+internal sealed class CompositionDecoratorTests
+{
+    private IPolicyEngine<OrnamentationItem> _mockOrnamentationEngine = null!;
+
+    private CompositionDecorator _compositionDecorator = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var compositionConfiguration = new CompositionConfiguration(
+            new HashSet<VoiceConfiguration>
+            {
+                new(Voice.Soprano, Notes.A4, Notes.A5),
+                new(Voice.Alto, Notes.C3, Notes.C4)
+            },
+            Scale.Parse("C Major"),
+            Meter.FourFour,
+            CompositionLength: 100
+        );
+
+        _mockOrnamentationEngine = Substitute.For<IPolicyEngine<OrnamentationItem>>();
+
+        _compositionDecorator = new CompositionDecorator(_mockOrnamentationEngine, compositionConfiguration);
+    }
+
+    [Test]
+    public void WhenDecorateIsInvoked_ThenOrnamentationEngineIsInvoked_ForEachVoiceAndChord()
+    {
+        // arrange
+        var chordA = new BaroquenChord(
+            [
+                new BaroquenNote(Voice.Soprano, Notes.A4),
+                new BaroquenNote(Voice.Alto, Notes.C3)
+            ]
+        );
+
+        var chordB = new BaroquenChord(
+            [
+                new BaroquenNote(Voice.Soprano, Notes.A4),
+                new BaroquenNote(Voice.Alto, Notes.C3)
+            ]
+        );
+
+        var chordC = new BaroquenChord(
+            [
+                new BaroquenNote(Voice.Soprano, Notes.A4),
+                new BaroquenNote(Voice.Alto, Notes.C3)
+            ]
+        );
+
+        var chordD = new BaroquenChord(
+            [
+                new BaroquenNote(Voice.Soprano, Notes.A4),
+                new BaroquenNote(Voice.Alto, Notes.C3)
+            ]
+        );
+
+        var composition = new Composition(
+            [
+                new Measure(
+                    [
+                        new Beat(chordA),
+                        new Beat(chordB),
+                        new Beat(chordC),
+                        new Beat(chordD)
+                    ],
+                    Meter.FourFour
+                )
+            ]
+        );
+
+        // act
+        _compositionDecorator.Decorate(composition);
+
+        // assert
+        _mockOrnamentationEngine.ReceivedWithAnyArgs(8).Process(Arg.Any<OrnamentationItem>());
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Policies/CanApplyPassingToneTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Policies/CanApplyPassingToneTests.cs
@@ -1,0 +1,74 @@
+﻿using Atrea.PolicyEngine.Policies.Input;
+using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation;
+using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies;
+using BaroquenMelody.Library.Infrastructure.Collections;
+using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Policies;
+
+[TestFixture]
+internal sealed class CanApplyPassingToneTests
+{
+    private CanApplyPassingTone _canApplyPassingTone = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var compositionConfiguration = new CompositionConfiguration(
+            new HashSet<VoiceConfiguration>
+            {
+                new(Voice.Soprano, Notes.A4, Notes.A5),
+                new(Voice.Alto, Notes.C3, Notes.C4)
+            },
+            Scale.Parse("C Major"),
+            Meter.FourFour,
+            CompositionLength: 100
+        );
+
+        _canApplyPassingTone = new CanApplyPassingTone(compositionConfiguration);
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void ShouldProcess(OrnamentationItem item, InputPolicyResult expectedInputPolicyResult)
+    {
+        // act
+        var inputPolicyResult = _canApplyPassingTone.ShouldProcess(item);
+
+        // assert
+        inputPolicyResult.Should().Be(expectedInputPolicyResult);
+    }
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            var testCompositionContext = new FixedSizeList<Beat>(1);
+
+            yield return new TestCaseData(
+                new OrnamentationItem(
+                    Voice.Soprano,
+                    testCompositionContext,
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.F4)]))
+                ),
+                InputPolicyResult.Continue
+            ).SetName($"When notes are a third apart, then {nameof(InputPolicyResult.Continue)} is returned.");
+
+            yield return new TestCaseData(
+                new OrnamentationItem(
+                    Voice.Soprano,
+                    testCompositionContext,
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.G4)]))
+                ),
+                InputPolicyResult.Reject
+            ).SetName($"When notes are not a third apart, then {nameof(InputPolicyResult.Reject)} is returned.");
+        }
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Policies/HasNoOrnamentationTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Policies/HasNoOrnamentationTests.cs
@@ -1,0 +1,59 @@
+﻿using Atrea.PolicyEngine.Policies.Input;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation;
+using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies;
+using BaroquenMelody.Library.Infrastructure.Collections;
+using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Policies;
+
+[TestFixture]
+internal sealed class HasNoOrnamentationTests
+{
+    private HasNoOrnamentation _hasNoOrnamentation = null!;
+
+    [SetUp]
+    public void SetUp() => _hasNoOrnamentation = new HasNoOrnamentation();
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void ShouldProcess(OrnamentationItem ornamentationItem, InputPolicyResult expectedInputPolicyResult)
+    {
+        // act
+        var result = _hasNoOrnamentation.ShouldProcess(ornamentationItem);
+
+        // assert
+        result.Should().Be(expectedInputPolicyResult);
+    }
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            var testCompositionContext = new FixedSizeList<Beat>(1);
+
+            yield return new TestCaseData(
+                new OrnamentationItem(
+                    Voice.Soprano,
+                    testCompositionContext,
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4)])),
+                    null
+                ),
+                InputPolicyResult.Continue
+            ).SetName($"When note has no ornamentation, then {nameof(InputPolicyResult.Continue)} is returned.");
+
+            yield return new TestCaseData(
+                new OrnamentationItem(
+                    Voice.Soprano,
+                    testCompositionContext,
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4) { Ornamentations = { new BaroquenNote(Voice.Soprano, Notes.G2) } }])),
+                    null
+                ),
+                InputPolicyResult.Reject
+            ).SetName($"When note has ornamentation, then {nameof(InputPolicyResult.Reject)} is returned.");
+        }
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Processors/PassingToneProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Processors/PassingToneProcessorTests.cs
@@ -1,0 +1,82 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation;
+using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
+using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
+using BaroquenMelody.Library.Infrastructure.Collections;
+using FluentAssertions;
+using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Processors;
+
+[TestFixture]
+internal sealed class PassingToneProcessorTests
+{
+    private PassingToneProcessor _processor = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var compositionConfiguration = new CompositionConfiguration(
+            new HashSet<VoiceConfiguration>
+            {
+                new(Voice.Soprano, Notes.C3, Notes.C5),
+                new(Voice.Alto, Notes.C2, Notes.C4)
+            },
+            Scale.Parse("C Major"),
+            Meter.FourFour,
+            CompositionLength: 100
+        );
+
+        _processor = new PassingToneProcessor(new MusicalTimeSpanCalculator(), compositionConfiguration);
+    }
+
+    [Test]
+    public void Process_applies_descending_passing_tone_as_expected()
+    {
+        // arrange
+        var ornamentationItem = new OrnamentationItem(
+            Voice.Soprano,
+            new FixedSizeList<Beat>(1),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.F4)]))
+        );
+
+        // act
+        _processor.Process(ornamentationItem);
+
+        // assert
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+
+        noteToAssert.Ornamentations.Should().ContainSingle();
+        noteToAssert.Ornamentations[0].Raw.Should().Be(Notes.G4);
+        noteToAssert.Duration.Should().Be(MusicalTimeSpan.Eighth);
+        noteToAssert.Ornamentations[0].Duration.Should().Be(MusicalTimeSpan.Eighth);
+    }
+
+    [Test]
+    public void Process_applies_ascending_passing_tone_as_expected()
+    {
+        // arrange
+        var ornamentationItem = new OrnamentationItem(
+            Voice.Soprano,
+            new FixedSizeList<Beat>(1),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C5)]))
+        );
+
+        // act
+        _processor.Process(ornamentationItem);
+
+        // assert
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+
+        noteToAssert.Ornamentations.Should().ContainSingle();
+        noteToAssert.Ornamentations[0].Raw.Should().Be(Notes.B4);
+        noteToAssert.Duration.Should().Be(MusicalTimeSpan.Eighth);
+        noteToAssert.Ornamentations[0].Duration.Should().Be(MusicalTimeSpan.Eighth);
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculatorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculatorTests.cs
@@ -1,0 +1,58 @@
+﻿using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
+using FluentAssertions;
+using Melanchall.DryWetMidi.Interaction;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Utilities;
+
+[TestFixture]
+internal sealed class MusicalTimeSpanCalculatorTests
+{
+    private MusicalTimeSpanCalculator _musicalTimeSpanCalculator = null!;
+
+    [SetUp]
+    public void SetUp() => _musicalTimeSpanCalculator = new MusicalTimeSpanCalculator();
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void CalculatePrimaryNoteTimeSpan_ShouldReturnExpectedTimeSpan(
+        OrnamentationType ornamentationType,
+        Meter meter,
+        MusicalTimeSpan expectedPrimaryNoteMusicalTimeSpan,
+        MusicalTimeSpan expectedOrnamentationMusicalTimeSpan)
+    {
+        // act
+        var primaryNoteMusicalTimeSpan = _musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(ornamentationType, meter);
+        var ornamentationMusicalTimeSpan = _musicalTimeSpanCalculator.CalculateOrnamentationTimeSpan(ornamentationType, meter);
+
+        // assert
+        primaryNoteMusicalTimeSpan.Should().Be(expectedPrimaryNoteMusicalTimeSpan);
+        ornamentationMusicalTimeSpan.Should().Be(expectedOrnamentationMusicalTimeSpan);
+    }
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            yield return new TestCaseData(OrnamentationType.PassingTone, Meter.FourFour, MusicalTimeSpan.Eighth, MusicalTimeSpan.Eighth);
+
+            // more test cases to come as more ornamentation types and meters are added...
+        }
+    }
+
+    [Test]
+    [TestCase(OrnamentationType.PassingTone, (Meter)9001)]
+    [TestCase((OrnamentationType)9001, Meter.FourFour)]
+    public void WhenOrnamentationOrMeterIsOutOfRange_ThenArgumentOutOfRangeExceptionIsThrown(OrnamentationType ornamentationType, Meter meter)
+    {
+        // act
+        var actPrimary = () => _musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(ornamentationType, meter);
+        var actOrnamentation = () => _musicalTimeSpanCalculator.CalculateOrnamentationTimeSpan(ornamentationType, meter);
+
+        // assert
+        actPrimary.Should().Throw<ArgumentOutOfRangeException>();
+        actOrnamentation.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}


### PR DESCRIPTION
## Description

Leverage [Atrea.PolicyEngine](https://github.com/wbaldoumas/atrea-policyengine) for building out a framework for musical ornamentation. This will allow for creating individual "engines" for each type of ornamentation to be introduced over time, allowing for easy extension, testability, and modularity of ornamentation.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
