### PR TITLE
Performance Optimization

### DIFF
--- a/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using BaroquenMelody.Library.Compositions.Enums;
+﻿using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
 using Melanchall.DryWetMidi.MusicTheory;
 
 namespace BaroquenMelody.Library.Compositions.Configurations;
@@ -15,7 +16,7 @@ namespace BaroquenMelody.Library.Compositions.Configurations;
 internal sealed record CompositionConfiguration(
     ISet<VoiceConfiguration> VoiceConfigurations,
     PhrasingConfiguration PhrasingConfiguration,
-    Scale Scale,
+    BaroquenScale Scale,
     Meter Meter,
     int CompositionLength,
     int CompositionContextSize = 8)
@@ -32,7 +33,7 @@ internal sealed record CompositionConfiguration(
 
     public CompositionConfiguration(
         ISet<VoiceConfiguration> VoiceConfigurations,
-        Scale Scale,
+        BaroquenScale Scale,
         Meter Meter,
         int CompositionLength,
         int CompositionContextSize = 4)

--- a/src/BaroquenMelody.Library/Compositions/Domain/BaroquenScale.cs
+++ b/src/BaroquenMelody.Library/Compositions/Domain/BaroquenScale.cs
@@ -1,0 +1,59 @@
+﻿using Melanchall.DryWetMidi.MusicTheory;
+
+namespace BaroquenMelody.Library.Compositions.Domain;
+
+/// <summary>
+///    Represents a scale in a musical composition.
+/// </summary>
+internal sealed class BaroquenScale
+{
+    private readonly IReadOnlyList<Note> _notes;
+
+    private readonly IDictionary<Note, IReadOnlyList<Note>> _ascendingNotes = new Dictionary<Note, IReadOnlyList<Note>>();
+
+    private readonly IDictionary<Note, IReadOnlyList<Note>> _descendingNotes = new Dictionary<Note, IReadOnlyList<Note>>();
+
+    /// <summary>
+    ///     The raw scale that this Baroquen scale is based on.
+    /// </summary>
+    public Scale Raw { get; }
+
+    public BaroquenScale(Scale raw)
+    {
+        Raw = raw;
+        _notes = raw.GetNotes().ToList();
+
+        foreach (var note in _notes)
+        {
+            _ascendingNotes[note] = Raw.GetAscendingNotes(note).ToList();
+            _descendingNotes[note] = Raw.GetDescendingNotes(note).ToList();
+        }
+    }
+
+    /// <summary>
+    ///     Converts a string representation of a musical scale into its equivalent <see cref="BaroquenScale"/>.
+    /// </summary>
+    /// <param name="scale">The string representation of a musical scale.</param>
+    /// <returns>The equivalent <see cref="BaroquenScale"/>.</returns>
+    public static BaroquenScale Parse(string scale) => new(Scale.Parse(scale));
+
+    /// <summary>
+    ///     Retrieve all notes in the scale.
+    /// </summary>
+    /// <returns>All notes in the scale.</returns>
+    public IReadOnlyList<Note> GetNotes() => _notes;
+
+    /// <summary>
+    ///     Retrieve the ascending notes from the given note.
+    /// </summary>
+    /// <param name="note">The note to retrieve the ascending notes from.</param>
+    /// <returns>The ascending notes from the given note.</returns>
+    public IReadOnlyList<Note> GetAscendingNotes(Note note) => _ascendingNotes[note];
+
+    /// <summary>
+    ///     Retrieve the descending notes from the given note.
+    /// </summary>
+    /// <param name="note">The note to retrieve the descending notes from.</param>
+    /// <returns>The descending notes from the given note.</returns>
+    public IReadOnlyList<Note> GetDescendingNotes(Note note) => _descendingNotes[note];
+}

--- a/src/BaroquenMelody.Library/Compositions/Enums/NoteMotion.cs
+++ b/src/BaroquenMelody.Library/Compositions/Enums/NoteMotion.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///   Indicates the motion taken to arrive at a given note from the previous note.
 /// </summary>
-internal enum NoteMotion : byte
+public enum NoteMotion : byte
 {
     /// <summary>
     ///     Indicates that the note is arrived at by moving up from the previous note.

--- a/src/BaroquenMelody.Library/Compositions/Evaluations/Rules/AvoidDissonantLeaps.cs
+++ b/src/BaroquenMelody.Library/Compositions/Evaluations/Rules/AvoidDissonantLeaps.cs
@@ -1,7 +1,6 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Extensions;
-using Melanchall.DryWetMidi.MusicTheory;
 
 namespace BaroquenMelody.Library.Compositions.Evaluations.Rules;
 

--- a/src/BaroquenMelody.Library/Compositions/Extensions/BaroquenChordExtensions.cs
+++ b/src/BaroquenMelody.Library/Compositions/Extensions/BaroquenChordExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
 using BaroquenMelody.Library.Compositions.Domain;
-using Melanchall.DryWetMidi.MusicTheory;
 
 namespace BaroquenMelody.Library.Compositions.Extensions;
 
@@ -9,7 +8,7 @@ namespace BaroquenMelody.Library.Compositions.Extensions;
 /// </summary>
 internal static class BaroquenChordExtensions
 {
-    public static BaroquenChord ApplyChordChoice(this BaroquenChord chord, Scale scale, ChordChoice chordChoice) => new(
+    public static BaroquenChord ApplyChordChoice(this BaroquenChord chord, BaroquenScale scale, ChordChoice chordChoice) => new(
         from noteChoice in chordChoice.NoteChoices
         let voice = noteChoice.Voice
         let note = chord[voice]

--- a/src/BaroquenMelody.Library/Compositions/Extensions/BaroquenNoteExtensions.cs
+++ b/src/BaroquenMelody.Library/Compositions/Extensions/BaroquenNoteExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
-using Melanchall.DryWetMidi.MusicTheory;
 
 namespace BaroquenMelody.Library.Compositions.Extensions;
 
@@ -10,12 +9,12 @@ namespace BaroquenMelody.Library.Compositions.Extensions;
 /// </summary>
 internal static class BaroquenNoteExtensions
 {
-    public static BaroquenNote ApplyNoteChoice(this BaroquenNote note, Scale scale, NoteChoice noteChoice)
+    public static BaroquenNote ApplyNoteChoice(this BaroquenNote note, BaroquenScale scale, NoteChoice noteChoice)
     {
         var nextNote = noteChoice.Motion switch
         {
-            NoteMotion.Ascending => scale.GetAscendingNotes(note.Raw).ElementAt(noteChoice.ScaleStepChange),
-            NoteMotion.Descending => scale.GetDescendingNotes(note.Raw).ElementAt(noteChoice.ScaleStepChange),
+            NoteMotion.Ascending => scale.GetAscendingNotes(note.Raw)[noteChoice.ScaleStepChange],
+            NoteMotion.Descending => scale.GetDescendingNotes(note.Raw)[noteChoice.ScaleStepChange],
             NoteMotion.Oblique => note.Raw,
             _ => throw new ArgumentOutOfRangeException(nameof(noteChoice))
         };

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/OrnamentationEngineBuilder.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/OrnamentationEngineBuilder.cs
@@ -34,7 +34,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
 
     private IPolicyEngine<OrnamentationItem> BuildSixteenthNoteRunEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(),
+            new WantsToOrnament(90),
             new HasNoOrnamentation(),
             new IsApplicableInterval(compositionConfiguration, SixteenthNoteRunProcessor.Interval)
         )

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Policies/IsApplicableInterval.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Policies/IsApplicableInterval.cs
@@ -1,6 +1,5 @@
 ﻿using Atrea.PolicyEngine.Policies.Input;
 using BaroquenMelody.Library.Compositions.Configurations;
-using Melanchall.DryWetMidi.MusicTheory;
 
 namespace BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies;
 

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/PassingToneProcessor.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/PassingToneProcessor.cs
@@ -3,7 +3,6 @@ using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
-using Melanchall.DryWetMidi.MusicTheory;
 
 namespace BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
 

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/SixteenthNoteRunProcessor.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/SixteenthNoteRunProcessor.cs
@@ -3,7 +3,6 @@ using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
-using Melanchall.DryWetMidi.MusicTheory;
 
 namespace BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
 

--- a/src/BaroquenMelody.Library/Compositions/Strategies/CompositionStrategy.cs
+++ b/src/BaroquenMelody.Library/Compositions/Strategies/CompositionStrategy.cs
@@ -22,9 +22,9 @@ internal sealed class CompositionStrategy(
     /// </summary>
     private readonly HashSet<NoteName> validStartingNoteNames =
     [
-        compositionConfiguration.Scale.GetDegree(ScaleDegree.Tonic),
-        compositionConfiguration.Scale.GetDegree(ScaleDegree.Mediant),
-        compositionConfiguration.Scale.GetDegree(ScaleDegree.Dominant)
+        compositionConfiguration.Scale.Raw.GetDegree(ScaleDegree.Tonic),
+        compositionConfiguration.Scale.Raw.GetDegree(ScaleDegree.Mediant),
+        compositionConfiguration.Scale.Raw.GetDegree(ScaleDegree.Dominant)
     ];
 
     public IReadOnlyList<ChordChoice> GetPossibleChordChoices(IReadOnlyList<BaroquenChord> precedingChords)

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -1,6 +1,7 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
 using BaroquenMelody.Library.Compositions.Composers;
 using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Evaluations.Rules;
 using BaroquenMelody.Library.Compositions.Ornamentation;
@@ -16,10 +17,10 @@ using Melanchall.DryWetMidi.MusicTheory;
 using Melanchall.DryWetMidi.Standards;
 using System.Globalization;
 
+// proof of concept testing code...
 Console.WriteLine("Hit 'enter' to start composing...");
 Console.ReadLine();
 
-// proof of concept testing code...
 var phrasingConfiguration = new PhrasingConfiguration(
     PhraseLengths: [2, 4, 8],
     MaxPhraseRepetitions: 4,
@@ -36,9 +37,9 @@ var compositionConfiguration = new CompositionConfiguration(
         new(Voice.Bass, Notes.C2, Notes.C3)
     },
     phrasingConfiguration,
-    Scale.Parse("D dorian"),
+    BaroquenScale.Parse("C Minor"),
     Meter.FourFour,
-    100
+    25
 );
 
 var compositionRule = new AggregateCompositionRule(
@@ -59,8 +60,6 @@ var compositionStrategyFactory = new CompositionStrategyFactory(
 
 var compositionStrategy = compositionStrategyFactory.Create(compositionConfiguration);
 
-Console.WriteLine("Done creating composition strategy!");
-
 var compositionDecorator = new CompositionDecorator(
     new OrnamentationEngineBuilder(compositionConfiguration, new MusicalTimeSpanCalculator()).Build(),
     compositionConfiguration
@@ -77,9 +76,13 @@ var composer = new Composer(
 
 Console.WriteLine("Composing...");
 
+var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
 var composition = composer.Compose();
 
-Console.WriteLine("Done composing!");
+stopwatch.Stop();
+
+Console.WriteLine($"Done composing! Elapsed time: {stopwatch.Elapsed}.");
 Console.WriteLine("Creating MIDI file...");
 
 // just for testing purposes, we'll create a MIDI file with 3 tracks, one for each voice

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/ChordChoiceRepositoryFactoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/ChordChoiceRepositoryFactoryTests.cs
@@ -1,9 +1,9 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
 using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Extensions;
 using FluentAssertions;
-using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -36,7 +36,7 @@ internal sealed class ChordChoiceRepositoryFactoryTests
             Enumerable.Range(0, numberOfVoices)
                 .Select(index => new VoiceConfiguration(Voice.Soprano, index.ToNote(), (index + 1).ToNote()))
                 .ToHashSet(),
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
         );
@@ -58,7 +58,7 @@ internal sealed class ChordChoiceRepositoryFactoryTests
                 // invalid configuration: only one voice
                 new(Voice.Soprano, 55.ToNote(), 90.ToNote())
             },
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
         );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/DuetChordChoiceRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/DuetChordChoiceRepositoryTests.cs
@@ -1,9 +1,9 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
 using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Extensions;
 using FluentAssertions;
-using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -52,7 +52,7 @@ internal sealed class DuetChordChoiceRepositoryTests
                 new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
                 new(Voice.Alto, 45.ToNote(), 80.ToNote())
             },
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
         );
@@ -92,7 +92,7 @@ internal sealed class DuetChordChoiceRepositoryTests
                 new(Voice.Alto, 45.ToNote(), 80.ToNote()),
                 new(Voice.Tenor, 35.ToNote(), 70.ToNote())
             },
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
         );
@@ -117,7 +117,7 @@ internal sealed class DuetChordChoiceRepositoryTests
                 new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
                 new(Voice.Alto, 45.ToNote(), 80.ToNote())
             },
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
         );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/QuartetChordChoiceRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/QuartetChordChoiceRepositoryTests.cs
@@ -1,9 +1,9 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
 using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Extensions;
 using FluentAssertions;
-using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -76,7 +76,7 @@ internal sealed class QuartetChordChoiceRepositoryTests
                 new(Voice.Tenor, 35.ToNote(), 70.ToNote()),
                 new(Voice.Bass, 25.ToNote(), 60.ToNote())
             },
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
         );
