### PR TITLE
Fugue Proof of Concept

### DIFF
--- a/src/BaroquenMelody.Library/Compositions/Extensions/BaroquenChordExtensions.cs
+++ b/src/BaroquenMelody.Library/Compositions/Extensions/BaroquenChordExtensions.cs
@@ -10,7 +10,7 @@ internal static class BaroquenChordExtensions
 {
     public static BaroquenChord ApplyChordChoice(this BaroquenChord chord, BaroquenScale scale, ChordChoice chordChoice) => new(
         (
-            from noteChoice in chordChoice.NoteChoices
+            from noteChoice in chordChoice.NoteChoices.Where(noteChoice => chord.Notes.Exists(note => note.Voice == noteChoice.Voice))
             let voice = noteChoice.Voice
             let note = chord[voice]
             select note.ApplyNoteChoice(scale, noteChoice)

--- a/src/BaroquenMelody.Library/Compositions/MusicTheory/INoteTransposer.cs
+++ b/src/BaroquenMelody.Library/Compositions/MusicTheory/INoteTransposer.cs
@@ -3,7 +3,17 @@ using BaroquenMelody.Library.Compositions.Enums;
 
 namespace BaroquenMelody.Library.Compositions.MusicTheory;
 
+/// <summary>
+///     Represents a transposer that can transpose notes to different voices.
+/// </summary>
 internal interface INoteTransposer
 {
-    IEnumerable<BaroquenNote> TransposeToVoice(IEnumerable<BaroquenNote> notesToTranspose, Voice oldVoice, Voice newVoice);
+    /// <summary>
+    ///     Transposes the given notes to the specified voice.
+    /// </summary>
+    /// <param name="notesToTranspose">The notes to transpose.</param>
+    /// <param name="currentVoice">The current voice of the notes.</param>
+    /// <param name="targetVoice">The target voice to transpose the notes to.</param>
+    /// <returns>The transposed notes.</returns>
+    IEnumerable<BaroquenNote> TransposeToVoice(IEnumerable<BaroquenNote> notesToTranspose, Voice currentVoice, Voice targetVoice);
 }

--- a/src/BaroquenMelody.Library/Compositions/MusicTheory/INoteTransposer.cs
+++ b/src/BaroquenMelody.Library/Compositions/MusicTheory/INoteTransposer.cs
@@ -1,0 +1,9 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+
+namespace BaroquenMelody.Library.Compositions.MusicTheory;
+
+internal interface INoteTransposer
+{
+    IEnumerable<BaroquenNote> TransposeToVoice(IEnumerable<BaroquenNote> notesToTranspose, Voice oldVoice, Voice newVoice);
+}

--- a/src/BaroquenMelody.Library/Compositions/MusicTheory/NoteTransposer.cs
+++ b/src/BaroquenMelody.Library/Compositions/MusicTheory/NoteTransposer.cs
@@ -6,58 +6,58 @@ namespace BaroquenMelody.Library.Compositions.MusicTheory;
 
 internal sealed class NoteTransposer(CompositionConfiguration compositionConfiguration) : INoteTransposer
 {
-    public IEnumerable<BaroquenNote> TransposeToVoice(IEnumerable<BaroquenNote> notesToTranspose, Voice oldVoice, Voice newVoice)
+    public IEnumerable<BaroquenNote> TransposeToVoice(IEnumerable<BaroquenNote> notesToTranspose, Voice currentVoice, Voice targetVoice)
     {
-        var oldVoiceConfiguration = compositionConfiguration.VoiceConfigurationsByVoice[oldVoice];
-        var newVoiceConfiguration = compositionConfiguration.VoiceConfigurationsByVoice[newVoice];
+        var currentVoiceConfiguration = compositionConfiguration.VoiceConfigurationsByVoice[currentVoice];
+        var targetVoiceConfiguration = compositionConfiguration.VoiceConfigurationsByVoice[targetVoice];
 
         var notes = compositionConfiguration.Scale.GetNotes();
 
-        var oldVoiceMin = notes.IndexOf(oldVoiceConfiguration.MinNote);
-        var oldVoiceMax = notes.IndexOf(oldVoiceConfiguration.MaxNote);
-        var newVoiceMin = notes.IndexOf(newVoiceConfiguration.MinNote);
-        var newVoiceMax = notes.IndexOf(newVoiceConfiguration.MaxNote);
+        var currentVoiceMinNoteIndex = notes.IndexOf(currentVoiceConfiguration.MinNote);
+        var currentVoiceMaxNoteIndex = notes.IndexOf(currentVoiceConfiguration.MaxNote);
+        var targetVoiceMinNoteIndex = notes.IndexOf(targetVoiceConfiguration.MinNote);
+        var targetVoiceMaxNoteIndex = notes.IndexOf(targetVoiceConfiguration.MaxNote);
 
-        var result = new List<BaroquenNote>();
+        var transposedNotes = new List<BaroquenNote>();
 
-        foreach (var note in notesToTranspose)
+        foreach (var noteToTranspose in notesToTranspose)
         {
-            var noteIndex = notes.IndexOf(note.Raw);
-            var newNoteIndex = Transpose(oldVoiceMin, oldVoiceMax, newVoiceMin, newVoiceMax, noteIndex);
+            var noteToTransposeNoteIndex = notes.IndexOf(noteToTranspose.Raw);
+            var transposedNoteIndex = Transpose(currentVoiceMinNoteIndex, currentVoiceMaxNoteIndex, targetVoiceMinNoteIndex, targetVoiceMaxNoteIndex, noteToTransposeNoteIndex);
 
-            var newNote = new BaroquenNote(newVoice, notes[newNoteIndex])
+            var transposedNote = new BaroquenNote(targetVoice, notes[transposedNoteIndex])
             {
-                OrnamentationType = note.OrnamentationType,
-                Duration = note.Duration
+                OrnamentationType = noteToTranspose.OrnamentationType,
+                Duration = noteToTranspose.Duration
             };
 
-            foreach (var ornamentedNote in note.Ornamentations)
+            foreach (var ornamentedNote in noteToTranspose.Ornamentations)
             {
                 var ornamentedNoteIndex = notes.IndexOf(ornamentedNote.Raw);
-                var newOrnamentedNoteIndex = Transpose(oldVoiceMin, oldVoiceMax, newVoiceMin, newVoiceMax, ornamentedNoteIndex);
+                var transposedOrnamentedNoteIndex = Transpose(currentVoiceMinNoteIndex, currentVoiceMaxNoteIndex, targetVoiceMinNoteIndex, targetVoiceMaxNoteIndex, ornamentedNoteIndex);
 
-                var newOrnamentedNote = new BaroquenNote(newVoice, notes[newOrnamentedNoteIndex])
+                var newOrnamentedNote = new BaroquenNote(targetVoice, notes[transposedOrnamentedNoteIndex])
                 {
                     OrnamentationType = ornamentedNote.OrnamentationType,
                     Duration = ornamentedNote.Duration
                 };
 
-                newNote.Ornamentations.Add(newOrnamentedNote);
+                transposedNote.Ornamentations.Add(newOrnamentedNote);
             }
 
-            result.Add(newNote);
+            transposedNotes.Add(transposedNote);
         }
 
-        return result;
+        return transposedNotes;
     }
 
-    public static int Transpose(int oldMin, int oldMax, int newMin, int newMax, int numberToTranspose)
+    public static int Transpose(int currentMin, int currentMax, int targetMin, int targetMax, int noteIndexToTranspose)
     {
-        var oldMiddle = (oldMin + oldMax) / 2.0;
-        var newMiddle = (newMin + newMax) / 2.0;
+        var oldMiddle = (currentMin + currentMax) / 2.0;
+        var newMiddle = (targetMin + targetMax) / 2.0;
 
         var middleDifference = (int)Math.Round(newMiddle - oldMiddle, MidpointRounding.ToZero);
 
-        return numberToTranspose + middleDifference;
+        return noteIndexToTranspose + middleDifference;
     }
 }

--- a/src/BaroquenMelody.Library/Compositions/MusicTheory/NoteTransposer.cs
+++ b/src/BaroquenMelody.Library/Compositions/MusicTheory/NoteTransposer.cs
@@ -1,0 +1,63 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+
+namespace BaroquenMelody.Library.Compositions.MusicTheory;
+
+internal sealed class NoteTransposer(CompositionConfiguration compositionConfiguration) : INoteTransposer
+{
+    public IEnumerable<BaroquenNote> TransposeToVoice(IEnumerable<BaroquenNote> notesToTranspose, Voice oldVoice, Voice newVoice)
+    {
+        var oldVoiceConfiguration = compositionConfiguration.VoiceConfigurationsByVoice[oldVoice];
+        var newVoiceConfiguration = compositionConfiguration.VoiceConfigurationsByVoice[newVoice];
+
+        var notes = compositionConfiguration.Scale.GetNotes();
+
+        var oldVoiceMin = notes.IndexOf(oldVoiceConfiguration.MinNote);
+        var oldVoiceMax = notes.IndexOf(oldVoiceConfiguration.MaxNote);
+        var newVoiceMin = notes.IndexOf(newVoiceConfiguration.MinNote);
+        var newVoiceMax = notes.IndexOf(newVoiceConfiguration.MaxNote);
+
+        var result = new List<BaroquenNote>();
+
+        foreach (var note in notesToTranspose)
+        {
+            var noteIndex = notes.IndexOf(note.Raw);
+            var newNoteIndex = Transpose(oldVoiceMin, oldVoiceMax, newVoiceMin, newVoiceMax, noteIndex);
+
+            var newNote = new BaroquenNote(newVoice, notes[newNoteIndex])
+            {
+                OrnamentationType = note.OrnamentationType,
+                Duration = note.Duration
+            };
+
+            foreach (var ornamentedNote in note.Ornamentations)
+            {
+                var ornamentedNoteIndex = notes.IndexOf(ornamentedNote.Raw);
+                var newOrnamentedNoteIndex = Transpose(oldVoiceMin, oldVoiceMax, newVoiceMin, newVoiceMax, ornamentedNoteIndex);
+
+                var newOrnamentedNote = new BaroquenNote(newVoice, notes[newOrnamentedNoteIndex])
+                {
+                    OrnamentationType = ornamentedNote.OrnamentationType,
+                    Duration = ornamentedNote.Duration
+                };
+
+                newNote.Ornamentations.Add(newOrnamentedNote);
+            }
+
+            result.Add(newNote);
+        }
+
+        return result;
+    }
+
+    public static int Transpose(int oldMin, int oldMax, int newMin, int newMax, int numberToTranspose)
+    {
+        var oldMiddle = (oldMin + oldMax) / 2.0;
+        var newMiddle = (newMin + newMax) / 2.0;
+
+        var middleDifference = (int)Math.Round(newMiddle - oldMiddle, MidpointRounding.ToZero);
+
+        return numberToTranspose + middleDifference;
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/OrnamentationEngineBuilder.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/OrnamentationEngineBuilder.cs
@@ -112,7 +112,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
 
     private IPolicyEngine<OrnamentationItem> BuildDelayedThirtySecondNoteRunEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(10),
+            new WantsToOrnament(15),
             new NoteHasNoOrnamentation(),
             new IsApplicableInterval(compositionConfiguration, DelayedThirtySecondNoteRunProcessor.Interval)
         )
@@ -122,7 +122,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
 
     private IPolicyEngine<OrnamentationItem> BuildDoubleTurnEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(25),
+            new WantsToOrnament(30),
             new NoteHasNoOrnamentation(),
             new IsApplicableInterval(compositionConfiguration, DoubleTurnProcessor.Interval)
         )
@@ -153,7 +153,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
     private IPolicyEngine<OrnamentationItem> BuildDecorateDominantSeventhIntervalEngine(NoteName targetNote, int intervalChange) => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
             new HasNextBeat(),
-            new WantsToOrnament(25),
+            new WantsToOrnament(30),
             new NoteHasNoOrnamentation(),
             new NoteIsTargetNote(targetNote),
             new BeatContainsTargetNotes([compositionConfiguration.Scale.Dominant, compositionConfiguration.Scale.LeadingTone, compositionConfiguration.Scale.Supertonic]),
@@ -167,7 +167,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
 
     private IPolicyEngine<OrnamentationItem> BuildDoubleThirtySecondNoteRunProcessor() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(10),
+            new WantsToOrnament(15),
             new NoteHasNoOrnamentation(),
             new IsApplicableInterval(compositionConfiguration, ThirtySecondNoteRunProcessor.Interval)
         )
@@ -190,7 +190,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
 
     private IPolicyEngine<OrnamentationItem> BuildMordentProcessor() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(5),
+            new WantsToOrnament(1),
             new NoteHasNoOrnamentation(),
             new Not<OrnamentationItem>(new BeatContainsTargetOrnamentation(OrnamentationType.Mordent)),
             new IsIntervalWithinVoiceRange(compositionConfiguration, 1).And(new IsIntervalWithinVoiceRange(compositionConfiguration, -1))

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Policies/Input/WantsToOrnament.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Policies/Input/WantsToOrnament.cs
@@ -4,7 +4,7 @@ using BaroquenMelody.Library.Infrastructure.Random;
 namespace BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies.Input;
 
 /// <inheritdoc cref="IInputPolicy{T}"/>
-internal sealed class WantsToOrnament(int Probability = 75) : IInputPolicy<OrnamentationItem>
+internal sealed class WantsToOrnament(int Probability = 80) : IInputPolicy<OrnamentationItem>
 {
     public InputPolicyResult ShouldProcess(OrnamentationItem item) => WeightedRandomBooleanGenerator.Generate(Probability) ? InputPolicyResult.Continue : InputPolicyResult.Reject;
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/SustainedNoteProcessor.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/SustainedNoteProcessor.cs
@@ -16,9 +16,9 @@ internal sealed class SustainedNoteProcessor(IMusicalTimeSpanCalculator musicalT
         var nextNote = item.NextBeat![item.Voice];
 
         currentNote.Duration = musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.Sustain, configuration.Meter);
-        nextNote.Duration = musicalTimeSpanCalculator.CalculateOrnamentationTimeSpan(OrnamentationType.Rest, configuration.Meter);
+        nextNote.Duration = musicalTimeSpanCalculator.CalculateOrnamentationTimeSpan(OrnamentationType.MidSustain, configuration.Meter);
 
         currentNote.OrnamentationType = OrnamentationType.Sustain;
-        nextNote.OrnamentationType = OrnamentationType.Rest;
+        nextNote.OrnamentationType = OrnamentationType.MidSustain;
     }
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Enums/OrnamentationType.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Enums/OrnamentationType.cs
@@ -40,7 +40,7 @@ internal enum OrnamentationType : byte
     /// <summary>
     ///     A rest over multiple beats.
     /// </summary>
-    Rest,
+    MidSustain,
 
     /// <summary>
     ///     A delayed thirty-second note run between two notes.
@@ -80,5 +80,10 @@ internal enum OrnamentationType : byte
     /// <summary>
     ///     A mordent accentuating a note.
     /// </summary>
-    Mordent
+    Mordent,
+
+    /// <summary>
+    ///     A rest.
+    /// </summary>
+    Rest
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Enums/OrnamentationType.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Enums/OrnamentationType.cs
@@ -38,7 +38,7 @@ internal enum OrnamentationType : byte
     Sustain,
 
     /// <summary>
-    ///     A rest over multiple beats.
+    ///     A note that is part of another sustained note.
     /// </summary>
     MidSustain,
 

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/ICompositionDecorator.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/ICompositionDecorator.cs
@@ -1,4 +1,5 @@
 ﻿using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
 
 namespace BaroquenMelody.Library.Compositions.Ornamentation;
 
@@ -12,6 +13,13 @@ internal interface ICompositionDecorator
     /// </summary>
     /// <param name="composition">The composition to decorate.</param>
     void Decorate(Composition composition);
+
+    /// <summary>
+    ///     Decorate the given voice in the composition.
+    /// </summary>
+    /// <param name="composition">The composition to decorate.</param>
+    /// <param name="voice">The voice to decorate.</param>
+    void Decorate(Composition composition, Voice voice);
 
     /// <summary>
     ///    Apply sustain to the composition by identifying repeated notes and extending their duration.

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculator.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculator.cs
@@ -26,7 +26,7 @@ internal sealed class MusicalTimeSpanCalculator : IMusicalTimeSpanCalculator
         OrnamentationType.ThirtySecondNoteRun when meter == Meter.FourFour => MusicalTimeSpan.ThirtySecond,
         OrnamentationType.Pedal when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
         OrnamentationType.Mordent when meter == Meter.FourFour => MusicalTimeSpan.ThirtySecond,
-        OrnamentationType.Rest => Zero,
+        OrnamentationType.MidSustain => Zero,
         _ => throw new ArgumentOutOfRangeException(nameof(ornamentationType), ornamentationType, $"Invalid {nameof(OrnamentationType)}")
     };
 
@@ -48,7 +48,7 @@ internal sealed class MusicalTimeSpanCalculator : IMusicalTimeSpanCalculator
         OrnamentationType.Pedal when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
         OrnamentationType.Mordent when meter == Meter.FourFour && ornamentationStep == 1 => MusicalTimeSpan.ThirtySecond,
         OrnamentationType.Mordent when meter == Meter.FourFour && ornamentationStep == 2 => MusicalTimeSpan.Eighth.Dotted(1),
-        OrnamentationType.Rest => Zero,
+        OrnamentationType.MidSustain => Zero,
         _ => throw new ArgumentOutOfRangeException(nameof(ornamentationType), ornamentationType, $"Invalid {nameof(OrnamentationType)}")
     };
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculator.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculator.cs
@@ -27,6 +27,7 @@ internal sealed class MusicalTimeSpanCalculator : IMusicalTimeSpanCalculator
         OrnamentationType.Pedal when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
         OrnamentationType.Mordent when meter == Meter.FourFour => MusicalTimeSpan.ThirtySecond,
         OrnamentationType.MidSustain => Zero,
