### PR TITLE
Look-ahed Evaluation

### DIFF
--- a/src/BaroquenMelody.Library/Compositions/Enums/NoteMotion.cs
+++ b/src/BaroquenMelody.Library/Compositions/Enums/NoteMotion.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///   Indicates the motion taken to arrive at a given note from the previous note.
 /// </summary>
-public enum NoteMotion : byte
+internal enum NoteMotion : byte
 {
     /// <summary>
     ///     Indicates that the note is arrived at by moving up from the previous note.

--- a/src/BaroquenMelody.Library/Compositions/Strategies/CompositionStrategy.cs
+++ b/src/BaroquenMelody.Library/Compositions/Strategies/CompositionStrategy.cs
@@ -60,6 +60,7 @@ internal sealed class CompositionStrategy(
 
         do
         {
+            // try to first choose a note that hasn't been chosen at all, then only choose a note that has not already been doubled...
             var unChosenNotes = startingNoteCounts.Where(startingNoteCount => startingNoteCount.Value == 0)
                 .Select(startingNoteCount => startingNoteCount.Key)
                 .ToHashSet();

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -31,10 +31,10 @@ var phrasingConfiguration = new PhrasingConfiguration(
 var compositionConfiguration = new CompositionConfiguration(
     new HashSet<VoiceConfiguration>
     {
-        new(Voice.Soprano, Notes.G5, Notes.C7),
+        new(Voice.Soprano, Notes.G5, Notes.C6),
         new(Voice.Alto, Notes.C4, Notes.G5),
         new(Voice.Tenor, Notes.C3, Notes.C4),
-        new(Voice.Bass, Notes.G1, Notes.C3)
+        new(Voice.Bass, Notes.C2, Notes.C3)
     },
     phrasingConfiguration,
     BaroquenScale.Parse("C Minor"),

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -31,10 +31,10 @@ var phrasingConfiguration = new PhrasingConfiguration(
 var compositionConfiguration = new CompositionConfiguration(
     new HashSet<VoiceConfiguration>
     {
-        new(Voice.Soprano, Notes.G5, Notes.C6),
+        new(Voice.Soprano, Notes.G5, Notes.C7),
         new(Voice.Alto, Notes.C4, Notes.G5),
         new(Voice.Tenor, Notes.C3, Notes.C4),
-        new(Voice.Bass, Notes.C2, Notes.C3)
+        new(Voice.Bass, Notes.G1, Notes.C3)
     },
     phrasingConfiguration,
     BaroquenScale.Parse("C Minor"),

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Strategies/CompositionStrategyTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Strategies/CompositionStrategyTests.cs
@@ -66,10 +66,7 @@ internal sealed class CompositionStrategyTests
         _compositionStrategy = new CompositionStrategy(
             _mockChordChoiceRepository,
             _mockCompositionRule,
-            _compositionConfiguration,
-            maxRepeatedNotes: 2,
-            maxLookAheadDepth: 2,
-            minLookAheadChordChoices: 2
+            _compositionConfiguration
         );
     }
 


### PR DESCRIPTION
## Description

Implement look-ahead evaluation within `CompositionStrategy` to ensure that compositions avoid hitting dead ends where they're unable to proceed from the given composition state.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass