### PR TITLE
Avoid Direct Perfects

### DIFF
--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Policies/Input/WantsToOrnament.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Policies/Input/WantsToOrnament.cs
@@ -4,7 +4,7 @@ using BaroquenMelody.Library.Infrastructure.Random;
 namespace BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies.Input;
 
 /// <inheritdoc cref="IInputPolicy{T}"/>
-internal sealed class WantsToOrnament(int Probability = 66) : IInputPolicy<OrnamentationItem>
+internal sealed class WantsToOrnament(int Probability = 75) : IInputPolicy<OrnamentationItem>
 {
     public InputPolicyResult ShouldProcess(OrnamentationItem item) => WeightedRandomBooleanGenerator.Generate(Probability) ? InputPolicyResult.Continue : InputPolicyResult.Reject;
 }

--- a/src/BaroquenMelody.Library/Compositions/Rules/AvoidDirectIntervals.cs
+++ b/src/BaroquenMelody.Library/Compositions/Rules/AvoidDirectIntervals.cs
@@ -1,0 +1,61 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Enums.Extensions;
+using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
+using BaroquenMelody.Library.Compositions.MusicTheory.Enums.Extensions;
+using LazyCart;
+
+namespace BaroquenMelody.Library.Compositions.Rules;
+
+internal sealed class AvoidDirectIntervals(Interval targetInterval) : ICompositionRule
+{
+    public bool Evaluate(IReadOnlyList<BaroquenChord> precedingChords, BaroquenChord nextChord)
+    {
+        if (precedingChords.Count == 0)
+        {
+            return true;
+        }
+
+        var voices = nextChord.Notes.Select(note => note.Voice).ToArray();
+        var voiceCombos = new LazyCartesianProduct<Voice, Voice>(voices, voices);
+        var precedingChord = precedingChords[^1];
+
+        for (var i = 0; i < voiceCombos.Size; ++i)
+        {
+            var (voiceA, voiceB) = voiceCombos[i];
+
+            if (voiceA == voiceB)
+            {
+                continue;
+            }
+
+            if (HaveTargetInterval(nextChord, voiceA, voiceB, targetInterval) && HaveSameMotion(precedingChord, nextChord, voiceA, voiceB))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool HaveTargetInterval(BaroquenChord nextChord, Voice voiceA, Voice voiceB, Interval targetInterval)
+    {
+        var nextNoteA = nextChord[voiceA];
+        var nextNoteB = nextChord[voiceB];
+
+        return IntervalExtensions.FromNotes(nextNoteA, nextNoteB) == targetInterval;
+    }
+
+    private static bool HaveSameMotion(BaroquenChord precedingChord, BaroquenChord nextChord, Voice voiceA, Voice voiceB)
+    {
+        var lastNoteA = precedingChord[voiceA];
+        var lastNoteB = precedingChord[voiceB];
+        var nextNoteA = nextChord[voiceA];
+        var nextNoteB = nextChord[voiceB];
+
+        var noteMotionA = NoteMotionExtensions.FromNotes(lastNoteA, nextNoteA);
+        var noteMotionB = NoteMotionExtensions.FromNotes(lastNoteB, nextNoteB);
+
+        return noteMotionA != NoteMotion.Oblique && noteMotionB != NoteMotion.Oblique && noteMotionA == noteMotionB;
+    }
+}

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -39,7 +39,7 @@ var compositionConfiguration = new CompositionConfiguration(
         new(Voice.Bass, Notes.G0, Notes.C2)
     },
     phrasingConfiguration,
-    BaroquenScale.Parse("D Dorian"),
+    BaroquenScale.Parse("C Major"),
     Meter.FourFour,
     25
 );
@@ -55,7 +55,10 @@ var compositionRule = new AggregateCompositionRule(
         new AvoidParallelIntervals(Interval.PerfectFourth),
         new AvoidParallelIntervals(Interval.Unison),
         new AvoidOverDoubling(),
-        new FollowsStandardProgression(compositionConfiguration)
+        new FollowsStandardProgression(compositionConfiguration),
+        new AvoidDirectIntervals(Interval.PerfectFifth),
+        new AvoidDirectIntervals(Interval.PerfectFourth),
+        new AvoidDirectIntervals(Interval.Unison)
     ]
 );
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidDirectIntervalsTest.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidDirectIntervalsTest.cs
@@ -1,0 +1,72 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Rules;
+using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+using Interval = BaroquenMelody.Library.Compositions.MusicTheory.Enums.Interval;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Rules;
+
+[TestFixture]
+internal sealed class AvoidDirectIntervalsTest
+{
+    private AvoidDirectIntervals _avoidDirectIntervals = null!;
+
+    [SetUp]
+    public void SetUp() => _avoidDirectIntervals = new AvoidDirectIntervals(Interval.PerfectFifth);
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void Evaluate_ReturnsExpectedResult(IReadOnlyList<BaroquenChord> precedingChords, BaroquenChord nextChord, bool expectedResult)
+    {
+        // act
+        var result = _avoidDirectIntervals.Evaluate(precedingChords, nextChord);
+
+        // assert
+        result.Should().Be(expectedResult);
+    }
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4);
+            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4);
+
+            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3);
+            var altoA3 = new BaroquenNote(Voice.Alto, Notes.A3);
+            var altoA2 = new BaroquenNote(Voice.Alto, Notes.A2);
+
+            yield return new TestCaseData(
+                new List<BaroquenChord>(),
+                new BaroquenChord([sopranoC4, altoF3]),
+                true
+            ).SetName("If it's the first chord, no direct interval.");
+
+            yield return new TestCaseData(
+                new List<BaroquenChord> { new([sopranoC4, altoF3]) },
+                new BaroquenChord([sopranoD4, altoA2]),
+                true
+            ).SetName("No direct interval if moving in different directions.");
+
+            yield return new TestCaseData(
+                new List<BaroquenChord> { new([sopranoC4, altoF3]) },
+                new BaroquenChord([sopranoC4, altoF3]),
+                true
+            ).SetName("No direct interval if repeated.");
+
+            yield return new TestCaseData(
+                new List<BaroquenChord> { new([sopranoD4, altoF3]) },
+                new BaroquenChord([sopranoC4, altoA2]),
+                true
+            ).SetName("No direct interval moving to a different interval than specified.");
+
+            yield return new TestCaseData(
+                new List<BaroquenChord> { new([sopranoC4, altoF3]) },
+                new BaroquenChord([sopranoD4, altoA3]),
+                false
+            ).SetName("Direct interval if moving in the same direction to the interval.");
+        }
+    }
+}


### PR DESCRIPTION
## Description

A new composition rule to avoid direct perfect interval motion.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