+        OrnamentationType.Rest => Zero,
         _ => throw new ArgumentOutOfRangeException(nameof(ornamentationType), ornamentationType, $"Invalid {nameof(OrnamentationType)}")
     };
 
@@ -49,6 +50,7 @@ internal sealed class MusicalTimeSpanCalculator : IMusicalTimeSpanCalculator
         OrnamentationType.Mordent when meter == Meter.FourFour && ornamentationStep == 1 => MusicalTimeSpan.ThirtySecond,
         OrnamentationType.Mordent when meter == Meter.FourFour && ornamentationStep == 2 => MusicalTimeSpan.Eighth.Dotted(1),
         OrnamentationType.MidSustain => Zero,
+        OrnamentationType.Rest => Zero,
         _ => throw new ArgumentOutOfRangeException(nameof(ornamentationType), ornamentationType, $"Invalid {nameof(OrnamentationType)}")
     };
 }

--- a/src/BaroquenMelody.Library/Compositions/Phrasing/CompositionPhraser.cs
+++ b/src/BaroquenMelody.Library/Compositions/Phrasing/CompositionPhraser.cs
@@ -91,7 +91,7 @@ internal sealed class CompositionPhraser(ICompositionRule compositionRule, Compo
     /// <param name="measure">The measure to reset the ornamentation on.</param>
     private static void ResetPhraseEndOrnamentation(Measure measure)
     {
-        foreach (var note in measure.Beats.Last().Chord.Notes.Where(note => note.OrnamentationType != OrnamentationType.Rest))
+        foreach (var note in measure.Beats.Last().Chord.Notes.Where(note => note.OrnamentationType != OrnamentationType.MidSustain))
         {
             note.ResetOrnamentation();
         }

--- a/src/BaroquenMelody.Library/Compositions/Strategies/CompositionStrategy.cs
+++ b/src/BaroquenMelody.Library/Compositions/Strategies/CompositionStrategy.cs
@@ -33,6 +33,18 @@ internal sealed class CompositionStrategy(
         .Select(chordChoiceAndChord => chordChoiceAndChord.ChordChoice)
         .ToList();
 
+    public IReadOnlyList<BaroquenChord> GetPossibleChordsForPartiallyVoicedChords(IReadOnlyList<BaroquenChord> precedingChords, BaroquenChord nextChord)
+    {
+        var currentChord = precedingChords[^1];
+        var nextChordVoices = nextChord.Notes.Select(note => note.Voice).ToList();
+        var possibleChordChoices = GetPossibleChordChoices(precedingChords);
+
+        return possibleChordChoices
+            .Select(chordChoice => currentChord.ApplyChordChoice(compositionConfiguration.Scale, chordChoice))
+            .Where(possibleChord => nextChordVoices.TrueForAll(voice => possibleChord[voice].Raw == nextChord[voice].Raw))
+            .ToList();
+    }
+
     public BaroquenChord GenerateInitialChord()
     {
         var startingNoteCounts = validStartingNoteNames.ToDictionary(noteName => noteName, _ => 0);

--- a/src/BaroquenMelody.Library/Compositions/Strategies/ICompositionStrategy.cs
+++ b/src/BaroquenMelody.Library/Compositions/Strategies/ICompositionStrategy.cs
@@ -1,5 +1,7 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
 using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using System.Collections.Generic;
 
 namespace BaroquenMelody.Library.Compositions.Strategies;
 
@@ -20,4 +22,9 @@ internal interface ICompositionStrategy
     /// <param name="precedingChords">The chords which precede the proposed next chord.</param>
     /// <returns>The possible chord choices for the given preceding chords.</returns>
     public IReadOnlyList<ChordChoice> GetPossibleChordChoices(IReadOnlyList<BaroquenChord> precedingChords);
+
+    public IReadOnlyList<BaroquenChord> GetPossibleChordsForPartiallyVoicedChords(
+        IReadOnlyList<BaroquenChord> precedingChords,
+        BaroquenChord nextChord
+    );
 }

--- a/src/BaroquenMelody.Library/Compositions/Strategies/ICompositionStrategy.cs
+++ b/src/BaroquenMelody.Library/Compositions/Strategies/ICompositionStrategy.cs
@@ -1,7 +1,5 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
 using BaroquenMelody.Library.Compositions.Domain;
-using BaroquenMelody.Library.Compositions.Enums;
-using System.Collections.Generic;
 
 namespace BaroquenMelody.Library.Compositions.Strategies;
 

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -40,7 +40,7 @@ var compositionConfiguration = new CompositionConfiguration(
         new(Voice.Bass, Notes.C0, Notes.G1)
     },
     phrasingConfiguration,
-    BaroquenScale.Parse("C Minor"),
+    BaroquenScale.Parse("D Dorian"),
     Meter.FourFour,
     25
 );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ComposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ComposerTests.cs
@@ -4,6 +4,7 @@ using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Enums.Extensions;
+using BaroquenMelody.Library.Compositions.MusicTheory;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Phrasing;
 using BaroquenMelody.Library.Compositions.Strategies;
@@ -29,6 +30,8 @@ internal sealed class ComposerTests
 
     private ICompositionPhraser _mockCompositionPhraser = null!;
 
+    private INoteTransposer _noteTransposer = null!;
+
     private CompositionConfiguration _compositionConfiguration = null!;
 
     private Composer _composer = null!;
@@ -51,7 +54,9 @@ internal sealed class ComposerTests
             CompositionLength: 100
         );
 
-        _composer = new Composer(_mockCompositionStrategy, _mockCompositionDecorator, _mockCompositionPhraser, _compositionConfiguration);
+        _noteTransposer = new NoteTransposer(_compositionConfiguration);
+
+        _composer = new Composer(_mockCompositionStrategy, _mockCompositionDecorator, _mockCompositionPhraser, _noteTransposer, _compositionConfiguration);
     }
 
     [Test]