@@ -117,7 +117,7 @@ internal sealed class QuartetChordChoiceRepositoryTests
                 new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
                 new(Voice.Alto, 45.ToNote(), 80.ToNote())
             },
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
         );
@@ -144,7 +144,7 @@ internal sealed class QuartetChordChoiceRepositoryTests
                 new(Voice.Tenor, 35.ToNote(), 70.ToNote()),
                 new(Voice.Bass, 25.ToNote(), 60.ToNote())
             },
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
         );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/TrioChordChoiceRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/TrioChordChoiceRepositoryTests.cs
@@ -1,9 +1,9 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
 using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Extensions;
 using FluentAssertions;
-using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -64,7 +64,7 @@ internal sealed class TrioChordChoiceRepositoryTests
                 new(Voice.Alto, 45.ToNote(), 80.ToNote()),
                 new(Voice.Tenor, 35.ToNote(), 70.ToNote())
             },
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
         );
@@ -106,7 +106,7 @@ internal sealed class TrioChordChoiceRepositoryTests
                 new(Voice.Tenor, 35.ToNote(), 70.ToNote()),
                 new(Voice.Bass, 25.ToNote(), 60.ToNote())
             },
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
         );
@@ -132,7 +132,7 @@ internal sealed class TrioChordChoiceRepositoryTests
                 new(Voice.Alto, 45.ToNote(), 80.ToNote()),
                 new(Voice.Tenor, 35.ToNote(), 70.ToNote())
             },
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
         );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ComposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ComposerTests.cs
