### PR TITLE
Follow Standard Chord Progressions

### DIFF
--- a/src/BaroquenMelody.Library/Compositions/Rules/AvoidOverDoubling.cs
+++ b/src/BaroquenMelody.Library/Compositions/Rules/AvoidOverDoubling.cs
@@ -1,5 +1,4 @@
 ﻿using BaroquenMelody.Library.Compositions.Domain;
-using Melanchall.DryWetMidi.MusicTheory;
 
 namespace BaroquenMelody.Library.Compositions.Rules;
 

--- a/src/BaroquenMelody.Library/Compositions/Rules/FollowsStandardProgression.cs
+++ b/src/BaroquenMelody.Library/Compositions/Rules/FollowsStandardProgression.cs
@@ -1,0 +1,76 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using Melanchall.DryWetMidi.MusicTheory;
+
+namespace BaroquenMelody.Library.Compositions.Rules;
+
+internal sealed class FollowsStandardProgression(CompositionConfiguration compositionConfiguration) : ICompositionRule
+{
+    private readonly List<(HashSet<NoteName>, HashSet<NoteName>)> _validMajorProgressions =
+    [
+        (compositionConfiguration.Scale.I, compositionConfiguration.Scale.I),
+        (compositionConfiguration.Scale.I, compositionConfiguration.Scale.II),
+        (compositionConfiguration.Scale.I, compositionConfiguration.Scale.III),
+        (compositionConfiguration.Scale.I, compositionConfiguration.Scale.IV),
+        (compositionConfiguration.Scale.I, compositionConfiguration.Scale.V),
+        (compositionConfiguration.Scale.I, compositionConfiguration.Scale.VI),
+        (compositionConfiguration.Scale.I, compositionConfiguration.Scale.VII),
+
+        (compositionConfiguration.Scale.II, compositionConfiguration.Scale.I),
+        (compositionConfiguration.Scale.II, compositionConfiguration.Scale.II),
+        (compositionConfiguration.Scale.II, compositionConfiguration.Scale.III),
+        (compositionConfiguration.Scale.II, compositionConfiguration.Scale.V),
+        (compositionConfiguration.Scale.II, compositionConfiguration.Scale.VI),
+        (compositionConfiguration.Scale.II, compositionConfiguration.Scale.VII),
+
+        (compositionConfiguration.Scale.III, compositionConfiguration.Scale.II),
+        (compositionConfiguration.Scale.III, compositionConfiguration.Scale.III),
+        (compositionConfiguration.Scale.III, compositionConfiguration.Scale.IV),
+        (compositionConfiguration.Scale.III, compositionConfiguration.Scale.VI),
+
+        (compositionConfiguration.Scale.IV, compositionConfiguration.Scale.I),
+        (compositionConfiguration.Scale.IV, compositionConfiguration.Scale.III),
+        (compositionConfiguration.Scale.IV, compositionConfiguration.Scale.IV),
+        (compositionConfiguration.Scale.IV, compositionConfiguration.Scale.V),
+        (compositionConfiguration.Scale.IV, compositionConfiguration.Scale.VII),
+
+        (compositionConfiguration.Scale.V, compositionConfiguration.Scale.I),
+        (compositionConfiguration.Scale.V, compositionConfiguration.Scale.V),
+        (compositionConfiguration.Scale.V, compositionConfiguration.Scale.VI),
+
+        (compositionConfiguration.Scale.VI, compositionConfiguration.Scale.II),
+        (compositionConfiguration.Scale.VI, compositionConfiguration.Scale.IV),
+        (compositionConfiguration.Scale.VI, compositionConfiguration.Scale.VI),
+
+        (compositionConfiguration.Scale.VII, compositionConfiguration.Scale.I),
+        (compositionConfiguration.Scale.VII, compositionConfiguration.Scale.III),
+        (compositionConfiguration.Scale.VII, compositionConfiguration.Scale.VI),
+        (compositionConfiguration.Scale.VII, compositionConfiguration.Scale.VII)
+    ];
+
+    public bool Evaluate(IReadOnlyList<BaroquenChord> precedingChords, BaroquenChord nextChord)
+    {
+        if (precedingChords.Count == 0)
+        {
+            return true;
+        }
+
+        var precedingChordNoteNames = precedingChords[^1].Notes.Select(note => note.Raw.NoteName).ToHashSet();
+        var nextChordNoteNames = nextChord.Notes.Select(note => note.Raw.NoteName).ToHashSet();
+
+        return IsValidProgression(precedingChordNoteNames, nextChordNoteNames);
+    }
+
+    private bool IsValidProgression(HashSet<NoteName> precedingChordNoteNames, HashSet<NoteName> nextChordNoteNames)
+    {
+        foreach (var (validPrecedingChordNoteNames, validNextChordNoteNames) in _validMajorProgressions)
+        {
+            if (precedingChordNoteNames.IsSubsetOf(validPrecedingChordNoteNames) && nextChordNoteNames.IsSubsetOf(validNextChordNoteNames))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -39,7 +39,7 @@ var compositionConfiguration = new CompositionConfiguration(
         new(Voice.Bass, Notes.G0, Notes.C2)
     },
     phrasingConfiguration,
-    BaroquenScale.Parse("C Major"),
+    BaroquenScale.Parse("D Dorian"),
     Meter.FourFour,
     25
 );
@@ -54,7 +54,8 @@ var compositionRule = new AggregateCompositionRule(
         new AvoidParallelIntervals(Interval.PerfectFifth),
         new AvoidParallelIntervals(Interval.PerfectFourth),
         new AvoidParallelIntervals(Interval.Unison),
-        new AvoidOverDoubling()
+        new AvoidOverDoubling(),
+        new FollowsStandardProgression(compositionConfiguration)
     ]
 );
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/FollowsStandardProgressionTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/FollowsStandardProgressionTests.cs
@@ -1,0 +1,186 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Rules;
+using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Rules;
+
+[TestFixture]
+internal sealed class FollowsStandardProgressionTests
+{
+    private FollowsStandardProgression _followsStandardProgression = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var compositionConfiguration = new CompositionConfiguration(
+            new HashSet<VoiceConfiguration>
+            {
+                new(Voice.Soprano, Notes.C3, Notes.G6),
+                new(Voice.Alto, Notes.C2, Notes.G5),
+                new(Voice.Tenor, Notes.C1, Notes.G4)
+            },
+            BaroquenScale.Parse("C Major"),
+            Meter.FourFour,
+            CompositionLength: 100
+        );
+
+        _followsStandardProgression = new FollowsStandardProgression(compositionConfiguration);
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void Evaluate_ReturnsExpectedResult(IReadOnlyList<BaroquenChord> precedingChords, BaroquenChord nextChord, bool expectedResult) =>
+        _followsStandardProgression.Evaluate(precedingChords, nextChord).Should().Be(expectedResult);
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4);
+            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3);
+            var tenorG2 = new BaroquenNote(Voice.Tenor, Notes.G2);
+
+            var i = new BaroquenChord([sopranoC4, altoE3, tenorG2]);
+
+            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4);
+            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3);
+            var tenorA2 = new BaroquenNote(Voice.Tenor, Notes.A2);
+
+            var ii = new BaroquenChord([sopranoD4, altoF3, tenorA2]);
+
+            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4);
+            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3);
+            var tenorB2 = new BaroquenNote(Voice.Tenor, Notes.B2);
+
+            var iii = new BaroquenChord([sopranoE4, altoG3, tenorB2]);
+
+            var sopranoF4 = new BaroquenNote(Voice.Soprano, Notes.F4);
+            var altoA3 = new BaroquenNote(Voice.Alto, Notes.A3);
+            var tenorC3 = new BaroquenNote(Voice.Tenor, Notes.C3);
+
+            var iv = new BaroquenChord([sopranoF4, altoA3, tenorC3]);
+
+            var sopranoG4 = new BaroquenNote(Voice.Soprano, Notes.G4);
+            var altoB3 = new BaroquenNote(Voice.Alto, Notes.B3);
+            var tenorD3 = new BaroquenNote(Voice.Tenor, Notes.D3);
+
+            var v = new BaroquenChord([sopranoG4, altoB3, tenorD3]);
+
+            var sopranoA4 = new BaroquenNote(Voice.Soprano, Notes.A4);
+            var altoC4 = new BaroquenNote(Voice.Alto, Notes.C4);
+            var tenorE3 = new BaroquenNote(Voice.Tenor, Notes.E3);
+
+            var vi = new BaroquenChord([sopranoA4, altoC4, tenorE3]);
+
+            var sopranoB4 = new BaroquenNote(Voice.Soprano, Notes.B4);
+            var altoD4 = new BaroquenNote(Voice.Alto, Notes.D4);
+            var tenorF3 = new BaroquenNote(Voice.Tenor, Notes.F3);
+
+            var vii = new BaroquenChord([sopranoB4, altoD4, tenorF3]);
+
+            yield return new TestCaseData(new List<BaroquenChord>(), i, true).SetName("First chord is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { i }, i, true).SetName("I -> I is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { i }, ii, true).SetName("I -> II is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { i }, iii, true).SetName("I -> III is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { i }, iv, true).SetName("I -> IV is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { i }, v, true).SetName("I -> V is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { i }, vi, true).SetName("I -> VI is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { i }, vii, true).SetName("I -> VII is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { ii }, i, true).SetName("II -> I is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { ii }, ii, true).SetName("II -> II is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { ii }, iii, true).SetName("II -> III is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { ii }, v, true).SetName("II -> V is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { ii }, vi, true).SetName("II -> VI is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { ii }, vii, true).SetName("II -> VII is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { iii }, ii, true).SetName("III -> II is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { iii }, iii, true).SetName("III -> III is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { iii }, iv, true).SetName("III -> IV is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { iii }, vi, true).SetName("III -> VI is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { iv }, i, true).SetName("IV -> I is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { iv }, iii, true).SetName("IV -> III is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { iv }, iv, true).SetName("IV -> IV is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { iv }, v, true).SetName("IV -> V is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { iv }, vii, true).SetName("IV -> VII is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { v }, i, true).SetName("V -> I is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { v }, v, true).SetName("V -> V is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { v }, vi, true).SetName("V -> VI is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { vi }, ii, true).SetName("VI -> II is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { vi }, iv, true).SetName("VI -> IV is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { vi }, vi, true).SetName("VI -> VI is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { vii }, i, true).SetName("VII -> I is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { vii }, iii, true).SetName("VII -> III is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { vii }, vi, true).SetName("VII -> VI is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { vii }, vii, true).SetName("VII -> VII is always valid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { ii }, iv, false).SetName("II -> IV is invalid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { iii }, i, false).SetName("III -> I is invalid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { iii }, v, false).SetName("III -> V is invalid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { iii }, vii, false).SetName("III -> VII is invalid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { iv }, ii, false).SetName("IV -> II is invalid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { iv }, vi, false).SetName("IV -> VI is invalid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { v }, ii, false).SetName("V -> II is invalid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { v }, iii, false).SetName("V -> III is invalid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { v }, iv, false).SetName("V -> IV is invalid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { v }, vii, false).SetName("V -> VII is invalid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { vi }, i, false).SetName("VI -> I is invalid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { vi }, iii, false).SetName("VI -> III is invalid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { vi }, v, false).SetName("VI -> V is invalid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { vi }, vii, false).SetName("VI -> VII is invalid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { vii }, ii, false).SetName("VII -> II is invalid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { vii }, iv, false).SetName("VII -> IV is invalid.");
+
+            yield return new TestCaseData(new List<BaroquenChord> { vii }, v, false).SetName("VII -> V is invalid.");
+        }
+    }
+}


### PR DESCRIPTION
## Description

A new composition rule to ensure that the composition follows standard chord progressions.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
