### PR TITLE
Adjust Phrasing Framework

### DIFF
--- a/src/BaroquenMelody.Library/Compositions/Domain/Measure.cs
+++ b/src/BaroquenMelody.Library/Compositions/Domain/Measure.cs
@@ -7,4 +7,4 @@ namespace BaroquenMelody.Library.Compositions.Domain;
 /// </summary>
 /// <param name="Beats">The beats that make up the measure.</param>
 /// <param name="Meter">The meter of the measure.</param>
-internal sealed record Measure(IEnumerable<Beat> Beats, Meter Meter);
+internal sealed record Measure(IList<Beat> Beats, Meter Meter);

--- a/src/BaroquenMelody.Library/Compositions/Phrasing/CompositionPhraser.cs
+++ b/src/BaroquenMelody.Library/Compositions/Phrasing/CompositionPhraser.cs
@@ -8,9 +8,11 @@ namespace BaroquenMelody.Library.Compositions.Phrasing;
 
 internal sealed class CompositionPhraser(ICompositionRule compositionRule, CompositionConfiguration compositionConfiguration) : ICompositionPhraser
 {
-    private readonly List<RepeatedPhrase> repeatedPhrases = [];
+    private const int OneHundred = 100;
 
-    private RepeatedPhrase? coolOffPhrase;
+    private readonly List<RepeatedPhrase> phrasesToRepeat = [];
+
+    private readonly Queue<RepeatedPhrase> coolOffPhrases = new();
 
     public void AttemptPhraseRepetition(List<Measure> measures)
     {
@@ -24,21 +26,27 @@ internal sealed class CompositionPhraser(ICompositionRule compositionRule, Compo
 
     private bool AttemptToRepeatExistingPhrase(List<Measure> measures)
     {
-        if (repeatedPhrases.Count < compositionConfiguration.PhrasingConfiguration.MinPhraseRepetitionPoolSize)
+        var minPhraseRepetitionPoolSize = compositionConfiguration.PhrasingConfiguration.MinPhraseRepetitionPoolSize;
+
+        if (phrasesToRepeat.Count < minPhraseRepetitionPoolSize)
         {
             return false;
         }
 
-        foreach (var repeatedPhrase in repeatedPhrases.OrderBy(_ => ThreadLocalRandom.Next()).ToList().Where(repeatedPhrase => TryRepeatPhrase(measures, repeatedPhrase)))
+        foreach (var repeatedPhrase in phrasesToRepeat.OrderBy(_ => ThreadLocalRandom.Next()).ToList().Where(repeatedPhrase => TryRepeatPhrase(measures, repeatedPhrase)))
         {
-            repeatedPhrases.Remove(repeatedPhrase);
+            phrasesToRepeat.Remove(repeatedPhrase);
 
-            if (coolOffPhrase is not null)
+            if (coolOffPhrases.Count >= minPhraseRepetitionPoolSize && coolOffPhrases.TryDequeue(out var coolOffPhrase))
             {
-                repeatedPhrases.Add(coolOffPhrase);
+                phrasesToRepeat.Add(coolOffPhrase);
             }
 
-            coolOffPhrase = repeatedPhrase;
+            // If the phrase has not reached the maximum number of repetitions, add it to the cool off queue.
+            if (repeatedPhrase.RepetitionCount < compositionConfiguration.PhrasingConfiguration.MaxPhraseRepetitions)
+            {
+                coolOffPhrases.Enqueue(repeatedPhrase);
+            }
 
             return true;
         }
@@ -48,7 +56,7 @@ internal sealed class CompositionPhraser(ICompositionRule compositionRule, Compo
 
     private void AttemptToCreateAndRepeatNewPhrase(List<Measure> measures)
     {
-        foreach (var phraseLength in compositionConfiguration.PhrasingConfiguration.PhraseLengths.OrderBy(_ => ThreadLocalRandom.Next()))
+        foreach (var phraseLength in compositionConfiguration.PhrasingConfiguration.PhraseLengths.OrderByDescending(phraseLength => phraseLength))
         {
             if (measures.Count < phraseLength)
             {
@@ -57,7 +65,7 @@ internal sealed class CompositionPhraser(ICompositionRule compositionRule, Compo
 
             var lastMeasures = measures.Skip(measures.Count - phraseLength).Take(phraseLength).ToList();
 
-            if (ThreadLocalRandom.Next(100) > compositionConfiguration.PhrasingConfiguration.PhraseRepetitionProbability || !CanRepeatPhrase(measures, lastMeasures))
+            if (ThreadLocalRandom.Next(OneHundred) > compositionConfiguration.PhrasingConfiguration.PhraseRepetitionProbability || !CanRepeatPhrase(measures, lastMeasures))
             {
                 continue;
             }
@@ -68,7 +76,7 @@ internal sealed class CompositionPhraser(ICompositionRule compositionRule, Compo
                 RepetitionCount = 1
             };
 
-            repeatedPhrases.Add(repeatedPhrase);
+            phrasesToRepeat.Add(repeatedPhrase);
             measures.AddRange(lastMeasures);
 
             return;
@@ -78,13 +86,17 @@ internal sealed class CompositionPhraser(ICompositionRule compositionRule, Compo
     private bool TryRepeatPhrase(List<Measure> measures, RepeatedPhrase repeatedPhrase)
     {
         if (repeatedPhrase.RepetitionCount >= compositionConfiguration.PhrasingConfiguration.MaxPhraseRepetitions ||
-            ThreadLocalRandom.Next(100) > compositionConfiguration.PhrasingConfiguration.PhraseRepetitionProbability ||
+            ThreadLocalRandom.Next(OneHundred) > compositionConfiguration.PhrasingConfiguration.PhraseRepetitionProbability ||
             !CanRepeatPhrase(measures, repeatedPhrase.Phrase))
         {
             return false;
         }
 
-        Console.WriteLine($"REPEATING PREVIOUSLY REPEATED PHRASE: {repeatedPhrase.Id}. Repeat count: {repeatedPhrase.RepetitionCount}.");
+        // Clear the ornamentations to ensure smooth transitions between repetitions.
+        foreach (var note in measures[^1].Beats[^1].Chord.Notes)
+        {
+            note.Ornamentations.Clear();
+        }
 
         measures.AddRange(repeatedPhrase.Phrase);
         repeatedPhrase.RepetitionCount++;

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -17,24 +17,27 @@ using Melanchall.DryWetMidi.Standards;
 using System.Globalization;
 using Note = Melanchall.DryWetMidi.MusicTheory.Note;
 
+Console.WriteLine("Hit 'enter' to start composing...");
+Console.ReadLine();
+
 // proof of concept testing code...
 var phrasingConfiguration = new PhrasingConfiguration(
-    PhraseLengths: [1, 2],
+    PhraseLengths: [2, 4, 8],
     MaxPhraseRepetitions: 4,
-    MinPhraseRepetitionPoolSize: 2,
+    MinPhraseRepetitionPoolSize: 10,
     PhraseRepetitionProbability: 90
 );
 
 var compositionConfiguration = new CompositionConfiguration(
     new HashSet<VoiceConfiguration>
     {
-        new(Voice.Soprano, Note.Get(NoteName.G, 4), Note.Get(NoteName.C, 6)),
-        new(Voice.Alto, Note.Get(NoteName.C, 3), Note.Get(NoteName.G, 4)),
-        new(Voice.Tenor, Note.Get(NoteName.G, 2), Note.Get(NoteName.C, 3)),
-        new(Voice.Bass, Note.Get(NoteName.C, 1), Note.Get(NoteName.G, 2))
+        new(Voice.Soprano, Note.Get(NoteName.G, 5), Note.Get(NoteName.C, 6)),
+        new(Voice.Alto, Note.Get(NoteName.C, 4), Note.Get(NoteName.G, 5)),
+        new(Voice.Tenor, Note.Get(NoteName.C, 3), Note.Get(NoteName.C, 4)),
+        new(Voice.Bass, Note.Get(NoteName.C, 2), Note.Get(NoteName.C, 3))
     },
     phrasingConfiguration,
-    Scale.Parse("C Harmonic Minor"),
+    Scale.Parse("D dorian"),
     Meter.FourFour,
     100
 );


### PR DESCRIPTION
## Description

Maintain a queue of "cool off" phrases rather than just one within `CompositionPhraser`. Only start reusing repeated phrases from the queue once it has reached a set threshold.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
