### PR TITLE
Configurable Composition Rules

### DIFF
--- a/benchmarks/BaroquenMelody.Benchmarks/Compositions/BenchmarkData.cs
+++ b/benchmarks/BaroquenMelody.Benchmarks/Compositions/BenchmarkData.cs
@@ -21,6 +21,7 @@ internal static class BenchmarkData
             MinPhraseRepetitionPoolSize: 4,
             PhraseRepetitionProbability: 100
         ),
+        AggregateCompositionRuleConfiguration.Default,
         BaroquenScale.Parse("D Dorian"),
         Meter.FourFour,
         25

--- a/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
+++ b/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
@@ -14,10 +14,11 @@
 
   <ItemGroup>
     <PackageReference Include="Atrea.PolicyEngine" Version="4.0.1" />
+    <PackageReference Include="Atrea.Utilities" Version="1.0.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
     <PackageReference Include="LazyCart" Version="0.4.5" />
     <PackageReference Include="Melanchall.DryWetMidi" Version="7.1.0" />
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.161">
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.162">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/BaroquenMelody.Library/Compositions/Composers/EndingComposer.cs
+++ b/src/BaroquenMelody.Library/Compositions/Composers/EndingComposer.cs
@@ -170,6 +170,8 @@ internal sealed class EndingComposer(
 
         var restingChord = new BaroquenChord(finalChordOfComposition);
 
+        restingChord.ResetOrnamentation();
+
         foreach (var note in restingChord.Notes)
         {
             note.OrnamentationType = OrnamentationType.Rest;

--- a/src/BaroquenMelody.Library/Compositions/Configurations/AggregateCompositionRuleConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/AggregateCompositionRuleConfiguration.cs
@@ -1,0 +1,14 @@
+﻿using Atrea.Utilities.Enums;
+using BaroquenMelody.Library.Compositions.Rules.Enums;
+
+namespace BaroquenMelody.Library.Compositions.Configurations;
+
+internal sealed record AggregateCompositionRuleConfiguration(ISet<CompositionRuleConfiguration> Configurations)
+{
+    public static AggregateCompositionRuleConfiguration Default { get; } = new(
+        EnumUtils<ConfigurableCompositionRule>
+            .AsEnumerable()
+            .Select(compositionRule => new CompositionRuleConfiguration(compositionRule))
+            .ToHashSet()
+    );
+}

--- a/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
@@ -10,6 +10,7 @@ namespace BaroquenMelody.Library.Compositions.Configurations;
 /// </summary>
 /// <param name="VoiceConfigurations"> The voice configurations to be used in the composition. </param>
 /// <param name="PhrasingConfiguration"> The phrasing configuration to be used in the composition. </param>
+/// <param name="AggregateCompositionRuleConfiguration"> The configuration of the composition rules to use in the composition. </param>
 /// <param name="Scale"> The scale to be used in the composition. </param>
 /// <param name="CompositionLength"> The length of the composition in measures. </param>
 /// <param name="Meter"> The meter to be used in the composition. </param>
@@ -18,6 +19,7 @@ namespace BaroquenMelody.Library.Compositions.Configurations;
 internal sealed record CompositionConfiguration(
     ISet<VoiceConfiguration> VoiceConfigurations,
     PhrasingConfiguration PhrasingConfiguration,
+    AggregateCompositionRuleConfiguration AggregateCompositionRuleConfiguration,
     BaroquenScale Scale,
     Meter Meter,
     int CompositionLength,
@@ -49,6 +51,7 @@ internal sealed record CompositionConfiguration(
         : this(
             VoiceConfigurations,
             PhrasingConfiguration.Default,
+            AggregateCompositionRuleConfiguration.Default,
             Scale,
             Meter,
             CompositionLength,

--- a/src/BaroquenMelody.Library/Compositions/Configurations/CompositionRuleConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/CompositionRuleConfiguration.cs
@@ -1,0 +1,10 @@
+﻿using BaroquenMelody.Library.Compositions.Rules.Enums;
+
+namespace BaroquenMelody.Library.Compositions.Configurations;
+
+/// <summary>
+///     Represents a configuration for a composition rule.
+/// </summary>
+/// <param name="Rule">The composition rule type.</param>
+/// <param name="Strictness">How strictly the rule should be enforced.</param>
+internal sealed record CompositionRuleConfiguration(ConfigurableCompositionRule Rule, int Strictness = int.MaxValue);

--- a/src/BaroquenMelody.Library/Compositions/Configurations/PhrasingConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/PhrasingConfiguration.cs
@@ -9,12 +9,12 @@
 /// <param name="PhraseRepetitionProbability"> The probability that a phrase will be repeated in the composition. </param>
 internal sealed record PhrasingConfiguration(
     IList<int> PhraseLengths,
-    int MaxPhraseRepetitions = 4,
+    int MaxPhraseRepetitions = 8,
     int MinPhraseRepetitionPoolSize = 2,
-    int PhraseRepetitionProbability = 75
+    int PhraseRepetitionProbability = 100
 )
 {
-    public static PhrasingConfiguration Default => new(PhraseLengths: [1, 2, 4]);
+    public static PhrasingConfiguration Default => new(PhraseLengths: [1, 2, 3, 4, 5, 6, 7, 8]);
 
     public int MinPhraseLength { get; } = PhraseLengths.Min();
 }

--- a/src/BaroquenMelody.Library/Compositions/Rules/CompositionRuleFactory.cs
+++ b/src/BaroquenMelody.Library/Compositions/Rules/CompositionRuleFactory.cs
@@ -1,0 +1,41 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
+using BaroquenMelody.Library.Compositions.Rules.Enums;
+using BaroquenMelody.Library.Infrastructure.Random;
+
+namespace BaroquenMelody.Library.Compositions.Rules;
+
+/// <inheritdoc cref="ICompositionRuleFactory"/>
+internal sealed class CompositionRuleFactory(CompositionConfiguration compositionConfiguration, IWeightedRandomBooleanGenerator weightedRandomBooleanGenerator) : ICompositionRuleFactory
+{
+    private const int Threshold = 100;
+
+    public ICompositionRule CreateAggregate(AggregateCompositionRuleConfiguration aggregateConfiguration) => new AggregateCompositionRule(
+        aggregateConfiguration.Configurations
+            .Select(Create)
+            .Prepend(new EnsureVoiceRange(compositionConfiguration))
+            .ToList()
+    );
+
+    public ICompositionRule Create(CompositionRuleConfiguration configuration)
+    {
+        ICompositionRule compositionRule = configuration.Rule switch
+        {
+            ConfigurableCompositionRule.AvoidDissonance => new AvoidDissonance(),
+            ConfigurableCompositionRule.AvoidDissonantLeaps => new AvoidDissonantLeaps(compositionConfiguration),
+            ConfigurableCompositionRule.HandleAscendingSeventh => new HandleAscendingSeventh(compositionConfiguration),
+            ConfigurableCompositionRule.AvoidRepetition => new AvoidRepetition(),
+            ConfigurableCompositionRule.AvoidParallelFourths => new AvoidParallelIntervals(Interval.PerfectFourth),
+            ConfigurableCompositionRule.AvoidParallelFifths => new AvoidParallelIntervals(Interval.PerfectFifth),
+            ConfigurableCompositionRule.AvoidParallelOctaves => new AvoidParallelIntervals(Interval.Unison),
+            ConfigurableCompositionRule.AvoidDirectFourths => new AvoidDirectIntervals(Interval.PerfectFourth),
+            ConfigurableCompositionRule.AvoidDirectFifths => new AvoidDirectIntervals(Interval.PerfectFifth),
+            ConfigurableCompositionRule.AvoidDirectOctaves => new AvoidDirectIntervals(Interval.Unison),
+            ConfigurableCompositionRule.AvoidOverDoubling => new AvoidOverDoubling(),
+            ConfigurableCompositionRule.FollowStandardChordProgression => new FollowsStandardProgression(compositionConfiguration),
+            _ => throw new ArgumentOutOfRangeException(nameof(configuration), configuration.Rule, "The composition rule is not supported.")
+        };
+
+        return configuration.Strictness < Threshold ? new CompositionRuleBypass(compositionRule, weightedRandomBooleanGenerator, configuration.Strictness) : compositionRule;
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Rules/Enums/ConfigurableCompositionRule.cs
+++ b/src/BaroquenMelody.Library/Compositions/Rules/Enums/ConfigurableCompositionRule.cs
@@ -1,0 +1,67 @@
+﻿namespace BaroquenMelody.Library.Compositions.Rules.Enums;
+
+/// <summary>
+///     Represents the different configurable composition rules available for use.
+/// </summary>
+internal enum ConfigurableCompositionRule : byte
+{
+    /// <summary>
+    ///     Avoid dissonant intervals.
+    /// </summary>
+    AvoidDissonance,
+
+    /// <summary>
+    ///     Avoid dissonant leaps.
+    /// </summary>
+    AvoidDissonantLeaps,
+
+    /// <summary>
+    ///     Handle ascending sevenths.
+    /// </summary>
+    HandleAscendingSeventh,
+
+    /// <summary>
+    ///    Avoid repetition of notes within the same voice.
+    /// </summary>
+    AvoidRepetition,
+
+    /// <summary>
+    ///     Avoid parallel fourths.
+    /// </summary>
+    AvoidParallelFourths,
+
+    /// <summary>
+    ///     Avoid parallel fifths.
+    /// </summary>
+    AvoidParallelFifths,
+
+    /// <summary>
+    ///     Avoid parallel octaves.
+    /// </summary>
+    AvoidParallelOctaves,
+
+    /// <summary>
+    ///     Avoid direct fourths.
+    /// </summary>
+    AvoidDirectFourths,
+
+    /// <summary>
+    ///     Avoid direct fifths.
+    /// </summary>
+    AvoidDirectFifths,
+
+    /// <summary>
+    ///     Avoid direct octaves.
+    /// </summary>
+    AvoidDirectOctaves,
+
+    /// <summary>
+    ///     Avoid over-doubling of voices on the same note.
+    /// </summary>
+    AvoidOverDoubling,
+
+    /// <summary>
+    ///     Follow standard chord progression.
+    /// </summary>
+    FollowStandardChordProgression
+}

--- a/src/BaroquenMelody.Library/Compositions/Rules/ICompositionRuleFactory.cs
+++ b/src/BaroquenMelody.Library/Compositions/Rules/ICompositionRuleFactory.cs
@@ -1,0 +1,16 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+
+namespace BaroquenMelody.Library.Compositions.Rules;
+
+/// <summary>
+///     Creates <see cref="ICompositionRule"/> instances.
+/// </summary>
+internal interface ICompositionRuleFactory
+{
+    /// <summary>
+    ///     Create a composition rule.
+    /// </summary>
+    /// <param name="configuration">The composition rule configuration.</param>
+    /// <returns>The composition rule.</returns>
+    public ICompositionRule Create(CompositionRuleConfiguration configuration);
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsIntervalWithinVoiceRangeTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsIntervalWithinVoiceRangeTests.cs
@@ -28,6 +28,7 @@ internal sealed class IsIntervalWithinVoiceRangeTests
                 new(Voice.Bass, Notes.G0, Notes.C2)
             },
             PhrasingConfiguration.Default,
+            AggregateCompositionRuleConfiguration.Default,
             BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             25

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Phrasing/CompositionPhraserTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Phrasing/CompositionPhraserTests.cs
@@ -212,6 +212,7 @@ internal sealed class CompositionPhraserTests
         var compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>(),
             phrasingConfiguration,
+            AggregateCompositionRuleConfiguration.Default,
             BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             16

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidDissonantLeapTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidDissonantLeapTests.cs
@@ -32,6 +32,7 @@ internal sealed class AvoidDissonantLeapsTests
                 new(Voice.Bass, Notes.C2, Notes.C3)
             },
             phrasingConfiguration,
+            AggregateCompositionRuleConfiguration.Default,
             BaroquenScale.Parse("C Major"),
             Meter.FourFour,
             100

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/CompositionRuleFactoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/CompositionRuleFactoryTests.cs
@@ -1,0 +1,84 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Rules;
+using BaroquenMelody.Library.Compositions.Rules.Enums;
+using BaroquenMelody.Library.Infrastructure.Random;
+using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Rules;
+
+[TestFixture]
+internal sealed class CompositionRuleFactoryTests
+{
+    private CompositionRuleFactory _factory = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var compositionConfiguration = new CompositionConfiguration(
+            new HashSet<VoiceConfiguration>
+            {
+                new(Voice.Soprano, Notes.C3, Notes.C5),
+                new(Voice.Alto, Notes.C2, Notes.C4)
+            },
+            BaroquenScale.Parse("C Major"),
+            Meter.FourFour,
+            CompositionLength: 100
+        );
+
+        _factory = new CompositionRuleFactory(compositionConfiguration, Substitute.For<IWeightedRandomBooleanGenerator>());
+    }
+
+    [Test]
+    [TestCase(ConfigurableCompositionRule.AvoidDissonance, int.MaxValue, typeof(AvoidDissonance))]
+    [TestCase(ConfigurableCompositionRule.AvoidDissonantLeaps, int.MaxValue, typeof(AvoidDissonantLeaps))]
+    [TestCase(ConfigurableCompositionRule.HandleAscendingSeventh, int.MaxValue, typeof(HandleAscendingSeventh))]
+    [TestCase(ConfigurableCompositionRule.AvoidRepetition, int.MaxValue, typeof(AvoidRepetition))]
+    [TestCase(ConfigurableCompositionRule.AvoidParallelFourths, int.MaxValue, typeof(AvoidParallelIntervals))]
+    [TestCase(ConfigurableCompositionRule.AvoidParallelFifths, int.MaxValue, typeof(AvoidParallelIntervals))]
+    [TestCase(ConfigurableCompositionRule.AvoidParallelOctaves, int.MaxValue, typeof(AvoidParallelIntervals))]
+    [TestCase(ConfigurableCompositionRule.AvoidDirectFourths, int.MaxValue, typeof(AvoidDirectIntervals))]
+    [TestCase(ConfigurableCompositionRule.AvoidDirectFifths, int.MaxValue, typeof(AvoidDirectIntervals))]
+    [TestCase(ConfigurableCompositionRule.AvoidDirectOctaves, int.MaxValue, typeof(AvoidDirectIntervals))]
+    [TestCase(ConfigurableCompositionRule.AvoidOverDoubling, int.MaxValue, typeof(AvoidOverDoubling))]
+    [TestCase(ConfigurableCompositionRule.FollowStandardChordProgression, int.MaxValue, typeof(FollowsStandardProgression))]
+    [TestCase(ConfigurableCompositionRule.AvoidDissonance, int.MinValue, typeof(CompositionRuleBypass))]
+    public void Create_returns_expected_rule(ConfigurableCompositionRule rule, int strictness, Type expectedRuleType)
+    {
+        // arrange
+        var configuration = new CompositionRuleConfiguration(rule, strictness);
+
+        // act
+        var result = _factory.Create(configuration);
+
+        // assert
+        result.Should().BeOfType(expectedRuleType);
+    }
+
+    [Test]
+    public void Create_WhenCompositionRuleIsUnsupported_ThrowsArgumentOutOfRangeException()
+    {
+        // arrange
+        var configuration = new CompositionRuleConfiguration((ConfigurableCompositionRule)byte.MaxValue);
+
+        // act
+        var act = () => _factory.Create(configuration);
+
+        // assert
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public void CreateAggregate_returns_expected_rule()
+    {
+        // act
+        var result = _factory.CreateAggregate(AggregateCompositionRuleConfiguration.Default);
+
+        // assert
+        result.Should().BeOfType<AggregateCompositionRule>();
+    }
+}


### PR DESCRIPTION
## Description

Add configurations and factory for composition rules, allowing for composition rule configuration with optional bypass.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
