### PR TITLE
Composition Rule Bypass

### DIFF
--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/OrnamentationEngineBuilder.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/OrnamentationEngineBuilder.cs
@@ -9,6 +9,7 @@ using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies.Output;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
+using BaroquenMelody.Library.Infrastructure.Random;
 using Melanchall.DryWetMidi.MusicTheory;
 using System.Diagnostics.CodeAnalysis;
 
@@ -23,6 +24,8 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
     private const int DecorateDominantSeventhBelowLeadingToneInterval = -2;
 
     private readonly IChordNumberIdentifier _chordNumberIdentifier = new ChordNumberIdentifier(compositionConfiguration);
+
+    private readonly IWeightedRandomBooleanGenerator _weightedRandomBooleanGenerator = new WeightedRandomBooleanGenerator();
 
     public IPolicyEngine<OrnamentationItem> BuildOrnamentationEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithoutInputPolicies()
@@ -54,7 +57,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
 
     public IPolicyEngine<OrnamentationItem> BuildSustainedNoteEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(),
+            new WantsToOrnament(_weightedRandomBooleanGenerator),
             new IsRepeatedNote(),
             new NoteHasNoOrnamentation(),
             new IsApplicableInterval(compositionConfiguration, SustainedNoteProcessor.Interval)
@@ -65,7 +68,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
 
     private IPolicyEngine<OrnamentationItem> BuildPassingToneEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(),
+            new WantsToOrnament(_weightedRandomBooleanGenerator),
             new NoteHasNoOrnamentation(),
             new IsApplicableInterval(compositionConfiguration, PassingToneProcessor.Interval)
         )
@@ -75,7 +78,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
 
     private IPolicyEngine<OrnamentationItem> BuildDelayedPassingToneEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(),
+            new WantsToOrnament(_weightedRandomBooleanGenerator),
             new NoteHasNoOrnamentation(),
             new IsApplicableInterval(compositionConfiguration, PassingToneProcessor.Interval)
         )
@@ -85,7 +88,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
 
     private IPolicyEngine<OrnamentationItem> BuildTurnEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(),
+            new WantsToOrnament(_weightedRandomBooleanGenerator),
             new NoteHasNoOrnamentation(),
             new IsApplicableInterval(compositionConfiguration, TurnProcessor.Interval)
         )
@@ -95,7 +98,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
 
     private IPolicyEngine<OrnamentationItem> BuildAlternateTurnEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(),
+            new WantsToOrnament(_weightedRandomBooleanGenerator),
             new NoteHasNoOrnamentation(),
             new IsApplicableInterval(compositionConfiguration, AlternateTurnProcessor.Interval)
         )
@@ -105,7 +108,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
 
     private IPolicyEngine<OrnamentationItem> BuildSixteenthNoteRunEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(),
+            new WantsToOrnament(_weightedRandomBooleanGenerator),
             new NoteHasNoOrnamentation(),
             new IsApplicableInterval(compositionConfiguration, SixteenthNoteRunProcessor.Interval)
         )
@@ -115,7 +118,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
 
     private IPolicyEngine<OrnamentationItem> BuildDelayedThirtySecondNoteRunEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(15),
+            new WantsToOrnament(_weightedRandomBooleanGenerator, 15),
             new NoteHasNoOrnamentation(),
             new IsApplicableInterval(compositionConfiguration, DelayedThirtySecondNoteRunProcessor.Interval)
         )
@@ -125,7 +128,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
 
     private IPolicyEngine<OrnamentationItem> BuildDoubleTurnEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(30),
+            new WantsToOrnament(_weightedRandomBooleanGenerator, 30),
             new NoteHasNoOrnamentation(),
             new IsApplicableInterval(compositionConfiguration, DoubleTurnProcessor.Interval)
         )
@@ -135,7 +138,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
 
     private IPolicyEngine<OrnamentationItem> BuildDoublePassingToneEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(),
+            new WantsToOrnament(_weightedRandomBooleanGenerator),
             new NoteHasNoOrnamentation(),
             new IsApplicableInterval(compositionConfiguration, DoublePassingToneProcessor.Interval)
         )
@@ -145,7 +148,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
 
     private IPolicyEngine<OrnamentationItem> BuildDelayedDoublePassingToneEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(),
+            new WantsToOrnament(_weightedRandomBooleanGenerator),
             new NoteHasNoOrnamentation(),
             new IsApplicableInterval(compositionConfiguration, DoublePassingToneProcessor.Interval)
         )
