### PR TITLE
Refactor Composer

### DIFF
--- a/src/BaroquenMelody.Library/Compositions/Choices/ChordChoiceRepositoryFactory.cs
+++ b/src/BaroquenMelody.Library/Compositions/Choices/ChordChoiceRepositoryFactory.cs
@@ -5,7 +5,7 @@ namespace BaroquenMelody.Library.Compositions.Choices;
 /// <inheritdoc cref="IChordChoiceRepository"/>
 internal sealed class ChordChoiceRepositoryFactory(INoteChoiceGenerator noteChoiceGenerator) : IChordChoiceRepositoryFactory
 {
-    public IChordChoiceRepository Create(CompositionConfiguration compositionConfiguration) => compositionConfiguration.VoiceConfigurations.Count switch
+    public IChordChoiceRepository Create(CompositionConfiguration compositionConfiguration) => compositionConfiguration.Voices.Count switch
     {
         DuetChordChoiceRepository.NumberOfVoices => new DuetChordChoiceRepository(compositionConfiguration, noteChoiceGenerator),
         TrioChordChoiceRepository.NumberOfVoices => new TrioChordChoiceRepository(compositionConfiguration, noteChoiceGenerator),

--- a/src/BaroquenMelody.Library/Compositions/Choices/DuetChordChoiceRepository.cs
+++ b/src/BaroquenMelody.Library/Compositions/Choices/DuetChordChoiceRepository.cs
@@ -14,7 +14,7 @@ internal sealed class DuetChordChoiceRepository : IChordChoiceRepository
 
     public DuetChordChoiceRepository(CompositionConfiguration compositionConfiguration, INoteChoiceGenerator noteChoiceGenerator)
     {
-        if (compositionConfiguration.VoiceConfigurations.Count != NumberOfVoices)
+        if (compositionConfiguration.Voices.Count != NumberOfVoices)
         {
             throw new ArgumentException(
                 "The composition configuration must contain exactly two voice configurations.",
@@ -22,9 +22,9 @@ internal sealed class DuetChordChoiceRepository : IChordChoiceRepository
             );
         }
 
-        var noteChoicesForVoices = compositionConfiguration.VoiceConfigurations
-            .OrderBy(voiceConfiguration => voiceConfiguration.Voice)
-            .Select(voiceConfiguration => noteChoiceGenerator.GenerateNoteChoices(voiceConfiguration.Voice))
+        var noteChoicesForVoices = compositionConfiguration.Voices
+            .OrderBy(voice => voice)
+            .Select(noteChoiceGenerator.GenerateNoteChoices)
             .ToList();
 
         _noteChoices = new LazyCartesianProduct<NoteChoice, NoteChoice>(

--- a/src/BaroquenMelody.Library/Compositions/Composers/ChordComposer.cs
+++ b/src/BaroquenMelody.Library/Compositions/Composers/ChordComposer.cs
@@ -1,0 +1,19 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Extensions;
+using BaroquenMelody.Library.Compositions.Strategies;
+using BaroquenMelody.Library.Infrastructure.Random;
+
+namespace BaroquenMelody.Library.Compositions.Composers;
+
+/// <inheritdoc cref="IChordComposer"/>
+internal sealed class ChordComposer(ICompositionStrategy compositionStrategy, CompositionConfiguration compositionConfiguration) : IChordComposer
+{
+    public BaroquenChord Compose(IReadOnlyList<BaroquenChord> precedingChords)
+    {
+        var possibleChordChoices = compositionStrategy.GetPossibleChordChoices(precedingChords);
+        var chordChoice = possibleChordChoices.OrderBy(_ => ThreadLocalRandom.Next()).First();
+
+        return precedingChords[^1].ApplyChordChoice(compositionConfiguration.Scale, chordChoice);
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Composers/Composer.cs
+++ b/src/BaroquenMelody.Library/Compositions/Composers/Composer.cs
@@ -1,67 +1,48 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
-using BaroquenMelody.Library.Compositions.Enums;
-using BaroquenMelody.Library.Compositions.Enums.Extensions;
-using BaroquenMelody.Library.Compositions.Extensions;
-using BaroquenMelody.Library.Compositions.MusicTheory;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Phrasing;
-using BaroquenMelody.Library.Compositions.Strategies;
 using BaroquenMelody.Library.Infrastructure.Collections;
-using BaroquenMelody.Library.Infrastructure.Random;
 
 namespace BaroquenMelody.Library.Compositions.Composers;
 
 /// <summary>
 ///     Represents a composer which can generate a <see cref="Composition"/>.
 /// </summary>
-/// <param name="compositionStrategy"> The strategy that the composer should use to generate the composition. </param>
 /// <param name="compositionDecorator"> The decorator that the composer should use to decorate the composition. </param>
 /// <param name="compositionPhraser"> The phraser that the composer should use to phrase the composition. </param>
-/// <param name="noteTransposer"> The transposer that the composer should use to transpose notes. </param>
+/// <param name="chordComposer"> The chord composer that the composer should use to compose chords. </param>
+/// <param name="themeComposer"> The theme composer that the composer should use to compose themes. </param>
 /// <param name="compositionConfiguration"> The configuration to use to generate the composition. </param>
 internal sealed class Composer(
-    ICompositionStrategy compositionStrategy,
     ICompositionDecorator compositionDecorator,
     ICompositionPhraser compositionPhraser,
-    INoteTransposer noteTransposer,
+    IChordComposer chordComposer,
+    IThemeComposer themeComposer,
     CompositionConfiguration compositionConfiguration
 ) : IComposer
 {
     public Composition Compose()
     {
-        List<Measure> openingMeasures;
-
-        while (true)
-        {
-            try
-            {
-                openingMeasures = ComposeFugueSubject();
-                break;
-            }
-            catch (Exception)
-            {
-                Console.WriteLine("Failed to compose suitable fugue subject. Retrying...");
-            }
-        }
+        var theme = themeComposer.Compose();
 
         var compositionContext = new FixedSizeList<BaroquenChord>(
             compositionConfiguration.CompositionContextSize,
-            openingMeasures.SelectMany(measure => measure.Beats.Select(beat => beat.Chord))
+            theme.Exposition.SelectMany(measure => measure.Beats.Select(beat => beat.Chord))
         );
 
         var continuationMeasures = new List<Measure>();
 
         while (continuationMeasures.Count < compositionConfiguration.CompositionLength)
         {
-            var initialChord = ComposeNextChord(compositionContext);
-            var beats = new List<Beat>(compositionConfiguration.Meter.BeatsPerMeasure()) { new(initialChord) };
+            var initialChord = chordComposer.Compose(compositionContext);
+            var beats = new List<Beat>(compositionConfiguration.BeatsPerMeasure) { new(initialChord) };
 
             compositionContext.Add(initialChord);
 
-            while (beats.Count < compositionConfiguration.Meter.BeatsPerMeasure())
+            while (beats.Count < compositionConfiguration.BeatsPerMeasure)
             {
-                var nextChord = ComposeNextChord(compositionContext);
+                var nextChord = chordComposer.Compose(compositionContext);
 
                 compositionContext.Add(nextChord);
                 beats.Add(new Beat(nextChord));
@@ -74,12 +55,12 @@ internal sealed class Composer(
 
         compositionDecorator.Decorate(continuationComposition);
 
-        var phrasedComposition = PhraseComposition(continuationComposition);
+        var phrasedComposition = ApplyPhrasing(continuationComposition);
 
-        return new Composition([.. openingMeasures, .. phrasedComposition.Measures]);
+        return new Composition([.. theme.Exposition, .. phrasedComposition.Measures]);
     }
 
-    private Composition PhraseComposition(Composition initialComposition)
+    private Composition ApplyPhrasing(Composition initialComposition)
     {
         var currentMeasureIndex = 0;
         var phrasedMeasures = new List<Measure>();
@@ -88,7 +69,7 @@ internal sealed class Composer(
         {
             phrasedMeasures.Add(measure);
 
-            if (currentMeasureIndex++ % compositionConfiguration.PhrasingConfiguration.PhraseLengths.Min() == 0)
+            if (currentMeasureIndex++ % compositionConfiguration.PhrasingConfiguration.MinPhraseLength == 0)
             {
                 compositionPhraser.AttemptPhraseRepetition(phrasedMeasures);
             }
@@ -105,118 +86,5 @@ internal sealed class Composer(
         compositionDecorator.ApplySustain(phrasedComposition);
 
         return phrasedComposition;
-    }
-
-    private List<Measure> ComposeInitialMeasures()
-    {
-        var initialChord = compositionStrategy.GenerateInitialChord();
-        var beats = new List<Beat>(compositionConfiguration.Meter.BeatsPerMeasure()) { new(initialChord) };
-        var precedingChords = beats.Select(beat => beat.Chord).ToList();
-
-        while (beats.Count < compositionConfiguration.Meter.BeatsPerMeasure())
-        {
-            var nextChord = ComposeNextChord(precedingChords);
-
-            precedingChords.Add(nextChord);
-            beats.Add(new Beat(nextChord));
-        }
-
-        return new List<Measure>(compositionConfiguration.CompositionLength)
-        {
-            new(beats, compositionConfiguration.Meter)
-        };
-    }
-
-    private List<Measure> ComposeFugueSubject()
-    {
-        var initialMeasures = ComposeInitialMeasures();
-        var initialComposition = new Composition(initialMeasures);
-
-        var voices = compositionConfiguration.VoiceConfigurations
-            .OrderByDescending(voiceConfiguration => voiceConfiguration.MinNote)
-            .Select(voiceConfiguration => voiceConfiguration.Voice)
-            .ToList();
-
-        var fugueSubjectVoice = voices[0];
-
-        compositionDecorator.Decorate(initialComposition, fugueSubjectVoice);
-
-        var fugueSubject = initialComposition.Measures
-            .SelectMany(measure => measure.Beats)
-            .Select(beat => beat.Chord[fugueSubjectVoice])
-            .ToList();
-
-        var workingChords = initialComposition.Measures.SelectMany(measure => measure.Beats.Select(beat => beat.Chord)).ToList();
-
-        ContinueFugueSubject(fugueSubject, fugueSubjectVoice, workingChords, voices);
-
-        return StripVoicesFromFugueSubject(workingChords, voices);
-    }
-
-    private void ContinueFugueSubject(List<BaroquenNote> fugueSubject, Voice fugueSubjectVoice, List<BaroquenChord> workingChords, List<Voice> voices)
-    {
-        var processedVoices = new List<Voice> { fugueSubjectVoice };
-
-        foreach (var voice in voices.Where(voice => voice != fugueSubjectVoice))
-        {
-            var precedingChord = workingChords[^1];
-            var nextChords = new List<BaroquenChord>();
-
-            var transposedSubjectChords = noteTransposer.TransposeToVoice(fugueSubject, fugueSubjectVoice, voice)
-                .Select(note => new BaroquenChord([note]))
-                .ToList();
-
-            // ReSharper disable once ForeachCanBePartlyConvertedToQueryUsingAnotherGetEnumerator
-            foreach (var transposedSubjectChord in transposedSubjectChords)
-            {
-                var nextChord = compositionStrategy.GetPossibleChordsForPartiallyVoicedChords([precedingChord], transposedSubjectChord).OrderBy(_ => ThreadLocalRandom.Next()).First();
-
-                var transposedSubjectNote = transposedSubjectChord[voice];
-                var otherNotes = nextChord.Notes.Where(note => note.Voice != voice).ToList();
-                var workingChord = new BaroquenChord([.. otherNotes, transposedSubjectNote]);
-
-                nextChords.Add(workingChord);
-                precedingChord = workingChord;
-            }
-
-            var tempComposition = new Composition([new Measure(nextChords.Select(chord => new Beat(chord)).ToList(), compositionConfiguration.Meter)]);
-
-            foreach (var processedVoice in processedVoices)
-            {
-                compositionDecorator.Decorate(tempComposition, processedVoice);
-            }
-
-            workingChords.AddRange(nextChords);
-            processedVoices.Add(voice);
-        }
-    }
-
-    private List<Measure> StripVoicesFromFugueSubject(List<BaroquenChord> workingChords, List<Voice> voices)
-    {
-        var beatIndex = 0;
-        var measures = new List<Measure>();
-        var inProcessVoices = new List<Voice>();
-
-        foreach (var voice in voices)
-        {
-            inProcessVoices.Add(voice);
-
-            var beats = workingChords.Skip(beatIndex).Take(compositionConfiguration.Meter.BeatsPerMeasure()).Select(chord => new Beat(chord)).ToList();
-            var strippedBeats = beats.Select(beat => new BaroquenChord(beat.Chord.Notes.Where(note => inProcessVoices.Contains(note.Voice)).ToList())).Select(newChord => new Beat(newChord)).ToList();
-
-            beatIndex += compositionConfiguration.Meter.BeatsPerMeasure();
-
-            measures.Add(new Measure(strippedBeats, compositionConfiguration.Meter));
-        }
-
-        return measures;
-    }
-
-    private BaroquenChord ComposeNextChord(IReadOnlyList<BaroquenChord> precedingChords)
-    {
-        var possibleChordChoices = compositionStrategy.GetPossibleChordChoices(precedingChords);
-        var chordChoice = possibleChordChoices.OrderBy(_ => ThreadLocalRandom.Next()).First();
-
-        return precedingChords[^1].ApplyChordChoice(compositionConfiguration.Scale, chordChoice);
     }
 }

--- a/src/BaroquenMelody.Library/Compositions/Composers/IChordComposer.cs
+++ b/src/BaroquenMelody.Library/Compositions/Composers/IChordComposer.cs
@@ -1,0 +1,16 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+
+namespace BaroquenMelody.Library.Compositions.Composers;
+
+/// <summary>
+///     Represents a composer which can compose the next chord in a sequence of preceding chords.
+/// </summary>
+internal interface IChordComposer
+{
+    /// <summary>
+    ///     Composes the next chord in the sequence of <paramref name="precedingChords"/>.
+    /// </summary>
+    /// <param name="precedingChords">The preceding chords used to generate the next chord.</param>
+    /// <returns>A <see cref="BaroquenChord"/> to continue with from the preceding chords.</returns>
+    BaroquenChord Compose(IReadOnlyList<BaroquenChord> precedingChords);
+}

--- a/src/BaroquenMelody.Library/Compositions/Composers/IThemeComposer.cs
+++ b/src/BaroquenMelody.Library/Compositions/Composers/IThemeComposer.cs
@@ -1,0 +1,17 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+
+namespace BaroquenMelody.Library.Compositions.Composers;
+
+/// <summary>
+///    Represents a composer which can generate a <see cref="BaroquenTheme"/>.
+/// </summary>
+internal interface IThemeComposer
+{
+    /// <summary>
+    ///     Composes a <see cref="BaroquenTheme"/>. When possible, the exposition of the composition
+    ///     is the opening subject of a fugue. If a suitable fugue subject cannot be found, then the
+    ///     composition begins with all four voices sounding at once.
+    /// </summary>
+    /// <returns>A <see cref="BaroquenTheme"/>.</returns>
+    BaroquenTheme Compose();
+}

--- a/src/BaroquenMelody.Library/Compositions/Composers/ThemeComposer.cs
+++ b/src/BaroquenMelody.Library/Compositions/Composers/ThemeComposer.cs
@@ -1,0 +1,155 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.MusicTheory;
+using BaroquenMelody.Library.Compositions.Ornamentation;
+using BaroquenMelody.Library.Compositions.Strategies;
+using BaroquenMelody.Library.Infrastructure.Random;
+
+namespace BaroquenMelody.Library.Compositions.Composers;
+
+/// <inheritdoc cref="IThemeComposer"/>
+internal sealed class ThemeComposer(
+    ICompositionStrategy compositionStrategy,
+    ICompositionDecorator compositionDecorator,
+    IChordComposer chordComposer,
+    INoteTransposer noteTransposer,
+    CompositionConfiguration compositionConfiguration
+) : IThemeComposer
+{
+    public BaroquenTheme Compose()
+    {
+        while (true)
+        {
+            if (TryComposeFugueSubject(out var fugueSubject))
+            {
+                return fugueSubject!;
+            }
+
+            Console.WriteLine("Failed to compose suitable fugue subject. Retrying...");
+        }
+    }
+
+    private bool TryComposeFugueSubject(out BaroquenTheme? theme)
+    {
+        var initialMeasures = ComposeInitialMeasures();
+        var initialComposition = new Composition(initialMeasures);
+
+        var voices = compositionConfiguration.VoiceConfigurations
+            .OrderByDescending(voiceConfiguration => voiceConfiguration.MinNote)
+            .Select(voiceConfiguration => voiceConfiguration.Voice)
+            .ToList();
+
+        var fugueSubjectVoice = voices[0];
+
+        compositionDecorator.Decorate(initialComposition, fugueSubjectVoice);
+
+        var fugueSubject = initialComposition.Measures
+            .SelectMany(measure => measure.Beats)
+            .Select(beat => beat.Chord[fugueSubjectVoice])
+            .ToList();
+
+        var workingChords = initialComposition.Measures.SelectMany(measure => measure.Beats.Select(beat => beat.Chord)).ToList();
+
+        workingChords = ContinueFugueSubject(fugueSubject, fugueSubjectVoice, workingChords, voices);
+
+        if (workingChords.Count == 0)
+        {
+            theme = null;
+            return false;
+        }
+
+        theme = StripVoicesFromFugueSubject(workingChords, voices);
+
+        return true;
+    }
+
+    private List<Measure> ComposeInitialMeasures()
+    {
+        var initialChord = compositionStrategy.GenerateInitialChord();
+        var beats = new List<Beat>(compositionConfiguration.BeatsPerMeasure) { new(initialChord) };
+        var precedingChords = beats.Select(beat => beat.Chord).ToList();
+
+        while (beats.Count < compositionConfiguration.BeatsPerMeasure)
+        {
+            var nextChord = chordComposer.Compose(precedingChords);
+
+            precedingChords.Add(nextChord);
+            beats.Add(new Beat(nextChord));
+        }
+
+        return new List<Measure>(compositionConfiguration.CompositionLength)
+        {
+            new(beats, compositionConfiguration.Meter)
+        };
+    }
+
+    private List<BaroquenChord> ContinueFugueSubject(List<BaroquenNote> fugueSubject, Voice fugueSubjectVoice, List<BaroquenChord> workingChords, List<Voice> voices)
+    {
+        var processedVoices = new List<Voice> { fugueSubjectVoice };
+
+        foreach (var voice in voices.Where(voice => voice != fugueSubjectVoice))
+        {
+            var precedingChord = workingChords[^1];
+            var nextChords = new List<BaroquenChord>();
+
+            var transposedSubjectChords = noteTransposer.TransposeToVoice(fugueSubject, fugueSubjectVoice, voice)
+                .Select(note => new BaroquenChord([note]))
+                .ToList();
+
+            // ReSharper disable once ForeachCanBePartlyConvertedToQueryUsingAnotherGetEnumerator
+            foreach (var transposedSubjectChord in transposedSubjectChords)
+            {
+                var possibleChords = compositionStrategy.GetPossibleChordsForPartiallyVoicedChords([precedingChord], transposedSubjectChord);
+
+                if (possibleChords.Count == 0)
+                {
+                    return [];
+                }
+
+                var nextChord = possibleChords.OrderBy(_ => ThreadLocalRandom.Next()).First();
+                var transposedSubjectNote = transposedSubjectChord[voice];
+                var otherNotes = nextChord.Notes.Where(note => note.Voice != voice).ToList();
+                var workingChord = new BaroquenChord([.. otherNotes, transposedSubjectNote]);
+
+                nextChords.Add(workingChord);
+                precedingChord = workingChord;
+            }
+
+            var tempComposition = new Composition([new Measure(nextChords.Select(chord => new Beat(chord)).ToList(), compositionConfiguration.Meter)]);
+
+            foreach (var processedVoice in processedVoices)
+            {
+                compositionDecorator.Decorate(tempComposition, processedVoice);
+            }
+
+            workingChords.AddRange(tempComposition.Measures.SelectMany(measure => measure.Beats.Select(beat => beat.Chord)));
+            processedVoices.Add(voice);
+        }
+
+        return workingChords;
+    }
+
+    private BaroquenTheme StripVoicesFromFugueSubject(List<BaroquenChord> workingChords, List<Voice> voices)
+    {
+        var beatIndex = 0;
+        var expositionMeasures = new List<Measure>();
+        var recapitulationMeasures = new List<Measure>();
+        var inProcessVoices = new List<Voice>();
+
+        foreach (var voice in voices)
+        {
+            inProcessVoices.Add(voice);
+
+            var beats = workingChords.Skip(beatIndex).Take(compositionConfiguration.BeatsPerMeasure).Select(chord => new Beat(chord)).ToList();
+            var strippedBeats = beats.Select(beat => new BaroquenChord(beat.Chord.Notes.Where(note => inProcessVoices.Contains(note.Voice)).ToList())).Select(newChord => new Beat(newChord)).ToList();
+
+            beatIndex += compositionConfiguration.BeatsPerMeasure;
+
+            recapitulationMeasures.Add(new Measure(beats, compositionConfiguration.Meter));
+            expositionMeasures.Add(new Measure(strippedBeats, compositionConfiguration.Meter));
+        }
+
+        return new BaroquenTheme(expositionMeasures, recapitulationMeasures);
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Enums.Extensions;
 using Melanchall.DryWetMidi.MusicTheory;
 
 namespace BaroquenMelody.Library.Compositions.Configurations;
@@ -24,6 +25,10 @@ internal sealed record CompositionConfiguration(
     public IDictionary<Voice, VoiceConfiguration> VoiceConfigurationsByVoice { get; } = VoiceConfigurations.ToDictionary(
         voiceConfiguration => voiceConfiguration.Voice
     );
+
+    public List<Voice> Voices { get; } = VoiceConfigurations.Select(voiceConfiguration => voiceConfiguration.Voice).ToList();
+
+    public int BeatsPerMeasure => Meter.BeatsPerMeasure();
 
     /// <summary>
     ///     Determine if the given note is within the range of the given voice for the composition.

--- a/src/BaroquenMelody.Library/Compositions/Configurations/PhrasingConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/PhrasingConfiguration.cs
@@ -15,4 +15,6 @@ internal sealed record PhrasingConfiguration(
 )
 {
     public static PhrasingConfiguration Default => new(PhraseLengths: [1, 2, 4]);
+
+    public int MinPhraseLength { get; } = PhraseLengths.Min();
 }

--- a/src/BaroquenMelody.Library/Compositions/Domain/BaroquenTheme.cs
+++ b/src/BaroquenMelody.Library/Compositions/Domain/BaroquenTheme.cs
@@ -1,0 +1,14 @@
+﻿namespace BaroquenMelody.Library.Compositions.Domain;
+
+/// <summary>
+///     A theme to be used in a composition.
+/// </summary>
+/// <param name="Exposition">The exposition, sometimes an opening fugue subject.</param>
+/// <param name="Recapitulation">The recapitulation, the theme repeated with additional ornamentation.</param>
+internal sealed record BaroquenTheme(List<Measure> Exposition, List<Measure> Recapitulation)
+{
+    public BaroquenTheme()
+        : this([], [])
+    {
+    }
+}

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -40,7 +40,7 @@ var compositionConfiguration = new CompositionConfiguration(
         new(Voice.Bass, Notes.C0, Notes.G1)
     },
     phrasingConfiguration,
-    BaroquenScale.Parse("D Dorian"),
+    BaroquenScale.Parse("C Major"),
     Meter.FourFour,
     25
 );
@@ -82,12 +82,21 @@ var compositionDecorator = new CompositionDecorator(
 
 var compositionPhraser = new CompositionPhraser(compositionRule, compositionConfiguration);
 var noteTransposer = new NoteTransposer(compositionConfiguration);
+var chordComposer = new ChordComposer(compositionStrategy, compositionConfiguration);
 
-var composer = new Composer(
+var themeComposer = new ThemeComposer(
     compositionStrategy,
     compositionDecorator,
-    compositionPhraser,
+    chordComposer,
     noteTransposer,
+    compositionConfiguration
+);
+
+var composer = new Composer(
+    compositionDecorator,
+    compositionPhraser,
+    chordComposer,
+    themeComposer,
     compositionConfiguration
 );
 
@@ -118,7 +127,7 @@ foreach (var measure in composition.Measures)
 {
     foreach (var beat in measure.Beats)
     {
-        foreach (var voice in compositionConfiguration.VoiceConfigurations.Select(vc => vc.Voice))
+        foreach (var voice in compositionConfiguration.Voices)
         {
             if (beat.Chord.Notes.TrueForAll(note => note.Voice != voice))
             {

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ChordComposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ChordComposerTests.cs
@@ -1,0 +1,88 @@
+﻿using BaroquenMelody.Library.Compositions.Choices;
+using BaroquenMelody.Library.Compositions.Composers;
+using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Strategies;
+using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Composers;
+
+[TestFixture]
+internal sealed class ChordComposerTests
+{
+    private ICompositionStrategy _mockCompositionStrategy = null!;
+
+    private CompositionConfiguration _compositionConfiguration = null!;
+
+    private ChordComposer _chordComposer = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockCompositionStrategy = Substitute.For<ICompositionStrategy>();
+
+        _compositionConfiguration = new CompositionConfiguration(
+            new HashSet<VoiceConfiguration>
+            {
+                new(Voice.Soprano, Notes.A4, Notes.A5),
+                new(Voice.Alto, Notes.C3, Notes.C4)
+            },
+            BaroquenScale.Parse("C Major"),
+            Meter.FourFour,
+            CompositionLength: 100
+        );
+
+        _chordComposer = new ChordComposer(_mockCompositionStrategy, _compositionConfiguration);
+    }
+
+    [Test]
+    public void WhenComposeIsInvoked_ThenCompositionIsReturned()
+    {
+        // arrange
+        _mockCompositionStrategy.GetPossibleChordChoices(Arg.Any<IReadOnlyList<BaroquenChord>>()).Returns(
+        [
+            new ChordChoice(
+            [
+                new NoteChoice(Voice.Soprano, NoteMotion.Ascending, 3),
+                new NoteChoice(Voice.Alto, NoteMotion.Descending, 3)
+            ]),
+            new ChordChoice(
+            [
+                new NoteChoice(Voice.Soprano, NoteMotion.Descending, 3),
+                new NoteChoice(Voice.Alto, NoteMotion.Ascending, 3)
+            ])
+        ]);
+
+        var precedingChords = new List<BaroquenChord>
+        {
+            new(
+            [
+                new BaroquenNote(Voice.Soprano, Notes.A4),
+                new BaroquenNote(Voice.Alto, Notes.C3)
+            ])
+        };
+
+        var expectedChordA = new BaroquenChord(
+        [
+            new BaroquenNote(Voice.Soprano, Notes.D5),
+            new BaroquenNote(Voice.Alto, Notes.G2)
+        ]);
+
+        var expectedChordB = new BaroquenChord(
+        [
+            new BaroquenNote(Voice.Soprano, Notes.E4),
+            new BaroquenNote(Voice.Alto, Notes.F3)
+        ]);
+
+        // act
+        var resultChord = _chordComposer.Compose(precedingChords);
+
+        // assert
+        resultChord.Should().NotBeNull();
+        resultChord.Should().Match<BaroquenChord>(actualChord => actualChord == expectedChordA || actualChord == expectedChordB);
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ComposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ComposerTests.cs
@@ -3,7 +3,6 @@ using BaroquenMelody.Library.Compositions.Composers;
 using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
-using BaroquenMelody.Library.Compositions.Enums.Extensions;
 using BaroquenMelody.Library.Compositions.MusicTheory;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Phrasing;
@@ -32,6 +31,10 @@ internal sealed class ComposerTests
 
     private INoteTransposer _noteTransposer = null!;
 
+    private IChordComposer _chordComposer = null!;
+
+    private IThemeComposer _themeComposer = null!;
+
     private CompositionConfiguration _compositionConfiguration = null!;
 
     private Composer _composer = null!;
@@ -55,8 +58,10 @@ internal sealed class ComposerTests
         );
 
         _noteTransposer = new NoteTransposer(_compositionConfiguration);
+        _chordComposer = new ChordComposer(_mockCompositionStrategy, _compositionConfiguration);
+        _themeComposer = new ThemeComposer(_mockCompositionStrategy, _mockCompositionDecorator, _chordComposer, _noteTransposer, _compositionConfiguration);
 
-        _composer = new Composer(_mockCompositionStrategy, _mockCompositionDecorator, _mockCompositionPhraser, _noteTransposer, _compositionConfiguration);
+        _composer = new Composer(_mockCompositionDecorator, _mockCompositionPhraser, _chordComposer, _themeComposer, _compositionConfiguration);
     }
 
     [Test]
@@ -97,13 +102,13 @@ internal sealed class ComposerTests
 
         foreach (var measure in composition.Measures)
         {
-            measure.Beats.Should().HaveCount(_compositionConfiguration.Meter.BeatsPerMeasure());
+            measure.Beats.Should().HaveCount(_compositionConfiguration.BeatsPerMeasure);
         }
 
         _mockCompositionStrategy.Received(1).GenerateInitialChord();
 
         _mockCompositionStrategy
-            .Received(_compositionConfiguration.CompositionLength * _compositionConfiguration.Meter.BeatsPerMeasure() + 3) // 3 more to account for fugue subjects
+            .Received(_compositionConfiguration.CompositionLength * _compositionConfiguration.BeatsPerMeasure + 3) // 3 more to account for fugue subjects
             .GetPossibleChordChoices(Arg.Any<IReadOnlyList<BaroquenChord>>());
 
         _mockCompositionDecorator.Received(2).Decorate(Arg.Any<Composition>());


### PR DESCRIPTION
## Description

Refactor the `Composer` class, as it was taking on too many responsibilities.

- Create `ChordComposer` responsible for composing the next chord in a sequence of chords.
- Create `ThemeComposer` responsible for composing a `BaroquenTheme` for the composition
  - Attempts to compose a fugue subject for now
  - Will fall back to non-fugue subject in the future
- Added some better methods of exposing data on `CompositionConfiguration`

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