@@ -59,34 +64,36 @@ internal sealed class ComposerTests
     {
         // arrange
         _mockCompositionStrategy.GenerateInitialChord().Returns(
-            new BaroquenChord(
-                [
-                    new BaroquenNote(Voice.Soprano, MinSopranoNote),
-                    new BaroquenNote(Voice.Alto, MinAltoNote)
-                ]
-            )
+            new BaroquenChord([
+                new BaroquenNote(Voice.Soprano, MinSopranoNote),
+                new BaroquenNote(Voice.Alto, MinAltoNote)
+            ])
         );
 
         _mockCompositionStrategy
             .GetPossibleChordChoices(Arg.Any<IReadOnlyList<BaroquenChord>>())
-            .Returns(
-                new List<ChordChoice>
-                {
-                    new(
-                        [
-                            new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0),
-                            new NoteChoice(Voice.Alto, NoteMotion.Oblique, 0)
-                        ]
-                    )
-                }
-            );
+            .Returns([
+                new ChordChoice([
+                    new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0),
+                    new NoteChoice(Voice.Alto, NoteMotion.Oblique, 0)
+                ])
+            ]);
+
+        _mockCompositionStrategy
+            .GetPossibleChordsForPartiallyVoicedChords(Arg.Any<IReadOnlyList<BaroquenChord>>(), Arg.Any<BaroquenChord>())
+            .Returns([
+                new BaroquenChord([
+                    new BaroquenNote(Voice.Soprano, MinSopranoNote),
+                    new BaroquenNote(Voice.Alto, MinAltoNote)
+                ])
+            ]);
 
         // act
         var composition = _composer.Compose();
 
         // assert
         composition.Should().NotBeNull();