@@ -46,7 +46,7 @@ internal sealed class ComposerTests
                 new(Voice.Soprano, MinSopranoNote, MaxSopranoNote),
                 new(Voice.Alto, MinAltoNote, MaxAltoNote)
             },
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
         );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/CompositionConfigurationTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/CompositionConfigurationTests.cs
@@ -1,8 +1,8 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Extensions;
 using FluentAssertions;
-using Melanchall.DryWetMidi.MusicTheory;
 using NUnit.Framework;
 
 namespace BaroquenMelody.Library.Tests.Compositions.Configuration;
@@ -27,7 +27,7 @@ internal sealed class CompositionConfigurationTests
                 new(Voice.Tenor, 36.ToNote(), 48.ToNote()),
                 new(Voice.Bass, 24.ToNote(), 36.ToNote())
             },
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
         );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Evaluations/Rules/AvoidDissonantLeapTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Evaluations/Rules/AvoidDissonantLeapTests.cs
@@ -32,7 +32,7 @@ internal sealed class AvoidDissonantLeapsTests
                 new(Voice.Bass, Notes.C2, Notes.C3)
             },
             phrasingConfiguration,
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             100
         );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Evaluations/Rules/EnsureVoiceRangeTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Evaluations/Rules/EnsureVoiceRangeTests.cs