@@ -156,7 +159,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
     private IPolicyEngine<OrnamentationItem> BuildDecorateDominantSeventhIntervalEngine(NoteName targetNote, int intervalChange) => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
             new HasNextBeat(),
-            new WantsToOrnament(30),
+            new WantsToOrnament(_weightedRandomBooleanGenerator, 30),
             new NoteHasNoOrnamentation(),
             new NoteIsTargetNote(targetNote),
             new BeatContainsTargetNotes([compositionConfiguration.Scale.Dominant, compositionConfiguration.Scale.LeadingTone, compositionConfiguration.Scale.Supertonic]),
@@ -170,7 +173,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
 
     private IPolicyEngine<OrnamentationItem> BuildDoubleThirtySecondNoteRunProcessor() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(15),
+            new WantsToOrnament(_weightedRandomBooleanGenerator, 15),
             new NoteHasNoOrnamentation(),
             new IsApplicableInterval(compositionConfiguration, ThirtySecondNoteRunProcessor.Interval)
         )
@@ -180,7 +183,7 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
 
     private IPolicyEngine<OrnamentationItem> BuildPedalProcessor(IInputPolicy<OrnamentationItem> scaleDegreePolicy, int pedalInterval) => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(),
+            new WantsToOrnament(_weightedRandomBooleanGenerator),
             new NoteHasNoOrnamentation(),
             scaleDegreePolicy,
             new IsApplicableInterval(compositionConfiguration, PedalProcessor.Interval),
@@ -193,18 +196,18 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
 
     private IPolicyEngine<OrnamentationItem> BuildMordentProcessor() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(1),
+            new WantsToOrnament(_weightedRandomBooleanGenerator, 1),
             new NoteHasNoOrnamentation(),
             new Not<OrnamentationItem>(new BeatContainsTargetOrnamentation(OrnamentationType.Mordent)),
             new IsIntervalWithinVoiceRange(compositionConfiguration, 1).And(new IsIntervalWithinVoiceRange(compositionConfiguration, -1))
         )
-        .WithProcessors(new MordentProcessor(musicalTimeSpanCalculator, compositionConfiguration))
+        .WithProcessors(new MordentProcessor(musicalTimeSpanCalculator, _weightedRandomBooleanGenerator, compositionConfiguration))
         .WithoutOutputPolicies()
         .Build();
 
     private IPolicyEngine<OrnamentationItem> BuildRepeatedNoteProcessor(OrnamentationType ornamentationType) => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(5),
+            new WantsToOrnament(_weightedRandomBooleanGenerator, 5),
             new NoteHasNoOrnamentation()
         )
         .WithProcessors(new RepeatedNoteProcessor(musicalTimeSpanCalculator, compositionConfiguration, ornamentationType))
@@ -213,11 +216,11 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
 
     private IPolicyEngine<OrnamentationItem> BuildNeighborToneProcessor() => PolicyEngineBuilder<OrnamentationItem>.Configure()
         .WithInputPolicies(
-            new WantsToOrnament(25),
+            new WantsToOrnament(_weightedRandomBooleanGenerator, 25),
             new NoteHasNoOrnamentation(),
             new IsRepeatedNote()
         )
-        .WithProcessors(new NeighborToneProcessor(musicalTimeSpanCalculator, compositionConfiguration))
+        .WithProcessors(new NeighborToneProcessor(musicalTimeSpanCalculator, _weightedRandomBooleanGenerator, compositionConfiguration))
         .WithoutOutputPolicies()
         .Build();
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Policies/Input/WantsToOrnament.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Policies/Input/WantsToOrnament.cs
@@ -4,7 +4,7 @@ using BaroquenMelody.Library.Infrastructure.Random;
 namespace BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies.Input;
 
 /// <inheritdoc cref="IInputPolicy{T}"/>
