### PR TITLE
Note and Chord Equality

### DIFF
--- a/src/BaroquenMelody.Library/Compositions/Domain/BaroquenChord.cs
+++ b/src/BaroquenMelody.Library/Compositions/Domain/BaroquenChord.cs
@@ -15,6 +15,11 @@ internal sealed class BaroquenChord(IEnumerable<BaroquenNote> notes) : IEquatabl
 
     private readonly FrozenDictionary<Voice, BaroquenNote> _notes = notes.ToFrozenDictionary(note => note.Voice);
 
+    /// <summary>
+    ///     Determines if the <see cref="BaroquenChord"/> is equal to another <see cref="BaroquenChord"/>.
+    /// </summary>
+    /// <param name="other">The other <see cref="BaroquenChord"/> to compare against.</param>
+    /// <returns>Whether the <see cref="BaroquenChord"/> is equal to the other <see cref="BaroquenChord"/>.</returns>
     public bool Equals(BaroquenChord? other)
     {
         if (other is null)
@@ -25,6 +30,11 @@ internal sealed class BaroquenChord(IEnumerable<BaroquenNote> notes) : IEquatabl
         return ReferenceEquals(this, other) || Notes.SequenceEqual(other.Notes);
     }
 
+    /// <summary>
+    ///     Determines if the <see cref="BaroquenChord"/> is equal to another object.
+    /// </summary>
+    /// <param name="obj">The other object to compare against.</param>
+    /// <returns>Whether the <see cref="BaroquenChord"/> is equal to the other object.</returns>
     public override bool Equals(object? obj) => ReferenceEquals(this, obj) || (obj is BaroquenChord other && Equals(other));
 
     /// <summary>
@@ -35,6 +45,12 @@ internal sealed class BaroquenChord(IEnumerable<BaroquenNote> notes) : IEquatabl
     public override int GetHashCode() => throw new InvalidOperationException($"{nameof(BaroquenChord)} cannot be used as a hash key since it has mutable properties.");
 #pragma warning restore SA1615
 
+    /// <summary>
+    ///     Determines if the <see cref="BaroquenChord"/> is equal to another <see cref="BaroquenChord"/>.
+    /// </summary>
+    /// <param name="chord">The first <see cref="BaroquenChord"/> to compare.</param>
+    /// <param name="otherChord">The second <see cref="BaroquenChord"/> to compare.</param>
+    /// <returns>Whether the <see cref="BaroquenChord"/> is equal to the other <see cref="BaroquenChord"/>.</returns>
     public static bool operator ==(BaroquenChord? chord, BaroquenChord? otherChord)
     {
         if (ReferenceEquals(chord, otherChord))
@@ -50,5 +66,11 @@ internal sealed class BaroquenChord(IEnumerable<BaroquenNote> notes) : IEquatabl
         return chord.Equals(otherChord);
     }
 
+    /// <summary>
+    ///     Determines if the <see cref="BaroquenChord"/> is not equal to another <see cref="BaroquenChord"/>.
+    /// </summary>
+    /// <param name="chord">The first <see cref="BaroquenChord"/> to compare.</param>
+    /// <param name="otherChord">The second <see cref="BaroquenChord"/> to compare.</param>
+    /// <returns>Whether the <see cref="BaroquenChord"/> is not equal to the other <see cref="BaroquenChord"/>.</returns>
     public static bool operator !=(BaroquenChord? chord, BaroquenChord? otherChord) => !(chord == otherChord);
 }

--- a/src/BaroquenMelody.Library/Compositions/Domain/BaroquenChord.cs
+++ b/src/BaroquenMelody.Library/Compositions/Domain/BaroquenChord.cs
@@ -7,11 +7,48 @@ namespace BaroquenMelody.Library.Compositions.Domain;
 ///    Represents a chord in a composition.
 /// </summary>
 /// <param name="notes">The notes that are played during the chord.</param>