@@ -24,7 +24,7 @@ internal sealed class EnsureVoiceRangeTests
                 new(Voice.Tenor, Notes.C2, Notes.C3),
                 new(Voice.Bass, Notes.G1, Notes.G2)
             },
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
         );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Extensions/BaroquenNoteExtensionsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Extensions/BaroquenNoteExtensionsTests.cs
@@ -16,7 +16,7 @@ internal sealed class BaroquenNoteExtensionsTests
     {
         // arrange
         var note = new BaroquenNote(Voice.Soprano, Notes.A4);
-        var scale = Scale.Parse("C Major");
+        var scale = BaroquenScale.Parse("C Major");
         var noteChoice = new NoteChoice(Voice.Soprano, NoteMotion.Ascending, 2);
 
         // act
@@ -31,7 +31,7 @@ internal sealed class BaroquenNoteExtensionsTests
     {
         // arrange
         var note = new BaroquenNote(Voice.Soprano, Notes.C5);
-        var scale = Scale.Parse("C Major");
+        var scale = BaroquenScale.Parse("C Major");
         var noteChoice = new NoteChoice(Voice.Soprano, NoteMotion.Descending, 2);
 
         // act
@@ -46,7 +46,7 @@ internal sealed class BaroquenNoteExtensionsTests
     {
         // arrange
         var note = new BaroquenNote(Voice.Soprano, Notes.C5);
-        var scale = Scale.Parse("C Major");
+        var scale = BaroquenScale.Parse("C Major");
         var noteChoice = new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0);
 
         // act
@@ -61,7 +61,7 @@ internal sealed class BaroquenNoteExtensionsTests
     {
         // arrange
         var note = new BaroquenNote(Voice.Soprano, Notes.C5);
-        var scale = Scale.Parse("C Major");
+        var scale = BaroquenScale.Parse("C Major");
         var noteChoice = new NoteChoice(Voice.Soprano, (NoteMotion)99, 0);
 
         // act

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/CompositionDecoratorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/CompositionDecoratorTests.cs
@@ -25,7 +25,7 @@ internal sealed class CompositionDecoratorTests
                 new(Voice.Soprano, Notes.A4, Notes.A5),
                 new(Voice.Alto, Notes.C3, Notes.C4)
             },
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
         );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Policies/IsApplicableIntervalTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Policies/IsApplicableIntervalTests.cs
@@ -25,7 +25,7 @@ internal sealed class IsApplicableIntervalTests
                 new(Voice.Soprano, Notes.A4, Notes.A5),
                 new(Voice.Alto, Notes.C3, Notes.C4)
             },
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
         );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Processors/PassingToneProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Processors/PassingToneProcessorTests.cs
