### PR TITLE
Handle Ascending Sevenths

### DIFF
--- a/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
@@ -21,15 +21,17 @@ internal sealed record CompositionConfiguration(
     int CompositionLength,
     int CompositionContextSize = 8)
 {
+    public IDictionary<Voice, VoiceConfiguration> VoiceConfigurationsByVoice => VoiceConfigurations.ToDictionary(
+        voiceConfiguration => voiceConfiguration.Voice
+    );
+
     /// <summary>
     ///     Determine if the given note is within the range of the given voice for the composition.
     /// </summary>
     /// <param name="voice">The voice to check the note against.</param>
     /// <param name="note">The note to check against the voice.</param>
     /// <returns>Whether the note is within the range of the voice.</returns>
-    public bool IsNoteInVoiceRange(Voice voice, Note note) => VoiceConfigurations.First(
-        voiceConfiguration => voiceConfiguration.Voice == voice
-    ).IsNoteWithinVoiceRange(note);
+    public bool IsNoteInVoiceRange(Voice voice, Note note) => VoiceConfigurationsByVoice[voice].IsNoteWithinVoiceRange(note);
 
     public CompositionConfiguration(
         ISet<VoiceConfiguration> VoiceConfigurations,

--- a/src/BaroquenMelody.Library/Compositions/Evaluations/Rules/AvoidRepetition.cs
+++ b/src/BaroquenMelody.Library/Compositions/Evaluations/Rules/AvoidRepetition.cs
@@ -18,6 +18,6 @@ internal sealed class AvoidRepetition : ICompositionRule
 
         return nextChord.Notes
             .Select(note => note.Voice)
-            .All(voice => precedingChordsToCheck.Any(precedingChord => precedingChord[voice].Raw != nextChord[voice].Raw));
+            .All(voice => precedingChordsToCheck.Exists(precedingChord => precedingChord[voice].Raw != nextChord[voice].Raw));
     }
 }

