### PR TITLE
Sixteenth Note Run Ornamentations

### DIFF
--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/OrnamentationEngineBuilder.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/OrnamentationEngineBuilder.cs
@@ -14,18 +14,32 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
     public IPolicyEngine<OrnamentationItem> Build() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithoutInputPolicies()
         .WithProcessors(
-            BuildPassingToneEngine()
+            BuildPassingToneEngine(),
+            BuildSixteenthNoteRunEngine()
         )
         .WithoutOutputPolicies()
         .Build();
 
     private IPolicyEngine<OrnamentationItem> BuildPassingToneEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
+            new WantsToOrnament(),
             new HasNoOrnamentation(),
-            new CanApplyPassingTone(compositionConfiguration)
+            new IsApplicableInterval(compositionConfiguration, PassingToneProcessor.Interval)
         )
         .WithProcessors(
             new PassingToneProcessor(musicalTimeSpanCalculator, compositionConfiguration)
+        )
+        .WithoutOutputPolicies()
+        .Build();
+
+    private IPolicyEngine<OrnamentationItem> BuildSixteenthNoteRunEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()
+        .WithInputPolicies(
+            new WantsToOrnament(),
+            new HasNoOrnamentation(),
+            new IsApplicableInterval(compositionConfiguration, SixteenthNoteRunProcessor.Interval)
+        )
+        .WithProcessors(
+            new SixteenthNoteRunProcessor(musicalTimeSpanCalculator, compositionConfiguration)
         )
         .WithoutOutputPolicies()
         .Build();

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Policies/IsApplicableInterval.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Policies/IsApplicableInterval.cs
@@ -4,10 +4,8 @@ using Melanchall.DryWetMidi.MusicTheory;
 
 namespace BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies;
 
