### PR TITLE
Further Naming Convention Cleanup

### DIFF
--- a/src/BaroquenMelody.Library/Compositions/Domain/BaroquenNote.cs
+++ b/src/BaroquenMelody.Library/Compositions/Domain/BaroquenNote.cs
@@ -35,7 +35,7 @@ internal sealed class BaroquenNote(Voice voice, Note raw) : IEquatable<BaroquenN
     public SevenBitNumber NoteNumber => Raw.NoteNumber;
 
     /// <summary>
-    ///     The duration of the note. May be modified if the note is ornamented.
+    ///     The musical time span of the note. May be modified if the note is ornamented.
     /// </summary>
     public MusicalTimeSpan MusicalTimeSpan { get; set; } = MusicalTimeSpan.Quarter;
 

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/PedalProcessor.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/Processors/PedalProcessor.cs
@@ -40,13 +40,13 @@ internal sealed class PedalProcessor(
 
         currentNote.MusicalTimeSpan = musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.Pedal, compositionConfiguration.Meter);
 
-        var ornamentationDuration = musicalTimeSpanCalculator.CalculateOrnamentationTimeSpan(OrnamentationType.Pedal, compositionConfiguration.Meter);
+        var ornamentationTimeSpan = musicalTimeSpanCalculator.CalculateOrnamentationTimeSpan(OrnamentationType.Pedal, compositionConfiguration.Meter);
 
         foreach (var note in ornamentationNotes)
         {
             currentNote.Ornamentations.Add(new BaroquenNote(currentNote.Voice, note)
             {
-                MusicalTimeSpan = ornamentationDuration
+                MusicalTimeSpan = ornamentationTimeSpan
             });
         }
 

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/ICompositionDecorator.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/ICompositionDecorator.cs
@@ -22,7 +22,7 @@ internal interface ICompositionDecorator
     void Decorate(Composition composition, Voice voice);
 
     /// <summary>
-    ///    Apply sustain to the composition by identifying repeated notes and extending their duration.
+    ///    Apply sustain to the composition by identifying repeated notes and extending their musical time span.
     /// </summary>
     /// <param name="composition">The composition to apply sustain to.</param>
     void ApplySustain(Composition composition);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BaroquenNoteTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BaroquenNoteTests.cs
@@ -67,7 +67,7 @@ internal sealed class BaroquenNoteTests
             var noteWithDifferentPitch = new BaroquenNote(Voice.Soprano, Notes.D1);
             var noteWithDifferentVoice = new BaroquenNote(Voice.Alto, Notes.C1);
 
-            var noteWithDifferentDuration = new BaroquenNote(Voice.Soprano, Notes.C1)
+            var noteWithDifferentMusicalTimeSpan = new BaroquenNote(Voice.Soprano, Notes.C1)
             {
                 MusicalTimeSpan = note.MusicalTimeSpan.Triplet()
             };
@@ -87,7 +87,7 @@ internal sealed class BaroquenNoteTests
 
             yield return new TestCaseData(note, noteWithDifferentVoice, false).SetName("Notes with different voices are not equal");
 
-            yield return new TestCaseData(note, noteWithDifferentDuration, false).SetName("Notes with different durations are not equal");
+            yield return new TestCaseData(note, noteWithDifferentMusicalTimeSpan, false).SetName("Notes with different musical time spans are not equal");
 
             yield return new TestCaseData(note, noteWithOrnamentation, false).SetName("Notes with different ornamentations are not equal");
 


### PR DESCRIPTION
## Description

Address remaining "duration" naming, renamed to "musical time span".

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