--- a/src/BaroquenMelody.Library/Compositions/Evaluations/Rules/HandleAscendingSeventh.cs
+++ b/src/BaroquenMelody.Library/Compositions/Evaluations/Rules/HandleAscendingSeventh.cs
@@ -1,0 +1,43 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using Melanchall.DryWetMidi.MusicTheory;
+
+namespace BaroquenMelody.Library.Compositions.Evaluations.Rules;
+
+/// <inheritdoc cref="ICompositionRule"/>
+internal sealed class HandleAscendingSeventh(CompositionConfiguration compositionConfiguration) : ICompositionRule
+{
+    private const int SeventhScaleDegree = 6;
+
+    private readonly NoteName _seventhScaleDegreeNoteName = compositionConfiguration.Scale.Raw.GetStep(SeventhScaleDegree);
+
+    public bool Evaluate(IReadOnlyList<BaroquenChord> precedingChords, BaroquenChord nextChord)
+    {
+        if (precedingChords.Count < 2)
+        {
+            return true;
+        }
+
+        var nextToLastChord = precedingChords[^2];
+        var lastChord = precedingChords[^1];
+
+        foreach (var seventhNote in lastChord.Notes.Where(note => note.Raw.NoteName == _seventhScaleDegreeNoteName))
+        {
+            var nextToLastNote = nextToLastChord[seventhNote.Voice];
+
+            if (nextToLastNote.Raw.NoteNumber >= seventhNote.Raw.NoteNumber)
+            {
+                continue;
+            }
+
+            var nextNote = nextChord[seventhNote.Voice];
+
+            if (nextNote.Raw.NoteNumber <= seventhNote.Raw.NoteNumber)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Strategies/CompositionStrategyFactory.cs
+++ b/src/BaroquenMelody.Library/Compositions/Strategies/CompositionStrategyFactory.cs
@@ -12,6 +12,7 @@ internal sealed class CompositionStrategyFactory(
     public ICompositionStrategy Create(CompositionConfiguration compositionConfiguration) => new CompositionStrategy(
         chordChoiceRepositoryFactory.Create(compositionConfiguration),
         compositionRule,
-        compositionConfiguration
+        compositionConfiguration,
+        maxLookAheadDepth: 1
     );
 }

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -32,10 +32,10 @@ var phrasingConfiguration = new PhrasingConfiguration(
 var compositionConfiguration = new CompositionConfiguration(
     new HashSet<VoiceConfiguration>
     {
-        new(Voice.Soprano, Notes.G5, Notes.G6),
-        new(Voice.Alto, Notes.C4, Notes.G5),
-        new(Voice.Tenor, Notes.C3, Notes.C4),
-        new(Voice.Bass, Notes.G1, Notes.C3)
+        new(Voice.Soprano, Notes.C5, Notes.C6),
+        new(Voice.Alto, Notes.C4, Notes.C5),
+        new(Voice.Tenor, Notes.C2, Notes.C3),
+        new(Voice.Bass, Notes.C1, Notes.C2)
     },
     phrasingConfiguration,
     BaroquenScale.Parse("D Dorian"),
@@ -45,6 +45,7 @@ var compositionConfiguration = new CompositionConfiguration(
 
 var compositionRule = new AggregateCompositionRule(
     [
+        new HandleAscendingSeventh(compositionConfiguration),
         new EnsureVoiceRange(compositionConfiguration),
         new AvoidDissonance(),
         new AvoidDissonantLeaps(compositionConfiguration),
@@ -89,15 +90,15 @@ stopwatch.Stop();
 Console.WriteLine($"Done composing! Elapsed time: {stopwatch.Elapsed}.");
 Console.WriteLine("Creating MIDI file...");
 
-// just for testing purposes, we'll create a MIDI file with 3 tracks, one for each voice
+// just for testing purposes, we'll create a MIDI file with 4 tracks, one for each voice
 var tempoMap = TempoMap.Create(Tempo.FromBeatsPerMinute(60));
 
 var patternBuildersByVoice = new Dictionary<Voice, PatternBuilder>
 {
-    { Voice.Soprano, new PatternBuilder().ProgramChange(GeneralMidiProgram.Harpsichord) },
-    { Voice.Alto, new PatternBuilder().ProgramChange(GeneralMidiProgram.Harpsichord) },
-    { Voice.Tenor, new PatternBuilder().ProgramChange(GeneralMidiProgram.Harpsichord) },
-    { Voice.Bass, new PatternBuilder().ProgramChange(GeneralMidiProgram.Harpsichord) }
+    { Voice.Soprano, new PatternBuilder().ProgramChange(GeneralMidiProgram.ChurchOrgan) },
+    { Voice.Alto, new PatternBuilder().ProgramChange(GeneralMidiProgram.ChurchOrgan) },
+    { Voice.Tenor, new PatternBuilder().ProgramChange(GeneralMidiProgram.ChurchOrgan) },
+    { Voice.Bass, new PatternBuilder().ProgramChange(GeneralMidiProgram.ChurchOrgan) }
 };
 
 // Use pattern builders to add notes to the pattern for each voice...
@@ -146,6 +147,8 @@ var midiFile = new MidiFile(
     patternBuildersByVoice[Voice.Tenor].Build().ToTrackChunk(tempoMap, (FourBitNumber)1),
     patternBuildersByVoice[Voice.Bass].Build().ToTrackChunk(tempoMap, (FourBitNumber)1)
 );
+
+midiFile.ReplaceTempoMap(tempoMap);
 
 // save the MIDI file with a timestamp in the filename to avoid overwriting on subsequent test runs...
 var timestamp = DateTime.Now.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Evaluations/Rules/HandleAscendingSeventhTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Evaluations/Rules/HandleAscendingSeventhTests.cs
@@ -1,0 +1,68 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Evaluations.Rules;
+using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Evaluations.Rules;
+
+[TestFixture]
+internal sealed class HandleAscendingSeventhTests
+{
+    private HandleAscendingSeventh _handleAscendingSeventh = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var compositionConfiguration = new CompositionConfiguration(
+            new HashSet<VoiceConfiguration>
+            {
+                new(Voice.Soprano, Notes.G5, Notes.G6),
+                new(Voice.Alto, Notes.C4, Notes.G5)
+            },
+            BaroquenScale.Parse("C Major"),
+            Meter.FourFour,
+            100
+        );
+
+        _handleAscendingSeventh = new HandleAscendingSeventh(compositionConfiguration);
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void Evaluate_ReturnsExpectedResult(IReadOnlyList<BaroquenChord> precedingChords, BaroquenChord nextChord, bool expectedResult)
+    {
+        // act
+        var result = _handleAscendingSeventh.Evaluate(precedingChords, nextChord);
+
+        // assert
+        result.Should().Be(expectedResult);
+    }
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            var sopranoA3 = new BaroquenNote(Voice.Soprano, Notes.A3);
+            var sopranoB3 = new BaroquenNote(Voice.Soprano, Notes.B3);
+            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4);
+            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3);
+
+            var cMajor = new BaroquenChord([sopranoC4, altoE3]);
+            var eMinor = new BaroquenChord([sopranoB3, altoE3]);
+            var aMinor = new BaroquenChord([sopranoA3, altoE3]);
+
+            yield return new TestCaseData(new List<BaroquenChord>(), cMajor, true).SetName("No need to handle ascending seventh if it's the first chord.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { cMajor }, eMinor, true).SetName("No need to handle ascending seventh if it's the second chord.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { aMinor, eMinor }, cMajor, true).SetName("Correctly handles ascending seventh.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { aMinor, eMinor }, aMinor, false).SetName("Incorrectly handles ascending seventh.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { cMajor, eMinor }, aMinor, true).SetName("No need to handle ascending seventh if its descending.");
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Implement an `ICompositionRule` to ensure that ascending 7ths are resolved correctly.
- Small performance tweaks

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