-        composition.Measures.Should().HaveCount(_compositionConfiguration.CompositionLength);
+        composition.Measures.Should().HaveCountGreaterOrEqualTo(_compositionConfiguration.CompositionLength);
 
         foreach (var measure in composition.Measures)
         {
@@ -96,9 +103,9 @@ internal sealed class ComposerTests
         _mockCompositionStrategy.Received(1).GenerateInitialChord();
 
         _mockCompositionStrategy
-            .Received(_compositionConfiguration.CompositionLength * _compositionConfiguration.Meter.BeatsPerMeasure() - 1) // 1 less since the initial chord is generated separately
+            .Received(_compositionConfiguration.CompositionLength * _compositionConfiguration.Meter.BeatsPerMeasure() + 3) // 3 more to account for fugue subjects
             .GetPossibleChordChoices(Arg.Any<IReadOnlyList<BaroquenChord>>());
 
-        _mockCompositionDecorator.Received(1).Decorate(composition);
+        _mockCompositionDecorator.Received(2).Decorate(Arg.Any<Composition>());
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/MusicTheory/NoteTransposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/MusicTheory/NoteTransposerTests.cs
@@ -1,0 +1,130 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.MusicTheory;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using FluentAssertions;
+using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.MusicTheory;
+
+[TestFixture]
+internal sealed class NoteTransposerTests
+{
+    private NoteTransposer _noteTransposer = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var compositionConfiguration = new CompositionConfiguration(
+            new HashSet<VoiceConfiguration>
+            {
+                new(Voice.Soprano, Notes.C4, Notes.C6),
+                new(Voice.Alto, Notes.G2, Notes.G4),
+            },
+            BaroquenScale.Parse("C Major"),
+            Meter.FourFour,
+            CompositionLength: 100
+        );
+
+        _noteTransposer = new NoteTransposer(compositionConfiguration);
+    }
+
+    [Test]
+    public void Transpose_TransposesNotesAsExpected()
+    {
+        // arrange
+        var notesToTranspose = new List<BaroquenNote>
+        {
+            new(Voice.Soprano, Notes.C4)
+            {
+                OrnamentationType = OrnamentationType.PassingTone,
+                Duration = MusicalTimeSpan.Eighth,
+                Ornamentations =
+                {
+                    new BaroquenNote(Voice.Soprano, Notes.D4)
+                    {
+                        OrnamentationType = OrnamentationType.PassingTone,
+                        Duration = MusicalTimeSpan.Eighth
+                    }
+                }
+            },
+            new(Voice.Soprano, Notes.E4)
+            {
+                OrnamentationType = OrnamentationType.PassingTone,
+                Duration = MusicalTimeSpan.Eighth,
+                Ornamentations =
+                {
+                    new BaroquenNote(Voice.Soprano, Notes.F4)
+                    {
+                        OrnamentationType = OrnamentationType.PassingTone,
+                        Duration = MusicalTimeSpan.Eighth
+                    }
+                }
+            },
+            new(Voice.Soprano, Notes.G4)
+            {
+                OrnamentationType = OrnamentationType.None,
+                Duration = MusicalTimeSpan.Quarter
+            },
+            new(Voice.Soprano, Notes.C4)
+            {
+                OrnamentationType = OrnamentationType.None,
+                Duration = MusicalTimeSpan.Quarter
+            }
+        };
+
+        var expectedNotes = new List<BaroquenNote>
+        {
+            new(Voice.Alto, Notes.G2)
+            {
+                OrnamentationType = OrnamentationType.PassingTone,
+                Duration = MusicalTimeSpan.Eighth,
+                Ornamentations =
+                {
+                    new BaroquenNote(Voice.Alto, Notes.A2)
+                    {
+                        OrnamentationType = OrnamentationType.PassingTone,
+                        Duration = MusicalTimeSpan.Eighth
+                    }
+                }
+            },
+            new(Voice.Alto, Notes.B2)
+            {
+                OrnamentationType = OrnamentationType.PassingTone,
+                Duration = MusicalTimeSpan.Eighth,
+                Ornamentations =
+                {
+                    new BaroquenNote(Voice.Alto, Notes.C3)
+                    {
+                        OrnamentationType = OrnamentationType.PassingTone,
+                        Duration = MusicalTimeSpan.Eighth
+                    }
+                }
+            },
+            new(Voice.Alto, Notes.D3)
+            {
+                OrnamentationType = OrnamentationType.None,
+                Duration = MusicalTimeSpan.Quarter
+            },
+            new(Voice.Alto, Notes.G2)
+            {
+                OrnamentationType = OrnamentationType.None,
+                Duration = MusicalTimeSpan.Quarter
+            }
+        };
+
+        // act
+        var transposedNotes = _noteTransposer.TransposeToVoice(notesToTranspose, Voice.Soprano, Voice.Alto).ToList();
+
+        // assert
+        transposedNotes.Should().HaveCount(expectedNotes.Count);
+
+        for (var i = 0; i < transposedNotes.Count; i++)
+        {
+            transposedNotes[i].Should().BeEquivalentTo(expectedNotes[i]);
+        }
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/MusicTheory/NoteTransposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/MusicTheory/NoteTransposerTests.cs
@@ -22,7 +22,7 @@ internal sealed class NoteTransposerTests
             new HashSet<VoiceConfiguration>
             {
                 new(Voice.Soprano, Notes.C4, Notes.C6),
-                new(Voice.Alto, Notes.G2, Notes.G4),
+                new(Voice.Alto, Notes.G2, Notes.G4)
             },
             BaroquenScale.Parse("C Major"),
             Meter.FourFour,

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaners/OrnamentationCleanerFactoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaners/OrnamentationCleanerFactoryTests.cs
@@ -101,7 +101,7 @@ internal sealed class OrnamentationCleanerFactoryTests
     [TestCase(OrnamentationType.DecorateInterval, OrnamentationType.Mordent, typeof(MordentSixteenthNoteOrnamentationCleaner))]
     [TestCase(OrnamentationType.Mordent, OrnamentationType.Pedal, typeof(MordentSixteenthNoteOrnamentationCleaner))]
     [TestCase(OrnamentationType.Pedal, OrnamentationType.Mordent, typeof(MordentSixteenthNoteOrnamentationCleaner))]
-    [TestCase(OrnamentationType.Sustain, OrnamentationType.Rest, typeof(NoOpOrnamentationCleaner))]
+    [TestCase(OrnamentationType.Sustain, OrnamentationType.MidSustain, typeof(NoOpOrnamentationCleaner))]
     public void Get_Returns_Expected_OrnamentationCleaner(OrnamentationType ornamentationTypeA, OrnamentationType ornamentationTypeB, Type expectedType)
     {
         // act

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/CompositionDecoratorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/CompositionDecoratorTests.cs
@@ -93,6 +93,60 @@ internal sealed class CompositionDecoratorTests
     }
 
     [Test]
+    public void WhenDecorateIsInvokedForSpecificVoice_ThenOrnamentationEngineIsInvokedForVoice()
+    {
+        // arrange
+        var chordA = new BaroquenChord(
+            [
+                new BaroquenNote(Voice.Soprano, Notes.A4),
+                new BaroquenNote(Voice.Alto, Notes.C3)
+            ]
+        );
+
+        var chordB = new BaroquenChord(
+            [
+                new BaroquenNote(Voice.Soprano, Notes.A4),
+                new BaroquenNote(Voice.Alto, Notes.C3)
+            ]
+        );
+
+        var chordC = new BaroquenChord(
+            [
+                new BaroquenNote(Voice.Soprano, Notes.A4),
+                new BaroquenNote(Voice.Alto, Notes.C3)
+            ]
+        );
+
+        var chordD = new BaroquenChord(
+            [
+                new BaroquenNote(Voice.Soprano, Notes.A4),
+                new BaroquenNote(Voice.Alto, Notes.C3)
+            ]
+        );
+
+        var composition = new Composition(
+            [
+                new Measure(
+                    [
+                        new Beat(chordA),
+                        new Beat(chordB),
+                        new Beat(chordC),
+                        new Beat(chordD)
+                    ],
+                    Meter.FourFour
+                )
+            ]
+        );
+
+        // act
+        _compositionDecorator.Decorate(composition, Voice.Soprano);
+
+        // assert
+        _mockOrnamentationEngine.ReceivedWithAnyArgs(4).Process(Arg.Any<OrnamentationItem>());
+        _mockSustainEngine.DidNotReceiveWithAnyArgs().Process(Arg.Any<OrnamentationItem>());
+    }
+
+    [Test]
     public void WhenApplySustainIsInvoked_ThenSustainEngineIsInvoked_ForEachVoiceAndChord()
     {
         // arrange

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/SustainedNoteProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/SustainedNoteProcessorTests.cs
@@ -56,7 +56,7 @@ internal sealed class SustainedNoteProcessorTests
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.Sustain);
         noteToAssert.Ornamentations.Should().BeEmpty();
         noteToAssert.Duration.Should().Be(MusicalTimeSpan.Half);
-        nextNoteToAssert.OrnamentationType.Should().Be(OrnamentationType.Rest);
+        nextNoteToAssert.OrnamentationType.Should().Be(OrnamentationType.MidSustain);
         nextNoteToAssert.Ornamentations.Should().BeEmpty();
         nextNoteToAssert.Duration.Should().Be(new MusicalTimeSpan());
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculatorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculatorTests.cs
@@ -116,6 +116,8 @@ internal sealed class MusicalTimeSpanCalculatorTests
 
             yield return new TestCaseData(OrnamentationType.Mordent, Meter.FourFour, MusicalTimeSpan.ThirtySecond);
 
+            yield return new TestCaseData(OrnamentationType.Rest, Meter.FourFour, new MusicalTimeSpan());
+
             // more test cases to come as more ornamentation types and meters are added...
         }
     }