-internal sealed class BaroquenChord(IEnumerable<BaroquenNote> notes)
+internal sealed class BaroquenChord(IEnumerable<BaroquenNote> notes) : IEquatable<BaroquenChord>
 {
     public IEnumerable<BaroquenNote> Notes => _notes.Values;
 
     public BaroquenNote this[Voice voice] => _notes[voice];
 
     private readonly FrozenDictionary<Voice, BaroquenNote> _notes = notes.ToFrozenDictionary(note => note.Voice);
+
+    public bool Equals(BaroquenChord? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        return ReferenceEquals(this, other) || Notes.SequenceEqual(other.Notes);
+    }
+
+    public override bool Equals(object? obj) => ReferenceEquals(this, obj) || (obj is BaroquenChord other && Equals(other));
+
+    /// <summary>
+    ///    Throws an <see cref="InvalidOperationException"/> since <see cref="BaroquenChord"/> cannot be used as a hash key.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Always thrown.</exception>
+#pragma warning disable SA1615
+    public override int GetHashCode() => throw new InvalidOperationException($"{nameof(BaroquenChord)} cannot be used as a hash key since it has mutable properties.");
+#pragma warning restore SA1615
+
+    public static bool operator ==(BaroquenChord? chord, BaroquenChord? otherChord)
+    {
+        if (ReferenceEquals(chord, otherChord))
+        {
+            return true;
+        }
+
+        if (chord is null || otherChord is null)
+        {
+            return false;
+        }
+
+        return chord.Equals(otherChord);
+    }
+
+    public static bool operator !=(BaroquenChord? chord, BaroquenChord? otherChord) => !(chord == otherChord);
 }

--- a/src/BaroquenMelody.Library/Compositions/Domain/BaroquenNote.cs
+++ b/src/BaroquenMelody.Library/Compositions/Domain/BaroquenNote.cs
@@ -9,7 +9,7 @@ namespace BaroquenMelody.Library.Compositions.Domain;
 /// </summary>
 /// <param name="voice">The voice that the note is played in.</param>
 /// <param name="raw">The raw note that is played.</param>
-internal sealed class BaroquenNote(Voice voice, Note raw)
+internal sealed class BaroquenNote(Voice voice, Note raw) : IEquatable<BaroquenNote>
 {
     /// <summary>
     ///     The voice that the note is played in.
@@ -35,4 +35,71 @@ internal sealed class BaroquenNote(Voice voice, Note raw)
     ///     Whether or not this note has any ornamentations.
     /// </summary>
     public bool HasOrnamentations => Ornamentations.Any();
+
+    /// <summary>
+    ///     Determines if the <see cref="BaroquenNote"/> is equal to another <see cref="BaroquenNote"/>.
+    /// </summary>
+    /// <param name="other">The other <see cref="BaroquenNote"/> to compare against.</param>
+    /// <returns>Whether the <see cref="BaroquenNote"/> is equal to the other <see cref="BaroquenNote"/>.</returns>
+    public bool Equals(BaroquenNote? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return Voice == other.Voice &&
+               Raw == other.Raw &&
+               Duration == other.Duration &&
+               Ornamentations.SequenceEqual(other.Ornamentations);
+    }
+
+    /// <summary>
+    ///     Determines if the <see cref="BaroquenNote"/> is equal to another object.
+    /// </summary>
+    /// <param name="obj">The object to compare against.</param>
+    /// <returns>Whether the <see cref="BaroquenNote"/> is equal to the other object.</returns>
+    public override bool Equals(object? obj) => ReferenceEquals(this, obj) || (obj is BaroquenNote other && Equals(other));
+
+    /// <summary>
+    ///    Throws an <see cref="InvalidOperationException"/> since <see cref="BaroquenNote"/> cannot be used as a hash key.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Always thrown.</exception>
+#pragma warning disable SA1615
+    public override int GetHashCode() => throw new InvalidOperationException($"{nameof(BaroquenNote)} cannot be used as a hash key since it has mutable properties.");
+#pragma warning restore SA1615
+
+    /// <summary>
+    ///     Determines if the <see cref="BaroquenNote"/> is equal to another <see cref="BaroquenNote"/>.
+    /// </summary>
+    /// <param name="note">The first <see cref="BaroquenNote"/> to compare.</param>
+    /// <param name="otherNote">The second <see cref="BaroquenNote"/> to compare.</param>
+    /// <returns>Whether the <see cref="BaroquenNote"/> is equal to the other <see cref="BaroquenNote"/>.</returns>
+    public static bool operator ==(BaroquenNote? note, BaroquenNote? otherNote)
+    {
+        if (ReferenceEquals(note, otherNote))
+        {
+            return true;
+        }
+
+        if (note is null || otherNote is null)
+        {
+            return false;
+        }
+
+        return note.Equals(otherNote);
+    }
+
+    /// <summary>
+    ///     Determines if the <see cref="BaroquenNote"/> is not equal to another <see cref="BaroquenNote"/>.
+    /// </summary>
+    /// <param name="note">The first <see cref="BaroquenNote"/> to compare.</param>
+    /// <param name="otherNote">The second <see cref="BaroquenNote"/> to compare.</param>
+    /// <returns>Whether the <see cref="BaroquenNote"/> is not equal to the other <see cref="BaroquenNote"/>.</returns>
+    public static bool operator !=(BaroquenNote? note, BaroquenNote? otherNote) => !(note == otherNote);
 }