-internal sealed class CanApplyPassingTone(CompositionConfiguration configuration) : IInputPolicy<OrnamentationItem>
+internal sealed class IsApplicableInterval(CompositionConfiguration configuration, int Interval) : IInputPolicy<OrnamentationItem>
 {
-    private const int PassingToneInterval = 2;
-
     public InputPolicyResult ShouldProcess(OrnamentationItem item)
     {
         var currentNote = item.CurrentBeat[item.Voice];
@@ -18,6 +16,6 @@ internal sealed class CanApplyPassingTone(CompositionConfiguration configuration
         var currentNoteScaleIndex = notes.IndexOf(currentNote.Raw);
         var nextNoteScaleIndex = notes.IndexOf(nextNote?.Raw ?? currentNote.Raw);
 
-        return Math.Abs(nextNoteScaleIndex - currentNoteScaleIndex) == PassingToneInterval ? InputPolicyResult.Continue : InputPolicyResult.Reject;
+        return Math.Abs(nextNoteScaleIndex - currentNoteScaleIndex) == Interval ? InputPolicyResult.Continue : InputPolicyResult.Reject;
     }
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Policies/WantsToOrnament.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Policies/WantsToOrnament.cs
@@ -1,0 +1,14 @@
+﻿using Atrea.PolicyEngine.Policies.Input;
+using BaroquenMelody.Library.Infrastructure.Random;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies;
+
+internal sealed class WantsToOrnament(int Threshold = 50) : IInputPolicy<OrnamentationItem>
+{
+    private const int Max = 100;
+
+    public InputPolicyResult ShouldProcess(OrnamentationItem item)
+    {
+        return ThreadLocalRandom.Next(Max) > Threshold ? InputPolicyResult.Continue : InputPolicyResult.Reject;
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/PassingToneProcessor.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/PassingToneProcessor.cs
@@ -9,6 +9,8 @@ namespace BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
 
 internal class PassingToneProcessor(IMusicalTimeSpanCalculator musicalTimeSpanCalculator, CompositionConfiguration configuration) : IProcessor<OrnamentationItem>
 {
+    public const int Interval = 2;
+
     public void Process(OrnamentationItem item)
     {
         var currentNote = item.CurrentBeat[item.Voice];

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/SixteenthNoteRunProcessor.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/SixteenthNoteRunProcessor.cs
@@ -1,0 +1,51 @@
+﻿using Atrea.PolicyEngine.Processors;
+using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
+using Melanchall.DryWetMidi.MusicTheory;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
+
+internal sealed class SixteenthNoteRunProcessor(IMusicalTimeSpanCalculator musicalTimeSpanCalculator, CompositionConfiguration configuration) : IProcessor<OrnamentationItem>
+{
+    public const int Interval = 4;
+
+    public void Process(OrnamentationItem item)
+    {
+        var currentNote = item.CurrentBeat[item.Voice];
+        var nextNote = item.NextBeat![item.Voice];
+
+        var notes = configuration.Scale.GetNotes().ToList();
+
+        var currentNoteIndex = notes.IndexOf(currentNote.Raw);
+        var nextNoteIndex = notes.IndexOf(nextNote.Raw);
+
+        var firstNoteIndex = currentNoteIndex > nextNoteIndex ? currentNoteIndex - 1 : currentNoteIndex + 1;
+        var secondNoteIndex = currentNoteIndex > nextNoteIndex ? currentNoteIndex - 2 : currentNoteIndex + 2;
+        var thirdNoteIndex = currentNoteIndex > nextNoteIndex ? currentNoteIndex - 3 : currentNoteIndex + 3;
+
+        var firstNote = notes[firstNoteIndex];
+        var secondNote = notes[secondNoteIndex];
+        var thirdNote = notes[thirdNoteIndex];
+
+        currentNote.Duration = musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.SixteenthNoteRun, configuration.Meter);
+
+        var duration = musicalTimeSpanCalculator.CalculateOrnamentationTimeSpan(OrnamentationType.SixteenthNoteRun, configuration.Meter);
+
+        currentNote.Ornamentations.Add(new BaroquenNote(currentNote.Voice, firstNote)
+        {
+            Duration = duration
+        });
+
+        currentNote.Ornamentations.Add(new BaroquenNote(currentNote.Voice, secondNote)
+        {
+            Duration = duration
+        });
+
+        currentNote.Ornamentations.Add(new BaroquenNote(currentNote.Voice, thirdNote)
+        {
+            Duration = duration
+        });
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Enums/OrnamentationType.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Enums/OrnamentationType.cs
@@ -5,5 +5,10 @@ internal enum OrnamentationType
     /// <summary>
     ///     A passing tone between two notes.
     /// </summary>
-    PassingTone
+    PassingTone,
+
+    /// <summary>
+    ///     A sixteenth note run between two notes.
+    /// </summary>
+    SixteenthNoteRun
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculator.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculator.cs
@@ -9,12 +9,14 @@ internal sealed class MusicalTimeSpanCalculator : IMusicalTimeSpanCalculator
     public MusicalTimeSpan CalculatePrimaryNoteTimeSpan(OrnamentationType ornamentationType, Meter meter) => ornamentationType switch
     {
         OrnamentationType.PassingTone when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
+        OrnamentationType.SixteenthNoteRun when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
         _ => throw new ArgumentOutOfRangeException(nameof(ornamentationType), ornamentationType, null)
     };
 
     public MusicalTimeSpan CalculateOrnamentationTimeSpan(OrnamentationType ornamentationType, Meter meter) => ornamentationType switch
     {
         OrnamentationType.PassingTone when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
+        OrnamentationType.SixteenthNoteRun when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
         _ => throw new ArgumentOutOfRangeException(nameof(ornamentationType), ornamentationType, null)
     };
 }

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -15,7 +15,6 @@ using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
 using Melanchall.DryWetMidi.Standards;
 using System.Globalization;
-using Note = Melanchall.DryWetMidi.MusicTheory.Note;
 
 Console.WriteLine("Hit 'enter' to start composing...");
 Console.ReadLine();

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Policies/IsApplicableIntervalTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Policies/IsApplicableIntervalTests.cs
@@ -12,9 +12,9 @@ using NUnit.Framework;
 namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Policies;
 
 [TestFixture]
-internal sealed class CanApplyPassingToneTests
+internal sealed class IsApplicableIntervalTests
 {
-    private CanApplyPassingTone _canApplyPassingTone = null!;
+    private IsApplicableInterval _isApplicableInterval = null!;
 
     [SetUp]
     public void SetUp()
@@ -30,7 +30,7 @@ internal sealed class CanApplyPassingToneTests
             CompositionLength: 100
         );
 
-        _canApplyPassingTone = new CanApplyPassingTone(compositionConfiguration);
+        _isApplicableInterval = new IsApplicableInterval(compositionConfiguration, Interval: 2);
     }
 
     [Test]
@@ -38,7 +38,7 @@ internal sealed class CanApplyPassingToneTests
     public void ShouldProcess(OrnamentationItem item, InputPolicyResult expectedInputPolicyResult)
     {
         // act
-        var inputPolicyResult = _canApplyPassingTone.ShouldProcess(item);
+        var inputPolicyResult = _isApplicableInterval.ShouldProcess(item);
 
         // assert
         inputPolicyResult.Should().Be(expectedInputPolicyResult);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Policies/WantsToOrnamentTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Policies/WantsToOrnamentTests.cs
@@ -1,0 +1,43 @@
+﻿using Atrea.PolicyEngine.Policies.Input;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation;
+using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Policies;
+
+[TestFixture]
+internal sealed class WantsToOrnamentTests
+{
+    [Test]
+    public void ShouldProcess_WhenRandomNumberIsGreaterThanThreshold_ReturnsContinue()
+    {
+        // arrange
+        var policy = new WantsToOrnament(-1);
+
+        var ornamentationItem = new OrnamentationItem(Voice.Soprano, [], new Beat(new BaroquenChord([])), null);
+
+        // act
+        var result = policy.ShouldProcess(ornamentationItem);
+
+        // assert
+        result.Should().Be(InputPolicyResult.Continue);
+    }
+
+    [Test]
+    public void ShouldProcess_WhenRandomNumberIsLessThanOrEqualToThreshold_ReturnsReject()
+    {
+        // arrange
+        var policy = new WantsToOrnament(101);
+
+        var ornamentationItem = new OrnamentationItem(Voice.Soprano, [], new Beat(new BaroquenChord([])), null);
+
+        // act
+        var result = policy.ShouldProcess(ornamentationItem);
+
+        // assert
+        result.Should().Be(InputPolicyResult.Reject);
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Processors/SixteenthNoteRunProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Processors/SixteenthNoteRunProcessorTests.cs
@@ -1,0 +1,96 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation;
+using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
+using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
+using BaroquenMelody.Library.Infrastructure.Collections;
+using FluentAssertions;
+using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Processors;
+
+[TestFixture]
+internal sealed class SixteenthNoteRunProcessorTests
+{
+    private SixteenthNoteRunProcessor _processor = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var compositionConfiguration = new CompositionConfiguration(
+            new HashSet<VoiceConfiguration>
+            {
+                new(Voice.Soprano, Notes.C3, Notes.C5),
+                new(Voice.Alto, Notes.C2, Notes.C4)
+            },
+            Scale.Parse("C Major"),
+            Meter.FourFour,
+            CompositionLength: 100
+        );
+
+        _processor = new SixteenthNoteRunProcessor(new MusicalTimeSpanCalculator(), compositionConfiguration);
+    }
+
+    [Test]
+    public void Process_applies_descending_sixteenth_note_run_as_expected()
+    {
+        // arrange
+        var ornamentationItem = new OrnamentationItem(
+            Voice.Soprano,
+            new FixedSizeList<Beat>(1),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.F3)]))
+        );
+
+        // act
+        _processor.Process(ornamentationItem);
+
+        // assert
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+
+        noteToAssert.Ornamentations.Should().HaveCount(3);
+
+        noteToAssert.Ornamentations[0].Raw.Should().Be(Notes.B3);
+        noteToAssert.Ornamentations[1].Raw.Should().Be(Notes.A3);
+        noteToAssert.Ornamentations[2].Raw.Should().Be(Notes.G3);
+
+        noteToAssert.Ornamentations[0].Duration.Should().Be(MusicalTimeSpan.Sixteenth);
+        noteToAssert.Ornamentations[1].Duration.Should().Be(MusicalTimeSpan.Sixteenth);
+        noteToAssert.Ornamentations[2].Duration.Should().Be(MusicalTimeSpan.Sixteenth);
+
+        noteToAssert.Duration.Should().Be(MusicalTimeSpan.Sixteenth);
+    }
+
+    [Test]
+    public void Process_applies_ascending_sixteenth_note_run_as_expected()
+    {
+        // arrange
+        var ornamentationItem = new OrnamentationItem(
+            Voice.Soprano,
+            new FixedSizeList<Beat>(1),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.F3)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4)]))
+        );
+
+        // act
+        _processor.Process(ornamentationItem);
+
+        // assert
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+
+        noteToAssert.Ornamentations.Should().HaveCount(3);
+
+        noteToAssert.Ornamentations[0].Raw.Should().Be(Notes.G3);
+        noteToAssert.Ornamentations[1].Raw.Should().Be(Notes.A3);
+        noteToAssert.Ornamentations[2].Raw.Should().Be(Notes.B3);
+
+        noteToAssert.Ornamentations[0].Duration.Should().Be(MusicalTimeSpan.Sixteenth);
+        noteToAssert.Ornamentations[1].Duration.Should().Be(MusicalTimeSpan.Sixteenth);
+        noteToAssert.Ornamentations[2].Duration.Should().Be(MusicalTimeSpan.Sixteenth);
+
+        noteToAssert.Duration.Should().Be(MusicalTimeSpan.Sixteenth);
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculatorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculatorTests.cs
@@ -38,6 +38,8 @@ internal sealed class MusicalTimeSpanCalculatorTests
         {
             yield return new TestCaseData(OrnamentationType.PassingTone, Meter.FourFour, MusicalTimeSpan.Eighth, MusicalTimeSpan.Eighth);
 
+            yield return new TestCaseData(OrnamentationType.SixteenthNoteRun, Meter.FourFour, MusicalTimeSpan.Sixteenth, MusicalTimeSpan.Sixteenth);
+
             // more test cases to come as more ornamentation types and meters are added...
         }
     }


### PR DESCRIPTION
## Description

- Adds sixteenth note runs as ornamentations between notes.
- Converts `CanApplyPassingTone` input policy to `IsApplicableInterval` policy to improve sharing and reusability of code
- Introduces `WantsToOrnament` input policy, to provide a sense of randomness / creativity rather than applying ornamentations across the board

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