@@ -153,6 +155,8 @@ internal sealed class MusicalTimeSpanCalculatorTests
             yield return new TestCaseData(OrnamentationType.Mordent, Meter.FourFour, MusicalTimeSpan.ThirtySecond, 1);
 
             yield return new TestCaseData(OrnamentationType.Mordent, Meter.FourFour, MusicalTimeSpan.Eighth.Dotted(1), 2);
+
+            yield return new TestCaseData(OrnamentationType.Rest, Meter.FourFour, new MusicalTimeSpan(), 1);
 
             // more test cases to come as more ornamentation types and meters are added...
         }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculatorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculatorTests.cs
@@ -98,7 +98,7 @@ internal sealed class MusicalTimeSpanCalculatorTests
 
             yield return new TestCaseData(OrnamentationType.Sustain, Meter.FourFour, MusicalTimeSpan.Half);
 
-            yield return new TestCaseData(OrnamentationType.Rest, Meter.FourFour, new MusicalTimeSpan());
+            yield return new TestCaseData(OrnamentationType.MidSustain, Meter.FourFour, new MusicalTimeSpan());
 
             yield return new TestCaseData(OrnamentationType.DoubleTurn, Meter.FourFour, MusicalTimeSpan.ThirtySecond);
 
@@ -134,7 +134,7 @@ internal sealed class MusicalTimeSpanCalculatorTests
 
             yield return new TestCaseData(OrnamentationType.AlternateTurn, Meter.FourFour, MusicalTimeSpan.Sixteenth, 1);
 
