### PR TITLE
Bug Fixes

### DIFF
--- a/src/BaroquenMelody.Library/Compositions/Choices/NoteChoiceGenerator.cs
+++ b/src/BaroquenMelody.Library/Compositions/Choices/NoteChoiceGenerator.cs
@@ -5,14 +5,12 @@ namespace BaroquenMelody.Library.Compositions.Choices;
 /// <inheritdoc cref="INoteChoiceGenerator"/>
 internal sealed class NoteChoiceGenerator(byte minScaleStepChange = 1, byte maxScaleStepChange = 4) : INoteChoiceGenerator
 {
+    private readonly NoteMotion[] noteMotions = [NoteMotion.Ascending, NoteMotion.Descending];
+
     public ISet<NoteChoice> GenerateNoteChoices(Voice voice) => Enumerable
         .Range(minScaleStepChange, maxScaleStepChange - minScaleStepChange + 1)
         .Select(scaleStepChange => (byte)scaleStepChange)
-        .SelectMany(scaleStepChange =>
-            new[] { NoteMotion.Ascending, NoteMotion.Descending }.Select(noteMotion =>
-                new NoteChoice(voice, noteMotion, scaleStepChange)
-            )
-        )
+        .SelectMany(scaleStepChange => noteMotions.Select(noteMotion => new NoteChoice(voice, noteMotion, scaleStepChange)))
         .Append(new NoteChoice(voice, NoteMotion.Oblique, 0))
         .ToHashSet();
 }