--- a/src/BaroquenMelody.Library/Compositions/Strategies/CompositionStrategy.cs
+++ b/src/BaroquenMelody.Library/Compositions/Strategies/CompositionStrategy.cs
@@ -37,15 +37,10 @@ internal sealed class CompositionStrategy(
     {
         var startingNoteCounts = validStartingNoteNames.ToDictionary(noteName => noteName, _ => 0);
         var rawNotes = compositionConfiguration.Scale.GetNotes().ToList();
-        var notes = new HashSet<BaroquenNote>();
 
-        foreach (var voiceConfiguration in compositionConfiguration.VoiceConfigurations)
-        {
-            var rawNote = ChooseStartingNote(voiceConfiguration, rawNotes, validStartingNoteNames, ref startingNoteCounts);
-            var baroquenNote = new BaroquenNote(voiceConfiguration.Voice, rawNote);
-
-            notes.Add(baroquenNote);
-        }
+        var notes = compositionConfiguration.VoiceConfigurations
+            .Select(voiceConfiguration => new BaroquenNote(voiceConfiguration.Voice, ChooseStartingNote(voiceConfiguration, rawNotes, validStartingNoteNames, ref startingNoteCounts)))
+            .ToList();
 
         return new BaroquenChord(notes);
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BaroquenChordTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BaroquenChordTests.cs
@@ -1,0 +1,71 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Domain;
+
+[TestFixture]
+internal sealed class BaroquenChordTests
+{
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void Equality_methods_return_expected_results(BaroquenChord chord, BaroquenChord? otherChord, bool expectedEqualityResult)
+    {
+        // act + assert
+        chord.Equals(otherChord).Should().Be(expectedEqualityResult);
+        chord.Equals((object?)otherChord).Should().Be(expectedEqualityResult);
+        (chord == otherChord).Should().Be(expectedEqualityResult);
+        (chord != otherChord).Should().Be(!expectedEqualityResult);
+    }
+
+    [Test]
+    public void GetHashCode_throws_InvalidOperationException()
+    {
+        // arrange
+        var chord = new BaroquenChord(new[] { new BaroquenNote(Voice.Soprano, Notes.C1) });
+
+        // act
+        var act = () => chord.GetHashCode();
+
+        // assert
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            var sopranoC1 = new BaroquenNote(Voice.Soprano, Notes.C1);
+            var altoE1 = new BaroquenNote(Voice.Alto, Notes.E1);
+
+            var cMajor = new BaroquenChord([sopranoC1, altoE1]);
+            var identicalCMajor = new BaroquenChord([sopranoC1, altoE1]);
+
+            var sopranoD1 = new BaroquenNote(Voice.Soprano, Notes.D1);
+            var altoF1 = new BaroquenNote(Voice.Alto, Notes.F1);
+
+            var dMinor = new BaroquenChord([sopranoD1, altoF1]);
+
+            var sopranoC1WithOrnamentation = new BaroquenNote(Voice.Soprano, Notes.C1)
+            {
+                Ornamentations = { new BaroquenNote(Voice.Soprano, Notes.C2) }
+            };
+
+            var cMajorWithOrnamentation = new BaroquenChord([sopranoC1WithOrnamentation, altoE1]);
+
+            BaroquenChord? nullChord = null;
+
+            yield return new TestCaseData(cMajor, cMajor, true).SetName("Same chord instances are equal");
+
+            yield return new TestCaseData(cMajor, identicalCMajor, true).SetName("Identical chords are equal");
+
+            yield return new TestCaseData(cMajor, dMinor, false).SetName("Chords with different notes are not equal");
+
+            yield return new TestCaseData(cMajor, cMajorWithOrnamentation, false).SetName("Chords with different ornamentations are not equal");
+
+            yield return new TestCaseData(cMajor, nullChord, false).SetName("Null chord is not equal to any chord");
+        }
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BaroquenChordTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BaroquenChordTests.cs
@@ -11,11 +11,11 @@ internal sealed class BaroquenChordTests
 {
     [Test]
     [TestCaseSource(nameof(TestCases))]
-    public void Equality_methods_return_expected_results(BaroquenChord chord, BaroquenChord? otherChord, bool expectedEqualityResult)
+    public void Equality_methods_return_expected_results(BaroquenChord? chord, BaroquenChord? otherChord, bool expectedEqualityResult)
     {
         // act + assert
-        chord.Equals(otherChord).Should().Be(expectedEqualityResult);
-        chord.Equals((object?)otherChord).Should().Be(expectedEqualityResult);
+        chord?.Equals(otherChord).Should().Be(expectedEqualityResult);
+        chord?.Equals((object?)otherChord).Should().Be(expectedEqualityResult);
         (chord == otherChord).Should().Be(expectedEqualityResult);
         (chord != otherChord).Should().Be(!expectedEqualityResult);
     }
@@ -66,6 +66,8 @@ internal sealed class BaroquenChordTests
             yield return new TestCaseData(cMajor, cMajorWithOrnamentation, false).SetName("Chords with different ornamentations are not equal");
 
             yield return new TestCaseData(cMajor, nullChord, false).SetName("Null chord is not equal to any chord");
+
+            yield return new TestCaseData(nullChord, cMajor, false).SetName("Null chord is not equal to any chord");
         }
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BaroquenNoteTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BaroquenNoteTests.cs
@@ -11,11 +11,11 @@ internal sealed class BaroquenNoteTests
 {
     [Test]
     [TestCaseSource(nameof(TestCases))]
-    public void Equality_methods_return_expected_results(BaroquenNote note, BaroquenNote? otherNote, bool expectedEqualityResult)
+    public void Equality_methods_return_expected_results(BaroquenNote? note, BaroquenNote? otherNote, bool expectedEqualityResult)
     {
         // act + assert
-        note.Equals(otherNote).Should().Be(expectedEqualityResult);
-        note.Equals((object?)otherNote).Should().Be(expectedEqualityResult);
+        note?.Equals(otherNote).Should().Be(expectedEqualityResult);
+        note?.Equals((object?)otherNote).Should().Be(expectedEqualityResult);
         (note == otherNote).Should().Be(expectedEqualityResult);
         (note != otherNote).Should().Be(!expectedEqualityResult);
     }
@@ -67,6 +67,8 @@ internal sealed class BaroquenNoteTests
             yield return new TestCaseData(note, noteWithOrnamentation, false).SetName("Notes with different ornamentations are not equal");
 
             yield return new TestCaseData(note, nullNote, false).SetName("Null note is not equal to any note");
+
+            yield return new TestCaseData(nullNote, note, false).SetName("Null note is not equal to any note");
         }
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BaroquenNoteTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BaroquenNoteTests.cs
@@ -1,0 +1,72 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Domain;
+
+[TestFixture]
+internal sealed class BaroquenNoteTests
+{
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void Equality_methods_return_expected_results(BaroquenNote note, BaroquenNote? otherNote, bool expectedEqualityResult)
+    {
+        // act + assert
+        note.Equals(otherNote).Should().Be(expectedEqualityResult);
+        note.Equals((object?)otherNote).Should().Be(expectedEqualityResult);
+        (note == otherNote).Should().Be(expectedEqualityResult);
+        (note != otherNote).Should().Be(!expectedEqualityResult);
+    }
+
+    [Test]
+    public void GetHashCode_throws_InvalidOperationException()
+    {
+        // arrange
+        var note = new BaroquenNote(Voice.Soprano, Notes.C1);
+
+        // act
+        var act = () => note.GetHashCode();
+
+        // assert
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            var note = new BaroquenNote(Voice.Soprano, Notes.C1);
+            var identicalNote = new BaroquenNote(Voice.Soprano, Notes.C1);
+            var noteWithDifferentPitch = new BaroquenNote(Voice.Soprano, Notes.D1);
+            var noteWithDifferentVoice = new BaroquenNote(Voice.Alto, Notes.C1);
+
+            var noteWithDifferentDuration = new BaroquenNote(Voice.Soprano, Notes.C1)
+            {
+                Duration = note.Duration.Triplet()
+            };
+
+            var noteWithOrnamentation = new BaroquenNote(Voice.Soprano, Notes.C1)
+            {
+                Ornamentations = { new BaroquenNote(Voice.Soprano, Notes.C2) }
+            };
+
+            BaroquenNote? nullNote = null;
+
+            yield return new TestCaseData(note, note, true).SetName("Same note instances are equal");
+
+            yield return new TestCaseData(note, identicalNote, true).SetName("Identical notes are equal");
+
+            yield return new TestCaseData(note, noteWithDifferentPitch, false).SetName("Notes with different pitches are not equal");
+
+            yield return new TestCaseData(note, noteWithDifferentVoice, false).SetName("Notes with different voices are not equal");
+
+            yield return new TestCaseData(note, noteWithDifferentDuration, false).SetName("Notes with different durations are not equal");
+
+            yield return new TestCaseData(note, noteWithOrnamentation, false).SetName("Notes with different ornamentations are not equal");
+
+            yield return new TestCaseData(note, nullNote, false).SetName("Null note is not equal to any note");
+        }
+    }
+}


### PR DESCRIPTION
## Description

- Implement equality methods and operators for `BaroquenNote` and `BaroquenChord`.
- Prevent using these classes as hash keys since they are mutable.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