-            yield return new TestCaseData(OrnamentationType.Rest, Meter.FourFour, new MusicalTimeSpan(), 1);
+            yield return new TestCaseData(OrnamentationType.MidSustain, Meter.FourFour, new MusicalTimeSpan(), 1);
 
             yield return new TestCaseData(OrnamentationType.DoubleTurn, Meter.FourFour, MusicalTimeSpan.ThirtySecond, 1);
 


### PR DESCRIPTION
## Description

Proof of concept work which starts each piece with a fugue subject, which is then iteratively built upon.

- Define a `INoteTransposer` and implement a `NoteTransposer` which can take the fugue subject and transpose it to other voice ranges within the piece.
- Extended `CompositionStrategy` to offer a new method, which allows for targeting chord choices based on partially voiced chords. This allows for hydrating a set of chords with just the fugue subject (or any number of voices) and filtering down to next chords which contain the voiced notes.
- Lots of work in the `Composer` class to compose the fugue subject and extend it to other voices. 
  - There's a lot going on here and may have some of this abstracted out in the future.
  - Temp output to console to give some visibility into the composition state.
- Updated unit tests and added new ones.
- Renamed existing `OrnamentationType.Rest` to `OrnamentationType.MidSustain` to better capture what it was being used for. Added new true `OrnamentationType.Rest` to be used when an actual rest is happening for a given note.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
