### PR TITLE
Turn Ornamentations

### DIFF
--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/OrnamentationEngineBuilder.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/OrnamentationEngineBuilder.cs
@@ -17,6 +17,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
         .WithProcessors(
             BuildPassingToneEngine(),
             BuildDelayedPassingToneEngine(),
+            BuildTurnEngine(),
             BuildSixteenthNoteRunEngine()
         )
         .WithoutOutputPolicies()
@@ -42,6 +43,18 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
         )
         .WithProcessors(
             new PassingToneProcessor(musicalTimeSpanCalculator, compositionConfiguration, OrnamentationType.DelayedPassingTone)
+        )
+        .WithoutOutputPolicies()
+        .Build();
+
+    private IPolicyEngine<OrnamentationItem> BuildTurnEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()
+        .WithInputPolicies(
+            new WantsToOrnament(),
+            new HasNoOrnamentation(),
+            new IsApplicableInterval(compositionConfiguration, PassingToneProcessor.Interval)
+        )
+        .WithProcessors(
+            new TurnProcessor(musicalTimeSpanCalculator, compositionConfiguration)
         )
         .WithoutOutputPolicies()
         .Build();

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/TurnProcessor.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/TurnProcessor.cs
@@ -1,0 +1,52 @@
+﻿using Atrea.PolicyEngine.Processors;
+using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
+
+internal sealed class TurnProcessor(
+    IMusicalTimeSpanCalculator musicalTimeSpanCalculator,
+    CompositionConfiguration compositionConfiguration
+) : IProcessor<OrnamentationItem>
+{
+    public const int Interval = 1;
+
+    public void Process(OrnamentationItem item)
+    {
+        var currentNote = item.CurrentBeat[item.Voice];
+        var nextNote = item.NextBeat![item.Voice];
+
+        var notes = compositionConfiguration.Scale.GetNotes().ToList();
+
+        var currentNoteIndex = notes.IndexOf(currentNote.Raw);
+        var nextNoteIndex = notes.IndexOf(nextNote.Raw);
+
+        var firstNoteIndex = currentNoteIndex > nextNoteIndex ? currentNoteIndex - 1 : currentNoteIndex + 1;
+        var secondNoteIndex = currentNoteIndex > nextNoteIndex ? currentNoteIndex + 1 : currentNoteIndex - 1;
+
+        var firstNote = notes[firstNoteIndex];
+        var secondNote = notes[secondNoteIndex];
+        var thirdNote = notes[currentNoteIndex];
+
+        currentNote.Duration = musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.Turn, compositionConfiguration.Meter);
+
+        var duration = musicalTimeSpanCalculator.CalculateOrnamentationTimeSpan(OrnamentationType.Turn, compositionConfiguration.Meter);
+
+        currentNote.Ornamentations.Add(new BaroquenNote(currentNote.Voice, firstNote)
+        {
+            Duration = duration
+        });
+
+        currentNote.Ornamentations.Add(new BaroquenNote(currentNote.Voice, secondNote)
+        {
+            Duration = duration
+        });
+
+        currentNote.Ornamentations.Add(new BaroquenNote(currentNote.Voice, thirdNote)
+        {
+            Duration = duration
+        });
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Enums/OrnamentationType.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Enums/OrnamentationType.cs
@@ -1,6 +1,6 @@
 ﻿namespace BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 
-internal enum OrnamentationType
+internal enum OrnamentationType : byte
 {
     /// <summary>
     ///     A passing tone between two notes.
@@ -15,5 +15,10 @@ internal enum OrnamentationType
     /// <summary>
     ///    A delayed passing tone between two notes.
     /// </summary>
-    DelayedPassingTone
+    DelayedPassingTone,
+
+    /// <summary>
+    ///    A turn between two notes.
+    /// </summary>
+    Turn
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculator.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculator.cs
@@ -11,6 +11,7 @@ internal sealed class MusicalTimeSpanCalculator : IMusicalTimeSpanCalculator
         OrnamentationType.PassingTone when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
         OrnamentationType.SixteenthNoteRun when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
         OrnamentationType.DelayedPassingTone when meter == Meter.FourFour => MusicalTimeSpan.Eighth.Dotted(1),
+        OrnamentationType.Turn when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
         _ => throw new ArgumentOutOfRangeException(nameof(ornamentationType), ornamentationType, null)
     };
 
@@ -19,6 +20,7 @@ internal sealed class MusicalTimeSpanCalculator : IMusicalTimeSpanCalculator
         OrnamentationType.PassingTone when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
         OrnamentationType.SixteenthNoteRun when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
         OrnamentationType.DelayedPassingTone when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
+        OrnamentationType.Turn when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
         _ => throw new ArgumentOutOfRangeException(nameof(ornamentationType), ornamentationType, null)
     };
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Processors/TurnProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Processors/TurnProcessorTests.cs
@@ -1,0 +1,98 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation;
+using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
+using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
+using BaroquenMelody.Library.Infrastructure.Collections;
+using FluentAssertions;
+using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Processors;
+
+[TestFixture]
+internal sealed class TurnProcessorTests
+{
+    private TurnProcessor _processor = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var compositionConfiguration = new CompositionConfiguration(
+            new HashSet<VoiceConfiguration>
+            {
+                new(Voice.Soprano, Notes.C3, Notes.C5),
+                new(Voice.Alto, Notes.C2, Notes.C4)
+            },
+            BaroquenScale.Parse("C Major"),
+            Meter.FourFour,
+            CompositionLength: 100
+        );
+
+        _processor = new TurnProcessor(new MusicalTimeSpanCalculator(), compositionConfiguration);
+    }
+
+    [Test]
+    public void Process_applies_ascending_turn_as_expected()
+    {
+        // arrange
+        var ornamentationItem = new OrnamentationItem(
+            Voice.Soprano,
+            new FixedSizeList<Beat>(1),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.D4)]))
+        );
+
+        // act
+        _processor.Process(ornamentationItem);
+
+        // assert
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+
+        noteToAssert.Ornamentations.Should().HaveCount(3);
+
+        noteToAssert.Ornamentations[0].Raw.Should().Be(Notes.D4);
+        noteToAssert.Ornamentations[1].Raw.Should().Be(Notes.B3);
+        noteToAssert.Ornamentations[2].Raw.Should().Be(Notes.C4);
+
+        noteToAssert.Duration.Should().Be(MusicalTimeSpan.Sixteenth);
+
+        foreach (var baroquenNote in noteToAssert.Ornamentations)
+        {
+            baroquenNote.Duration.Should().Be(MusicalTimeSpan.Sixteenth);
+        }
+    }
+
+    [Test]
+    public void Process_applies_descending_turn_as_expected()
+    {
+        // arrange
+        var ornamentationItem = new OrnamentationItem(
+            Voice.Soprano,
+            new FixedSizeList<Beat>(1),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.B3)]))
+        );
+
+        // act
+        _processor.Process(ornamentationItem);
+
+        // assert
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+
+        noteToAssert.Ornamentations.Should().HaveCount(3);
+
+        noteToAssert.Ornamentations[0].Raw.Should().Be(Notes.B3);
+        noteToAssert.Ornamentations[1].Raw.Should().Be(Notes.D4);
+        noteToAssert.Ornamentations[2].Raw.Should().Be(Notes.C4);
+
+        noteToAssert.Duration.Should().Be(MusicalTimeSpan.Sixteenth);
+
+        foreach (var baroquenNote in noteToAssert.Ornamentations)
+        {
+            baroquenNote.Duration.Should().Be(MusicalTimeSpan.Sixteenth);
+        }
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculatorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculatorTests.cs
@@ -42,13 +42,15 @@ internal sealed class MusicalTimeSpanCalculatorTests
 
             yield return new TestCaseData(OrnamentationType.DelayedPassingTone, Meter.FourFour, MusicalTimeSpan.Eighth.Dotted(1), MusicalTimeSpan.Sixteenth);
 
+            yield return new TestCaseData(OrnamentationType.Turn, Meter.FourFour, MusicalTimeSpan.Sixteenth, MusicalTimeSpan.Sixteenth);
+
             // more test cases to come as more ornamentation types and meters are added...
         }
     }
 
     [Test]
     [TestCase(OrnamentationType.PassingTone, (Meter)9001)]
-    [TestCase((OrnamentationType)9001, Meter.FourFour)]
+    [TestCase((OrnamentationType)250, Meter.FourFour)]
     public void WhenOrnamentationOrMeterIsOutOfRange_ThenArgumentOutOfRangeExceptionIsThrown(OrnamentationType ornamentationType, Meter meter)
     {
         // act


### PR DESCRIPTION
## Description

Add support for ascending and descending turn ornamentation.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
