### PR TITLE
Delayed Passing Tone

### DIFF
--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/OrnamentationEngineBuilder.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/OrnamentationEngineBuilder.cs
@@ -3,6 +3,7 @@ using Atrea.PolicyEngine.Builders;
 using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using System.Diagnostics.CodeAnalysis;
 
@@ -15,6 +16,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
         .WithoutInputPolicies()
         .WithProcessors(
             BuildPassingToneEngine(),
+            BuildDelayedPassingToneEngine(),
             BuildSixteenthNoteRunEngine()
         )
         .WithoutOutputPolicies()
@@ -27,7 +29,19 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
             new IsApplicableInterval(compositionConfiguration, PassingToneProcessor.Interval)
         )
         .WithProcessors(
-            new PassingToneProcessor(musicalTimeSpanCalculator, compositionConfiguration)
+            new PassingToneProcessor(musicalTimeSpanCalculator, compositionConfiguration, OrnamentationType.PassingTone)
+        )
+        .WithoutOutputPolicies()
+        .Build();
+
+    private IPolicyEngine<OrnamentationItem> BuildDelayedPassingToneEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()
+        .WithInputPolicies(
+            new WantsToOrnament(),
+            new HasNoOrnamentation(),
+            new IsApplicableInterval(compositionConfiguration, PassingToneProcessor.Interval)
+        )
+        .WithProcessors(
+            new PassingToneProcessor(musicalTimeSpanCalculator, compositionConfiguration, OrnamentationType.DelayedPassingTone)
         )
         .WithoutOutputPolicies()
         .Build();

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/PassingToneProcessor.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/PassingToneProcessor.cs
@@ -6,7 +6,11 @@ using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 
 namespace BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
 
-internal class PassingToneProcessor(IMusicalTimeSpanCalculator musicalTimeSpanCalculator, CompositionConfiguration configuration) : IProcessor<OrnamentationItem>
+internal sealed class PassingToneProcessor(
+    IMusicalTimeSpanCalculator musicalTimeSpanCalculator,
+    CompositionConfiguration configuration,
+    OrnamentationType ornamentationType
+) : IProcessor<OrnamentationItem>
 {
     public const int Interval = 2;
 
@@ -23,11 +27,11 @@ internal class PassingToneProcessor(IMusicalTimeSpanCalculator musicalTimeSpanCa
         var passingToneScaleIndex = currentNoteScaleIndex > nextNoteScaleIndex ? currentNoteScaleIndex - 1 : currentNoteScaleIndex + 1;
         var passingTone = notes[passingToneScaleIndex];
 
-        currentNote.Duration = musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.PassingTone, configuration.Meter);
+        currentNote.Duration = musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(ornamentationType, configuration.Meter);
 
         currentNote.Ornamentations.Add(new BaroquenNote(currentNote.Voice, passingTone)
         {
-            Duration = musicalTimeSpanCalculator.CalculateOrnamentationTimeSpan(OrnamentationType.PassingTone, configuration.Meter)
+            Duration = musicalTimeSpanCalculator.CalculateOrnamentationTimeSpan(ornamentationType, configuration.Meter)
         });
     }
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Enums/OrnamentationType.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Enums/OrnamentationType.cs
@@ -10,5 +10,10 @@ internal enum OrnamentationType
     /// <summary>
     ///     A sixteenth note run between two notes.
     /// </summary>
-    SixteenthNoteRun
+    SixteenthNoteRun,
+
+    /// <summary>
+    ///    A delayed passing tone between two notes.
+    /// </summary>
+    DelayedPassingTone
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculator.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculator.cs
@@ -10,6 +10,7 @@ internal sealed class MusicalTimeSpanCalculator : IMusicalTimeSpanCalculator
     {
         OrnamentationType.PassingTone when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
         OrnamentationType.SixteenthNoteRun when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
+        OrnamentationType.DelayedPassingTone when meter == Meter.FourFour => MusicalTimeSpan.Eighth.Dotted(1),
         _ => throw new ArgumentOutOfRangeException(nameof(ornamentationType), ornamentationType, null)
     };
 
@@ -17,6 +18,7 @@ internal sealed class MusicalTimeSpanCalculator : IMusicalTimeSpanCalculator
     {
         OrnamentationType.PassingTone when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
         OrnamentationType.SixteenthNoteRun when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
+        OrnamentationType.DelayedPassingTone when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
         _ => throw new ArgumentOutOfRangeException(nameof(ornamentationType), ornamentationType, null)
     };
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Processors/PassingToneProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Processors/PassingToneProcessorTests.cs
@@ -3,6 +3,7 @@ using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Infrastructure.Collections;
 using FluentAssertions;
@@ -31,7 +32,7 @@ internal sealed class PassingToneProcessorTests
             CompositionLength: 100
         );
 
-        _processor = new PassingToneProcessor(new MusicalTimeSpanCalculator(), compositionConfiguration);
+        _processor = new PassingToneProcessor(new MusicalTimeSpanCalculator(), compositionConfiguration, OrnamentationType.PassingTone);
     }
 
     [Test]

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculatorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculatorTests.cs
@@ -40,6 +40,8 @@ internal sealed class MusicalTimeSpanCalculatorTests
 
             yield return new TestCaseData(OrnamentationType.SixteenthNoteRun, Meter.FourFour, MusicalTimeSpan.Sixteenth, MusicalTimeSpan.Sixteenth);
 
+            yield return new TestCaseData(OrnamentationType.DelayedPassingTone, Meter.FourFour, MusicalTimeSpan.Eighth.Dotted(1), MusicalTimeSpan.Sixteenth);
+
             // more test cases to come as more ornamentation types and meters are added...
         }
     }


### PR DESCRIPTION
## Description

Allow for configuration of ornamentation type within the passing tone processor, which allows for things like delayed passing tones to be added as ornamentation.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