--- a/src/BaroquenMelody.Library/Compositions/Domain/BaroquenChord.cs
+++ b/src/BaroquenMelody.Library/Compositions/Domain/BaroquenChord.cs
@@ -9,11 +9,20 @@ namespace BaroquenMelody.Library.Compositions.Domain;
 /// <param name="notes">The notes that are played during the chord.</param>
 internal sealed class BaroquenChord(IEnumerable<BaroquenNote> notes) : IEquatable<BaroquenChord>
 {
-    public IEnumerable<BaroquenNote> Notes => _notes.Values;
+    public IEnumerable<BaroquenNote> Notes => _notesByVoice.Values;
 
-    public BaroquenNote this[Voice voice] => _notes[voice];
+    public BaroquenNote this[Voice voice] => _notesByVoice[voice];
 
-    private readonly FrozenDictionary<Voice, BaroquenNote> _notes = notes.ToFrozenDictionary(note => note.Voice);
+    private readonly FrozenDictionary<Voice, BaroquenNote> _notesByVoice = notes.ToFrozenDictionary(note => note.Voice);
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="BaroquenChord"/> class.
+    /// </summary>
+    /// <param name="chord">The chord to copy.</param>
+    public BaroquenChord(BaroquenChord chord)
+        : this(chord.Notes.Select(note => new BaroquenNote(note)))
+    {
+    }
 
     /// <summary>
     ///     Determines if the <see cref="BaroquenChord"/> is equal to another <see cref="BaroquenChord"/>.

--- a/src/BaroquenMelody.Library/Compositions/Domain/BaroquenNote.cs
+++ b/src/BaroquenMelody.Library/Compositions/Domain/BaroquenNote.cs
@@ -37,6 +37,26 @@ internal sealed class BaroquenNote(Voice voice, Note raw) : IEquatable<BaroquenN
     public bool HasOrnamentations => Ornamentations.Any();
 
     /// <summary>
+    ///     Initializes a new instance of the <see cref="BaroquenNote"/> class.
+    /// </summary>
+    /// <param name="note">The note to copy.</param>
+    public BaroquenNote(BaroquenNote note)
+        : this(note.Voice, note.Raw)
+    {
+        Duration = note.Duration;
+        Ornamentations = note.Ornamentations.Select(ornamentation => new BaroquenNote(ornamentation)).ToList();
+    }
+
+    /// <summary>
+    ///     Resets the ornamentation on this note.
+    /// </summary>
+    public void ResetOrnamentation()
+    {
+        Duration = MusicalTimeSpan.Quarter;
+        Ornamentations.Clear();
+    }
+
+    /// <summary>
     ///     Determines if the <see cref="BaroquenNote"/> is equal to another <see cref="BaroquenNote"/>.
     /// </summary>
     /// <param name="other">The other <see cref="BaroquenNote"/> to compare against.</param>

--- a/src/BaroquenMelody.Library/Compositions/Domain/Beat.cs
+++ b/src/BaroquenMelody.Library/Compositions/Domain/Beat.cs
@@ -9,4 +9,10 @@ namespace BaroquenMelody.Library.Compositions.Domain;
 internal sealed record Beat(BaroquenChord Chord)
 {
     public BaroquenNote this[Voice voice] => Chord[voice];
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="Beat"/> class.
+    /// </summary>
+    /// <param name="beat">The beat to copy.</param>
+    public Beat(Beat beat) => Chord = new BaroquenChord(beat.Chord);
 }

--- a/src/BaroquenMelody.Library/Compositions/Domain/Measure.cs
+++ b/src/BaroquenMelody.Library/Compositions/Domain/Measure.cs
@@ -7,4 +7,11 @@ namespace BaroquenMelody.Library.Compositions.Domain;
 /// </summary>
 /// <param name="Beats">The beats that make up the measure.</param>
 /// <param name="Meter">The meter of the measure.</param>
-internal sealed record Measure(IList<Beat> Beats, Meter Meter);
+internal sealed record Measure(IList<Beat> Beats, Meter Meter)
+{
+    public Measure(Measure measure)
+    {
+        Beats = measure.Beats.Select(beat => new Beat(beat)).ToList();
+        Meter = measure.Meter;
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/CompositionDecorator.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/CompositionDecorator.cs
@@ -5,6 +5,7 @@ using BaroquenMelody.Library.Infrastructure.Collections;
 
 namespace BaroquenMelody.Library.Compositions.Ornamentation;
 
+/// <inheritdoc cref="ICompositionDecorator"/>
 internal sealed class CompositionDecorator(IProcessor<OrnamentationItem> decorationEngine, CompositionConfiguration configuration) : ICompositionDecorator
 {
     public void Decorate(Composition composition)
@@ -15,18 +16,21 @@ internal sealed class CompositionDecorator(IProcessor<OrnamentationItem> decorat
 
         foreach (var voice in voices)
         {
-            foreach (var currentBeat in beats)
+            for (var i = 0; i < beats.Count; ++i)
             {
+                var currentBeat = beats[i];
+                var nextBeat = beats.ElementAtOrDefault(i + 1);
+
                 var ornamentationItem = new OrnamentationItem(
                     voice,
                     compositionContext,
                     currentBeat,
-                    beats.ElementAtOrDefault(beats.IndexOf(currentBeat) + 1)
+                    nextBeat
                 );
 
                 decorationEngine.Process(ornamentationItem);
 
-                compositionContext.Add(currentBeat);
+                compositionContext.Add(beats[i]);
             }
         }
     }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/OrnamentationEngineBuilder.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/OrnamentationEngineBuilder.cs
@@ -17,8 +17,8 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
         .WithProcessors(
             BuildPassingToneEngine(),
             BuildDelayedPassingToneEngine(),
-            BuildTurnEngine(),
-            BuildSixteenthNoteRunEngine()
+            BuildSixteenthNoteRunEngine(),
+            BuildTurnEngine()
         )
         .WithoutOutputPolicies()
         .Build();
@@ -29,9 +29,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
             new HasNoOrnamentation(),
             new IsApplicableInterval(compositionConfiguration, PassingToneProcessor.Interval)
         )
-        .WithProcessors(
-            new PassingToneProcessor(musicalTimeSpanCalculator, compositionConfiguration, OrnamentationType.PassingTone)
-        )
+        .WithProcessors(new PassingToneProcessor(musicalTimeSpanCalculator, compositionConfiguration, OrnamentationType.PassingTone))
         .WithoutOutputPolicies()
         .Build();
 
@@ -41,9 +39,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
             new HasNoOrnamentation(),
             new IsApplicableInterval(compositionConfiguration, PassingToneProcessor.Interval)
         )
-        .WithProcessors(
-            new PassingToneProcessor(musicalTimeSpanCalculator, compositionConfiguration, OrnamentationType.DelayedPassingTone)
-        )
+        .WithProcessors(new PassingToneProcessor(musicalTimeSpanCalculator, compositionConfiguration, OrnamentationType.DelayedPassingTone))
         .WithoutOutputPolicies()
         .Build();
 
@@ -51,11 +47,9 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
         .WithInputPolicies(
             new WantsToOrnament(),
             new HasNoOrnamentation(),
-            new IsApplicableInterval(compositionConfiguration, PassingToneProcessor.Interval)
+            new IsApplicableInterval(compositionConfiguration, TurnProcessor.Interval)
         )
-        .WithProcessors(
-            new TurnProcessor(musicalTimeSpanCalculator, compositionConfiguration)
-        )
+        .WithProcessors(new TurnProcessor(musicalTimeSpanCalculator, compositionConfiguration))
         .WithoutOutputPolicies()
         .Build();
 
@@ -65,9 +59,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
             new HasNoOrnamentation(),
             new IsApplicableInterval(compositionConfiguration, SixteenthNoteRunProcessor.Interval)
         )
-        .WithProcessors(
-            new SixteenthNoteRunProcessor(musicalTimeSpanCalculator, compositionConfiguration)
-        )
+        .WithProcessors(new SixteenthNoteRunProcessor(musicalTimeSpanCalculator, compositionConfiguration))
         .WithoutOutputPolicies()
         .Build();
 }

--- a/src/BaroquenMelody.Library/Compositions/Phrasing/RepeatedPhrase.cs
+++ b/src/BaroquenMelody.Library/Compositions/Phrasing/RepeatedPhrase.cs
@@ -9,6 +9,4 @@ internal sealed class RepeatedPhrase
     public int RepetitionCount { get; set; }
 
     public required IList<Measure> Phrase { get; init; }
-
-    public Guid Id { get; } = Guid.NewGuid();
 }


### PR DESCRIPTION
## Description

- Properly clear ornamentation when repeating phrases
- Rather than using `IndexOf` within a `foreach` of the composition decorator, use a vanilla `for` loop to avoid issues with equality of duplicate notes returning incorrect indexes
- Introduce copy constructors so phrase repetition, ornamentation, and ornamentation clearing don't incorrectly mutate existing notes
- Fix `BuildTurnEngine` which was using incorrect applicable interval

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
