### PR TITLE
Additional Cleanup

### DIFF
--- a/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
+++ b/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atrea.PolicyEngine" Version="3.0.0" />
+    <PackageReference Include="Atrea.PolicyEngine" Version="4.0.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageReference Include="LazyCart" Version="0.4.5" />
     <PackageReference Include="Melanchall.DryWetMidi" Version="7.1.0" />
@@ -29,6 +29,12 @@
 
   <ItemGroup>
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="$(AssemblyName).Tests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+    <InternalsVisibleTo Include="baroquen-melody" />
   </ItemGroup>
 
 </Project>

--- a/src/BaroquenMelody.Library/Compositions/Composers/Composer.cs
+++ b/src/BaroquenMelody.Library/Compositions/Composers/Composer.cs
@@ -43,7 +43,7 @@ internal sealed class Composer(
         while (measures.Count < compositionConfiguration.CompositionLength)
         {
             var initialChord = ComposeNextChord(compositionContext);
-            var beats = new List<Beat> { new(initialChord) };
+            var beats = new List<Beat>(compositionConfiguration.Meter.BeatsPerMeasure()) { new(initialChord) };
 
             compositionContext.Add(initialChord);
 
@@ -96,7 +96,7 @@ internal sealed class Composer(
     private List<Measure> ComposeInitialMeasures()
     {
         var initialChord = compositionStrategy.GenerateInitialChord();
-        var beats = new List<Beat> { new(initialChord) };
+        var beats = new List<Beat>(compositionConfiguration.Meter.BeatsPerMeasure()) { new(initialChord) };
         var precedingChords = beats.Select(beat => beat.Chord).ToList();
 
         while (beats.Count < compositionConfiguration.Meter.BeatsPerMeasure())
@@ -107,7 +107,7 @@ internal sealed class Composer(
             beats.Add(new Beat(nextChord));
         }
 
-        return [new Measure(beats, compositionConfiguration.Meter)];
+        return new List<Measure>(compositionConfiguration.CompositionLength) { new(beats, compositionConfiguration.Meter) };
     }
 
     private BaroquenChord ComposeNextChord(IReadOnlyList<BaroquenChord> precedingChords)

--- a/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
@@ -21,7 +21,7 @@ internal sealed record CompositionConfiguration(
     int CompositionLength,
     int CompositionContextSize = 8)
 {
-    public IDictionary<Voice, VoiceConfiguration> VoiceConfigurationsByVoice => VoiceConfigurations.ToDictionary(
+    public IDictionary<Voice, VoiceConfiguration> VoiceConfigurationsByVoice { get; } = VoiceConfigurations.ToDictionary(
         voiceConfiguration => voiceConfiguration.Voice
     );
 

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Policies/WantsToOrnament.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Policies/WantsToOrnament.cs
@@ -3,12 +3,8 @@ using BaroquenMelody.Library.Infrastructure.Random;
 
 namespace BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies;
 
-internal sealed class WantsToOrnament(int Threshold = 50) : IInputPolicy<OrnamentationItem>
+/// <inheritdoc cref="IInputPolicy{T}"/>
+internal sealed class WantsToOrnament(int Probability = 50) : IInputPolicy<OrnamentationItem>
 {
-    private const int Max = 100;
-
-    public InputPolicyResult ShouldProcess(OrnamentationItem item)
-    {
-        return ThreadLocalRandom.Next(Max) > Threshold ? InputPolicyResult.Continue : InputPolicyResult.Reject;
-    }
+    public InputPolicyResult ShouldProcess(OrnamentationItem item) => WeightedRandomBooleanGenerator.Generate(Probability) ? InputPolicyResult.Continue : InputPolicyResult.Reject;
 }

--- a/src/BaroquenMelody.Library/Infrastructure/Random/WeightedRandomBooleanGenerator.cs
+++ b/src/BaroquenMelody.Library/Infrastructure/Random/WeightedRandomBooleanGenerator.cs
@@ -1,0 +1,16 @@
+﻿namespace BaroquenMelody.Library.Infrastructure.Random;
+
+/// <summary>
+///     Generates random boolean values. Can pass a probability to increase or decrease the likelihood of a true value.
+/// </summary>
+internal static class WeightedRandomBooleanGenerator
+{
+    private const int Threshold = 100;
+
+    /// <summary>
+    ///     Generates a random boolean value.
+    /// </summary>
+    /// <param name="weight">The probability of generating a true value. Default is 50.</param>
+    /// <returns>A random boolean value.</returns>
+    public static bool Generate(int weight = 50) => weight > ThreadLocalRandom.Next(Threshold);
+}

--- a/src/BaroquenMelody.Library/InternalsVisibleTo.cs
+++ b/src/BaroquenMelody.Library/InternalsVisibleTo.cs
@@ -1,5 +1,0 @@
-﻿using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("BaroquenMelody.Library.Tests")]
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
-[assembly: InternalsVisibleTo("baroquen-melody")]

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -24,8 +24,8 @@ Console.WriteLine("Hit 'enter' to start composing...");
 Console.ReadLine();
 
 var phrasingConfiguration = new PhrasingConfiguration(
-    PhraseLengths: [2, 4, 8],
-    MaxPhraseRepetitions: 4,
+    PhraseLengths: [1, 2, 4, 8],
+    MaxPhraseRepetitions: 8,
     MinPhraseRepetitionPoolSize: 4,
     PhraseRepetitionProbability: 100
 );
@@ -33,15 +33,15 @@ var phrasingConfiguration = new PhrasingConfiguration(
 var compositionConfiguration = new CompositionConfiguration(
     new HashSet<VoiceConfiguration>
     {
-        new(Voice.Soprano, Notes.C4, Notes.C5),
-        new(Voice.Alto, Notes.C3, Notes.C4),
-        new(Voice.Tenor, Notes.C2, Notes.C3),
-        new(Voice.Bass, Notes.C1, Notes.C2)
+        new(Voice.Soprano, Notes.C5, Notes.G6),
+        new(Voice.Alto, Notes.G3, Notes.C5),
+        new(Voice.Tenor, Notes.C2, Notes.G3),
+        new(Voice.Bass, Notes.G0, Notes.C2)
     },
     phrasingConfiguration,
     BaroquenScale.Parse("D Dorian"),
     Meter.FourFour,
-    50
+    25
 );
 
 var compositionRule = new AggregateCompositionRule(

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/ChordChoiceRepositoryFactoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/ChordChoiceRepositoryFactoryTests.cs
@@ -4,6 +4,7 @@ using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Extensions;
 using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -33,9 +34,7 @@ internal sealed class ChordChoiceRepositoryFactoryTests
     {
         // arrange
         var compositionConfiguration = new CompositionConfiguration(
-            Enumerable.Range(0, numberOfVoices)
-                .Select(index => new VoiceConfiguration(Voice.Soprano, index.ToNote(), (index + 1).ToNote()))
-                .ToHashSet(),
+            GenerateVoiceConfigurations(numberOfVoices),
             BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             CompositionLength: 100
@@ -69,4 +68,27 @@ internal sealed class ChordChoiceRepositoryFactoryTests
         // assert
         act.Should().Throw<ArgumentException>();
     }
+
+    private static HashSet<VoiceConfiguration> GenerateVoiceConfigurations(int numberOfVoices) => numberOfVoices switch
+    {
+        2 =>
+        [
+            new VoiceConfiguration(Voice.Soprano, Notes.C4, Notes.C5),
+            new VoiceConfiguration(Voice.Alto, Notes.C3, Notes.C4)
+        ],
+        3 =>
+        [
+            new VoiceConfiguration(Voice.Soprano, Notes.C4, Notes.C5),
+            new VoiceConfiguration(Voice.Alto, Notes.C3, Notes.C4),
+            new VoiceConfiguration(Voice.Tenor, Notes.C2, Notes.C3)
+        ],
+        4 =>
+        [
+            new VoiceConfiguration(Voice.Soprano, Notes.C4, Notes.C5),
+            new VoiceConfiguration(Voice.Alto, Notes.C3, Notes.C4),
+            new VoiceConfiguration(Voice.Tenor, Notes.C2, Notes.C3),
+            new VoiceConfiguration(Voice.Bass, Notes.C1, Notes.C2)
+        ],
+        _ => throw new ArgumentException("Invalid number of voices.")
+    };
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Policies/WantsToOrnamentTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Policies/WantsToOrnamentTests.cs
@@ -12,10 +12,10 @@ namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Policies;
 internal sealed class WantsToOrnamentTests
 {
     [Test]
-    public void ShouldProcess_WhenRandomNumberIsGreaterThanThreshold_ReturnsContinue()
+    public void ShouldProcess_WhenProbabilityHigherThanRandomNumber_ReturnsContinue()
     {
         // arrange
-        var policy = new WantsToOrnament(-1);
+        var policy = new WantsToOrnament(101);
 
         var ornamentationItem = new OrnamentationItem(Voice.Soprano, [], new Beat(new BaroquenChord([])), null);
 
@@ -27,10 +27,10 @@ internal sealed class WantsToOrnamentTests
     }
 
     [Test]
-    public void ShouldProcess_WhenRandomNumberIsLessThanOrEqualToThreshold_ReturnsReject()
+    public void ShouldProcess_WhenProbabilityLowerThanRandomNumber_ReturnsReject()
     {
         // arrange
-        var policy = new WantsToOrnament(101);
+        var policy = new WantsToOrnament(-1);
 
         var ornamentationItem = new OrnamentationItem(Voice.Soprano, [], new Beat(new BaroquenChord([])), null);
 


### PR DESCRIPTION
## Description

- Apply `InternalsVisibleTo` within project file rather than source.
- Fix `VoiceConfigurationsByVoice` in `CompositionConfiguration`, which was previously being regenerated every time it was accessed (oops). This fix improved performance by 50%.
- Allocate new lists with an expected capacity where possible.
- Introduce a `WeightedRandomBooleanGenerator` for improved semantics

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
