### PR TITLE
Avoid Over-Doubling

### DIFF
--- a/src/BaroquenMelody.Library/Compositions/Rules/AvoidOverDoubling.cs
+++ b/src/BaroquenMelody.Library/Compositions/Rules/AvoidOverDoubling.cs
@@ -1,0 +1,26 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+using Melanchall.DryWetMidi.MusicTheory;
+
+namespace BaroquenMelody.Library.Compositions.Rules;
+
+internal sealed class AvoidOverDoubling : ICompositionRule
+{
+    private const int DuetThreshold = 1;
+
+    private const int TrioThreshold = 2;
+
+    private const int QuartetThreshold = 3;
+
+    public bool Evaluate(IReadOnlyList<BaroquenChord> precedingChords, BaroquenChord nextChord)
+    {
+        var uniqueNoteNameCount = nextChord.Notes.GroupBy(note => note.Raw.NoteName).Count();
+
+        return nextChord.Notes.Count switch
+        {
+            2 => uniqueNoteNameCount > DuetThreshold,
+            3 => uniqueNoteNameCount >= TrioThreshold,
+            4 => uniqueNoteNameCount >= QuartetThreshold,
+            _ => true
+        };
+    }
+}

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -53,7 +53,8 @@ var compositionRule = new AggregateCompositionRule(
         new AvoidRepetition(),
         new AvoidParallelIntervals(Interval.PerfectFifth),
         new AvoidParallelIntervals(Interval.PerfectFourth),
-        new AvoidParallelIntervals(Interval.Unison)
+        new AvoidParallelIntervals(Interval.Unison),
+        new AvoidOverDoubling()
     ]
 );
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidOverDoublingTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidOverDoublingTests.cs
@@ -46,6 +46,8 @@ internal sealed class AvoidOverDoublingTests
         var quartetChordWithDuplicateNotes = new BaroquenChord([sopranoC4, altoC3, tenorC2, bassC1]);
         var quartetChordWithDifferingNotes = new BaroquenChord([sopranoC4, altoE3, tenorD2, bassF1]);
 
+        var soloChord = new BaroquenChord([sopranoC4]);
+
         yield return new TestCaseData(new List<BaroquenChord>(), duetChordWithDuplicateNotes, false);
 
         yield return new TestCaseData(new List<BaroquenChord>(), duetChordWithDifferingNotes, true);
@@ -57,5 +59,7 @@ internal sealed class AvoidOverDoublingTests
         yield return new TestCaseData(new List<BaroquenChord>(), quartetChordWithDuplicateNotes, false);
 
         yield return new TestCaseData(new List<BaroquenChord>(), quartetChordWithDifferingNotes, true);
+
+        yield return new TestCaseData(new List<BaroquenChord>(), soloChord, true);
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidOverDoublingTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidOverDoublingTests.cs
@@ -1,0 +1,61 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Rules;
+using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Rules;
+
+[TestFixture]
+internal sealed class AvoidOverDoublingTests
+{
+    private AvoidOverDoubling _avoidOverDoubling;
+
+    [SetUp]
+    public void SetUp() => _avoidOverDoubling = new AvoidOverDoubling();
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void Evaluate_ReturnsExpectedResult(IReadOnlyList<BaroquenChord> precedingChords, BaroquenChord nextChord, bool expectedResult)
+    {
+        var result = _avoidOverDoubling.Evaluate(precedingChords, nextChord);
+
+        result.Should().Be(expectedResult);
+    }
+
+    private static IEnumerable<TestCaseData> TestCases()
+    {
+        var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4);
+
+        var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3);
+        var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3);
+
+        var tenorC2 = new BaroquenNote(Voice.Tenor, Notes.C2);
+        var tenorD2 = new BaroquenNote(Voice.Tenor, Notes.D2);
+
+        var bassC1 = new BaroquenNote(Voice.Bass, Notes.C1);
+        var bassF1 = new BaroquenNote(Voice.Bass, Notes.F1);
+
+        var duetChordWithDuplicateNotes = new BaroquenChord([sopranoC4, altoC3]);
+        var duetChordWithDifferingNotes = new BaroquenChord([sopranoC4, altoE3]);
+
+        var trioChordWithDuplicateNotes = new BaroquenChord([sopranoC4, altoC3, tenorC2]);
+        var trioChordWithDifferingNotes = new BaroquenChord([sopranoC4, altoE3, tenorD2]);
+
+        var quartetChordWithDuplicateNotes = new BaroquenChord([sopranoC4, altoC3, tenorC2, bassC1]);
+        var quartetChordWithDifferingNotes = new BaroquenChord([sopranoC4, altoE3, tenorD2, bassF1]);
+
+        yield return new TestCaseData(new List<BaroquenChord>(), duetChordWithDuplicateNotes, false);
+
+        yield return new TestCaseData(new List<BaroquenChord>(), duetChordWithDifferingNotes, true);
+
+        yield return new TestCaseData(new List<BaroquenChord>(), trioChordWithDuplicateNotes, false);
+
+        yield return new TestCaseData(new List<BaroquenChord>(), trioChordWithDifferingNotes, true);
+
+        yield return new TestCaseData(new List<BaroquenChord>(), quartetChordWithDuplicateNotes, false);
+
+        yield return new TestCaseData(new List<BaroquenChord>(), quartetChordWithDifferingNotes, true);
+    }
+}


### PR DESCRIPTION
## Description

A new composition rule to avoid over-doubling. Ensures that there is a decent spread across different pitches within a given chord.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