-internal sealed class WantsToOrnament(int Probability = 80) : IInputPolicy<OrnamentationItem>
+internal sealed class WantsToOrnament(IWeightedRandomBooleanGenerator weightedRandomBooleanGenerator, int Probability = 80) : IInputPolicy<OrnamentationItem>
 {
-    public InputPolicyResult ShouldProcess(OrnamentationItem item) => WeightedRandomBooleanGenerator.Generate(Probability) ? InputPolicyResult.Continue : InputPolicyResult.Reject;
+    public InputPolicyResult ShouldProcess(OrnamentationItem item) => weightedRandomBooleanGenerator.IsTrue(Probability) ? InputPolicyResult.Continue : InputPolicyResult.Reject;
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/MordentProcessor.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/MordentProcessor.cs
@@ -9,6 +9,7 @@ namespace BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
 
 internal sealed class MordentProcessor(
     IMusicalTimeSpanCalculator musicalTimeSpanCalculator,
+    IWeightedRandomBooleanGenerator weightedRandomBooleanGenerator,
     CompositionConfiguration compositionConfiguration
 ) : IProcessor<OrnamentationItem>
 {
@@ -20,7 +21,7 @@ internal sealed class MordentProcessor(
 
         var currentNoteIndex = notes.IndexOf(currentNote.Raw);
 
-        var firstNoteIndex = WeightedRandomBooleanGenerator.Generate() ? currentNoteIndex + 1 : currentNoteIndex - 1;
+        var firstNoteIndex = weightedRandomBooleanGenerator.IsTrue() ? currentNoteIndex + 1 : currentNoteIndex - 1;
 
         // ReSharper disable once InlineTemporaryVariable
         var secondNoteIndex = currentNoteIndex;

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/NeighborToneProcessor.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/NeighborToneProcessor.cs
@@ -10,6 +10,7 @@ namespace BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
 /// <inheritdoc cref="IProcessor{T}"/>
 internal sealed class NeighborToneProcessor(
     IMusicalTimeSpanCalculator musicalTimeSpanCalculator,
+    IWeightedRandomBooleanGenerator weightedRandomBooleanGenerator,
     CompositionConfiguration compositionConfiguration
 ) : IProcessor<OrnamentationItem>
 {
@@ -19,7 +20,7 @@ internal sealed class NeighborToneProcessor(
         var notes = compositionConfiguration.Scale.GetNotes();
         var currentNoteScaleIndex = notes.IndexOf(currentNote.Raw);
 
-        var nextNoteScaleIndex = WeightedRandomBooleanGenerator.Generate() ? currentNoteScaleIndex + 1 : currentNoteScaleIndex - 1;
+        var nextNoteScaleIndex = weightedRandomBooleanGenerator.IsTrue() ? currentNoteScaleIndex + 1 : currentNoteScaleIndex - 1;
 
         var nextNote = notes[nextNoteScaleIndex];
 

--- a/src/BaroquenMelody.Library/Compositions/Phrasing/CompositionPhraser.cs
+++ b/src/BaroquenMelody.Library/Compositions/Phrasing/CompositionPhraser.cs
@@ -7,7 +7,12 @@ using BaroquenMelody.Library.Infrastructure.Random;
 
 namespace BaroquenMelody.Library.Compositions.Phrasing;
 
-internal sealed class CompositionPhraser(ICompositionRule compositionRule, IThemeSplitter themeSplitter, CompositionConfiguration compositionConfiguration) : ICompositionPhraser
+internal sealed class CompositionPhraser(
+    ICompositionRule compositionRule,
+    IThemeSplitter themeSplitter,
+    IWeightedRandomBooleanGenerator weightedRandomBooleanGenerator,
+    CompositionConfiguration compositionConfiguration
+) : ICompositionPhraser
 {
     private readonly List<RepeatedPhrase> phrasesToRepeat = [];
 
@@ -95,7 +100,7 @@ internal sealed class CompositionPhraser(ICompositionRule compositionRule, IThem
 
             var lastMeasures = measures.Skip(measures.Count - phraseLength).Take(phraseLength).Select(measure => new Measure(measure)).ToList();
 
-            if (!WeightedRandomBooleanGenerator.Generate(compositionConfiguration.PhrasingConfiguration.PhraseRepetitionProbability) || !CanRepeatPhrase(measures, lastMeasures))
+            if (!weightedRandomBooleanGenerator.IsTrue(compositionConfiguration.PhrasingConfiguration.PhraseRepetitionProbability) || !CanRepeatPhrase(measures, lastMeasures))
             {
                 continue;
             }
@@ -131,7 +136,7 @@ internal sealed class CompositionPhraser(ICompositionRule compositionRule, IThem
     private bool TryRepeatPhrase(List<Measure> measures, RepeatedPhrase repeatedPhrase)
     {
         if (repeatedPhrase.RepetitionCount >= compositionConfiguration.PhrasingConfiguration.MaxPhraseRepetitions ||
-            !WeightedRandomBooleanGenerator.Generate(compositionConfiguration.PhrasingConfiguration.PhraseRepetitionProbability) ||
+            !weightedRandomBooleanGenerator.IsTrue(compositionConfiguration.PhrasingConfiguration.PhraseRepetitionProbability) ||
             !CanRepeatPhrase(measures, repeatedPhrase.Phrase))
         {
             return false;

--- a/src/BaroquenMelody.Library/Compositions/Rules/CompositionRuleBypass.cs
+++ b/src/BaroquenMelody.Library/Compositions/Rules/CompositionRuleBypass.cs
@@ -1,0 +1,15 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Infrastructure.Random;
+
+namespace BaroquenMelody.Library.Compositions.Rules;
+
+/// <summary>
+///     A composition rule that allows for bypass of the underlying composition rule.
+/// </summary>
+internal sealed class CompositionRuleBypass(ICompositionRule rule, IWeightedRandomBooleanGenerator weightedRandomBooleanGenerator, int strictness) : ICompositionRule
+{
+    private const int Threshold = 100;
+
+    public bool Evaluate(IReadOnlyList<BaroquenChord> precedingChords, BaroquenChord nextChord) =>
+        weightedRandomBooleanGenerator.IsTrue(Threshold - strictness) || rule.Evaluate(precedingChords, nextChord);
+}

--- a/src/BaroquenMelody.Library/Infrastructure/Random/IWeightedRandomBooleanGenerator.cs
+++ b/src/BaroquenMelody.Library/Infrastructure/Random/IWeightedRandomBooleanGenerator.cs
@@ -1,0 +1,14 @@
+﻿namespace BaroquenMelody.Library.Infrastructure.Random;
+
+/// <summary>
+///     Generates random boolean values. Can pass a weight probability to increase or decrease the likelihood of a true value.
+/// </summary>
+public interface IWeightedRandomBooleanGenerator
+{
+    /// <summary>
+    ///     Generates a random boolean value.
+    /// </summary>
+    /// <param name="weight">The probability of generating a true value. Default is 50.</param>
+    /// <returns>A random boolean value.</returns>
+    bool IsTrue(int weight = 50);
+}

--- a/src/BaroquenMelody.Library/Infrastructure/Random/WeightedRandomBooleanGenerator.cs
+++ b/src/BaroquenMelody.Library/Infrastructure/Random/WeightedRandomBooleanGenerator.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///     Generates random boolean values. Can pass a probability to increase or decrease the likelihood of a true value.
 /// </summary>
-internal static class WeightedRandomBooleanGenerator
+internal sealed class WeightedRandomBooleanGenerator : IWeightedRandomBooleanGenerator
 {
     private const int Threshold = 100;
 
@@ -12,5 +12,5 @@ internal static class WeightedRandomBooleanGenerator
     /// </summary>
     /// <param name="weight">The probability of generating a true value. Default is 50.</param>
     /// <returns>A random boolean value.</returns>
-    public static bool Generate(int weight = 50) => weight > ThreadLocalRandom.Next(Threshold);
+    public bool IsTrue(int weight = 50) => weight > ThreadLocalRandom.Next(Threshold);
 }

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -11,6 +11,7 @@ using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Compositions.Phrasing;
 using BaroquenMelody.Library.Compositions.Rules;
 using BaroquenMelody.Library.Compositions.Strategies;
+using BaroquenMelody.Library.Infrastructure.Random;
 using Melanchall.DryWetMidi.Common;
 using Melanchall.DryWetMidi.Composing;
 using Melanchall.DryWetMidi.Core;
@@ -81,8 +82,9 @@ var compositionDecorator = new CompositionDecorator(
     compositionConfiguration
 );
 
+var weightedRandomBooleanGenerator = new WeightedRandomBooleanGenerator();
 var themeSplitter = new ThemeSplitter();
-var compositionPhraser = new CompositionPhraser(compositionRule, themeSplitter, compositionConfiguration);
+var compositionPhraser = new CompositionPhraser(compositionRule, themeSplitter, weightedRandomBooleanGenerator, compositionConfiguration);
 var noteTransposer = new NoteTransposer(compositionConfiguration);
 var chordComposer = new ChordComposer(compositionStrategy, compositionConfiguration);
 var chordNumberIdentifier = new ChordNumberIdentifier(compositionConfiguration);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/WantsToOrnamentTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/WantsToOrnamentTests.cs
@@ -3,6 +3,7 @@ using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies.Input;
+using BaroquenMelody.Library.Infrastructure.Random;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -11,11 +12,16 @@ namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Engine.Policie
 [TestFixture]
 internal sealed class WantsToOrnamentTests
 {
+    private IWeightedRandomBooleanGenerator _weightedRandomBooleanGenerator = null!;
+
+    [SetUp]
+    public void SetUp() => _weightedRandomBooleanGenerator = new WeightedRandomBooleanGenerator();
+
     [Test]
     public void ShouldProcess_WhenProbabilityHigherThanRandomNumber_ReturnsContinue()
     {
         // arrange
-        var policy = new WantsToOrnament(101);
+        var policy = new WantsToOrnament(_weightedRandomBooleanGenerator, 101);
 
         var ornamentationItem = new OrnamentationItem(Voice.Soprano, [], new Beat(new BaroquenChord([])), null);
 
@@ -30,7 +36,7 @@ internal sealed class WantsToOrnamentTests
     public void ShouldProcess_WhenProbabilityLowerThanRandomNumber_ReturnsReject()
     {
         // arrange
-        var policy = new WantsToOrnament(-1);
+        var policy = new WantsToOrnament(_weightedRandomBooleanGenerator, -1);
 
         var ornamentationItem = new OrnamentationItem(Voice.Soprano, [], new Beat(new BaroquenChord([])), null);
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Phrasing/CompositionPhraserTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Phrasing/CompositionPhraserTests.cs
@@ -3,6 +3,7 @@ using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Phrasing;
 using BaroquenMelody.Library.Compositions.Rules;
+using BaroquenMelody.Library.Infrastructure.Random;
 using FluentAssertions;
 using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
@@ -17,12 +18,15 @@ internal sealed class CompositionPhraserTests
 
     private IThemeSplitter _mockThemeSplitter = null!;
 
+    private IWeightedRandomBooleanGenerator _weightedRandomBooleanGenerator = null!;
+
     [SetUp]
     public void SetUp()
     {
         _mockCompositionRule = Substitute.For<ICompositionRule>();
         _mockThemeSplitter = Substitute.For<IThemeSplitter>();
         _mockThemeSplitter.SplitThemeIntoPhrases(Arg.Any<BaroquenTheme>()).Returns([]);
+        _weightedRandomBooleanGenerator = new WeightedRandomBooleanGenerator();
     }
 
     [Test]
@@ -209,6 +213,6 @@ internal sealed class CompositionPhraserTests
             16
         );
 
-        return new CompositionPhraser(_mockCompositionRule, _mockThemeSplitter, compositionConfiguration);
+        return new CompositionPhraser(_mockCompositionRule, _mockThemeSplitter, _weightedRandomBooleanGenerator, compositionConfiguration);
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/CompositionRuleBypassTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/CompositionRuleBypassTests.cs
@@ -1,0 +1,62 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Rules;
+using BaroquenMelody.Library.Infrastructure.Random;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Rules;
+
+[TestFixture]
+internal sealed class CompositionRuleBypassTests
+{
+    private ICompositionRule _mockCompositionRule = null!;
+
+    private IWeightedRandomBooleanGenerator _weightedRandomBooleanGenerator = null!;
+
+    private static readonly IReadOnlyList<BaroquenChord> _precedingChords = [];
+
+    private static readonly BaroquenChord _nextChord = new([]);
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockCompositionRule = Substitute.For<ICompositionRule>();
+        _mockCompositionRule.Evaluate(Arg.Any<IReadOnlyList<BaroquenChord>>(), Arg.Any<BaroquenChord>()).Returns(false);
+        _weightedRandomBooleanGenerator = new WeightedRandomBooleanGenerator();
+    }
+
+    [Test]
+    public void When_bypass_is_triggered_rule_is_not_evaluated()
+    {
+        // arrange
+        const int strictness = 0;
+
+        var bypass = new CompositionRuleBypass(_mockCompositionRule, _weightedRandomBooleanGenerator, strictness);
+
+        // act
+        var result = bypass.Evaluate(_precedingChords, _nextChord);
+
+        // assert
+        result.Should().BeTrue();
+
+        _mockCompositionRule.DidNotReceiveWithAnyArgs().Evaluate(default!, default!);
+    }
+
+    [Test]
+    public void When_bypass_is_not_triggered_rule_is_evaluated()
+    {
+        // arrange
+        const int strictness = 100;
+
+        var bypass = new CompositionRuleBypass(_mockCompositionRule, _weightedRandomBooleanGenerator, strictness);
+
+        // act
+        var result = bypass.Evaluate(_precedingChords, _nextChord);
+
+        // assert
+        result.Should().BeFalse();
+
+        _mockCompositionRule.Received(1).Evaluate(_precedingChords, _nextChord);
+    }
+}


### PR DESCRIPTION
## Description

Allow for composition rules to be bypassed based on some probability.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