@@ -26,7 +26,7 @@ internal sealed class PassingToneProcessorTests
                 new(Voice.Soprano, Notes.C3, Notes.C5),
                 new(Voice.Alto, Notes.C2, Notes.C4)
             },
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
         );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Processors/SixteenthNoteRunProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Processors/SixteenthNoteRunProcessorTests.cs
@@ -26,7 +26,7 @@ internal sealed class SixteenthNoteRunProcessorTests
                 new(Voice.Soprano, Notes.C3, Notes.C5),
                 new(Voice.Alto, Notes.C2, Notes.C4)
             },
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
         );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Phrasing/CompositionPhraserTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Phrasing/CompositionPhraserTests.cs
@@ -162,7 +162,7 @@ internal sealed class CompositionPhraserTests
         var compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>(),
             phrasingConfiguration,
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             16
         );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Strategies/CompositionStrategyFactoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Strategies/CompositionStrategyFactoryTests.cs
@@ -1,11 +1,11 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
 using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Evaluations.Rules;
 using BaroquenMelody.Library.Compositions.Extensions;
 using BaroquenMelody.Library.Compositions.Strategies;
 using FluentAssertions;
-using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -45,7 +45,7 @@ internal sealed class CompositionStrategyFactoryTests
                 new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
                 new(Voice.Alto, 45.ToNote(), 80.ToNote())
             },
-            Scale.Parse("C Major"),
+            BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
         );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Strategies/CompositionStrategyTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Strategies/CompositionStrategyTests.cs
@@ -58,7 +58,7 @@ internal sealed class CompositionStrategyTests
                 new(Voice.Tenor, MinTenorPitch.ToNote(), MaxTenorPitch.ToNote()),
                 new(Voice.Bass, MinBassPitch.ToNote(), MaxBassPitch.ToNote())
             },
-            Scale.Parse("C Major"),
+            new BaroquenScale(Scale.Parse("C Major")),
             Meter.FourFour,
             CompositionLength: 100
         );


### PR DESCRIPTION
## Description

This PR introduces a `BaroquenScale` domain object that helps with per-calculating all notes, ascending notes, and descending notes for the given underlying `Scale`. 

The underlying `Scale` methods were used extensively in "hot" paths during composition and introducing the `BaroquenScale` showed a 99.5% performance improvement in benchmarking.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe) - performance optimization

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
