### PR TITLE
Add Default Note TimeSpan

### DIFF
--- a/benchmarks/BaroquenMelody.Benchmarks/Compositions/BenchmarkData.cs
+++ b/benchmarks/BaroquenMelody.Benchmarks/Compositions/BenchmarkData.cs
@@ -25,6 +25,7 @@ internal static class BenchmarkData
         AggregateCompositionRuleConfiguration.Default,
         BaroquenScale.Parse("D Dorian"),
         Meter.FourFour,
+        MusicalTimeSpan.Half,
         25
     );
 

--- a/src/BaroquenMelody.Library/Compositions/Composers/ChordComposer.cs
+++ b/src/BaroquenMelody.Library/Compositions/Composers/ChordComposer.cs
@@ -1,8 +1,6 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Extensions;
-using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Compositions.Strategies;
 using BaroquenMelody.Library.Infrastructure.Exceptions;
 using BaroquenMelody.Library.Infrastructure.Logging;
@@ -14,7 +12,6 @@ namespace BaroquenMelody.Library.Compositions.Composers;
 /// <inheritdoc cref="IChordComposer"/>
 internal sealed class ChordComposer(
     ICompositionStrategy compositionStrategy,
-    IMusicalTimeSpanCalculator musicalTimeSpanCalculator,
     CompositionConfiguration compositionConfiguration,
     ILogger logger) : IChordComposer
 {
@@ -22,11 +19,10 @@ internal sealed class ChordComposer(
     {
         var possibleChordChoices = compositionStrategy.GetPossibleChordChoices(precedingChords);
         var chordChoice = possibleChordChoices.MinBy(static _ => ThreadLocalRandom.Next());
-        var timeSpan = musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.None, compositionConfiguration.Meter);
 
         if (chordChoice != null)
         {
-            return precedingChords[^1].ApplyChordChoice(compositionConfiguration.Scale, chordChoice, timeSpan);
+            return precedingChords[^1].ApplyChordChoice(compositionConfiguration.Scale, chordChoice, compositionConfiguration.DefaultNoteTimeSpan);
         }
 
         logger.NoValidChordChoicesAvailable();

--- a/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
@@ -1,7 +1,8 @@
 ﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Enums.Extensions;
-using Melanchall.DryWetMidi.MusicTheory;
+using Melanchall.DryWetMidi.Interaction;
+using Note = Melanchall.DryWetMidi.MusicTheory.Note;
 
 namespace BaroquenMelody.Library.Compositions.Configurations;
 
@@ -14,6 +15,7 @@ namespace BaroquenMelody.Library.Compositions.Configurations;
 /// <param name="Scale"> The scale to be used in the composition. </param>
 /// <param name="CompositionLength"> The length of the composition in measures. </param>
 /// <param name="Meter"> The meter to be used in the composition. </param>
+/// <param name="DefaultNoteTimeSpan"> The default note time span to be used in the composition. </param>
 /// <param name="CompositionContextSize"> The size of the context to be used in the composition. </param>
 /// <param name="Tempo"> The tempo of the composition, in beats per minute. </param>
 internal sealed record CompositionConfiguration(
@@ -22,6 +24,7 @@ internal sealed record CompositionConfiguration(
     AggregateCompositionRuleConfiguration AggregateCompositionRuleConfiguration,
     BaroquenScale Scale,
     Meter Meter,
+    MusicalTimeSpan DefaultNoteTimeSpan,
     int CompositionLength,
     int CompositionContextSize = 8,
     int Tempo = 120)
@@ -41,21 +44,4 @@ internal sealed record CompositionConfiguration(
     /// <param name="note">The note to check against the voice.</param>
     /// <returns>Whether the note is within the range of the voice.</returns>
     public bool IsNoteInVoiceRange(Voice voice, Note note) => VoiceConfigurationsByVoice[voice].IsNoteWithinVoiceRange(note);
-
-    public CompositionConfiguration(
-        ISet<VoiceConfiguration> VoiceConfigurations,
-        BaroquenScale Scale,
-        Meter Meter,
-        int CompositionLength,
-        int CompositionContextSize = 4)
-        : this(
-            VoiceConfigurations,
-            PhrasingConfiguration.Default,
-            AggregateCompositionRuleConfiguration.Default,
-            Scale,
-            Meter,
-            CompositionLength,
-            CompositionContextSize)
-    {
-    }
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/EighthNoteOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/EighthNoteOrnamentationCleaner.cs
@@ -1,15 +1,10 @@
 ﻿using Atrea.PolicyEngine.Processors;
 using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Extensions;
-using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 
 namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
 
-internal sealed class EighthNoteOrnamentationCleaner(
-    IMusicalTimeSpanCalculator musicalTimeSpanCalculator,
-    CompositionConfiguration compositionConfiguration
-) : IProcessor<OrnamentationCleaningItem>
+internal sealed class EighthNoteOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
 {
     private static readonly int[] _ornamentationIndices = [0, 1, 2];
 
@@ -20,15 +15,13 @@ internal sealed class EighthNoteOrnamentationCleaner(
             return;
         }
 
-        var defaultTimeSpan = musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.None, compositionConfiguration.Meter);
-
         if (item.Note > item.OtherNote)
         {
-            item.OtherNote.ResetOrnamentation(defaultTimeSpan);
+            item.OtherNote.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
         }
         else
         {
-            item.Note.ResetOrnamentation(defaultTimeSpan);
+            item.Note.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
         }
     }
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/MordentEighthNoteOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/MordentEighthNoteOrnamentationCleaner.cs
@@ -2,14 +2,10 @@
 using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Extensions;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 
 namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
 
-internal sealed class MordentEighthNoteOrnamentationCleaner(
-    IMusicalTimeSpanCalculator musicalTimeSpanCalculator,
-    CompositionConfiguration compositionConfiguration
-) : IProcessor<OrnamentationCleaningItem>
+internal sealed class MordentEighthNoteOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
 {
     private const int IndexToCheck = 1;
 
@@ -20,15 +16,13 @@ internal sealed class MordentEighthNoteOrnamentationCleaner(
             return;
         }
 
-        var defaultTimeSpan = musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.None, compositionConfiguration.Meter);
-
         if (item.Note.OrnamentationType == OrnamentationType.Mordent)
         {
-            item.Note.ResetOrnamentation(defaultTimeSpan);
+            item.Note.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
         }
         else
         {
-            item.OtherNote.ResetOrnamentation(defaultTimeSpan);
+            item.OtherNote.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
         }
     }
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/QuarterEighthNoteOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/QuarterEighthNoteOrnamentationCleaner.cs
@@ -3,14 +3,10 @@ using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Extensions;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 
 namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
 
-internal sealed class QuarterEighthNoteOrnamentationCleaner(
-    IMusicalTimeSpanCalculator musicalTimeSpanCalculator,
-    CompositionConfiguration compositionConfiguration
-) : IProcessor<OrnamentationCleaningItem>
+internal sealed class QuarterEighthNoteOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
 {
     private const int PassingToneIndexToCheck = 0;
 
@@ -35,8 +31,6 @@ internal sealed class QuarterEighthNoteOrnamentationCleaner(
             return;
         }
 
-        var defaultTimeSpan = musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.None, compositionConfiguration.Meter);
-
-        noteWithPassingToneOrnamentation.ResetOrnamentation(defaultTimeSpan);
+        noteWithPassingToneOrnamentation.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
     }
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/QuarterNoteOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/QuarterNoteOrnamentationCleaner.cs
@@ -3,14 +3,10 @@ using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Extensions;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 
 namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
 
-internal sealed class QuarterNoteOrnamentationCleaner(
-    IMusicalTimeSpanCalculator musicalTimeSpanCalculator,
-    CompositionConfiguration compositionConfiguration
-) : IProcessor<OrnamentationCleaningItem>
+internal sealed class QuarterNoteOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
 {
     private const int IndexToCheck = 0;
 
@@ -24,25 +20,23 @@ internal sealed class QuarterNoteOrnamentationCleaner(
             return;
         }
 
-        var defaultTimeSpan = musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.None, compositionConfiguration.Meter);
-
         if (ShouldCleanNoteBasedOnOrnamentation(note, otherNote))
         {
-            otherNote.ResetOrnamentation(defaultTimeSpan);
+            otherNote.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
         }
         else if (ShouldCleanNoteBasedOnOrnamentation(otherNote, note))
         {
-            note.ResetOrnamentation(defaultTimeSpan);
+            note.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
         }
         else
         {
             if (note > otherNote)
             {
-                otherNote.ResetOrnamentation(defaultTimeSpan);
+                otherNote.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
             }
             else
             {
-                note.ResetOrnamentation(defaultTimeSpan);
+                note.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
             }
         }
     }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/SixteenthEighthNoteOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/SixteenthEighthNoteOrnamentationCleaner.cs
@@ -3,14 +3,10 @@ using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Extensions;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 
 namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
 
-internal sealed class SixteenthEighthNoteOrnamentationCleaner(
-    IMusicalTimeSpanCalculator musicalTimeSpanCalculator,
-    CompositionConfiguration compositionConfiguration
-) : IProcessor<OrnamentationCleaningItem>
+internal sealed class SixteenthEighthNoteOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
 {
     private static readonly (int EighthNoteIndex, int SixteenthNoteIndex)[] IndicesToCheck = [(0, 1), (1, 3), (2, 5)];
 
@@ -33,15 +29,13 @@ internal sealed class SixteenthEighthNoteOrnamentationCleaner(
             return;
         }
 
-        var defaultTimeSpan = musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.None, compositionConfiguration.Meter);
-
         if (noteWithEighthNotes > noteWithSixteenthNotes)
         {
-            noteWithSixteenthNotes.ResetOrnamentation(defaultTimeSpan);
+            noteWithSixteenthNotes.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
         }
         else
         {
-            noteWithEighthNotes.ResetOrnamentation(defaultTimeSpan);
+            noteWithEighthNotes.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
         }
     }
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/SixteenthNoteOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/SixteenthNoteOrnamentationCleaner.cs
@@ -1,15 +1,10 @@
 ﻿using Atrea.PolicyEngine.Processors;
 using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Extensions;
-using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 
 namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
 
-internal sealed class SixteenthNoteOrnamentationCleaner(
-    IMusicalTimeSpanCalculator musicalTimeSpanCalculator,
-    CompositionConfiguration compositionConfiguration
-) : IProcessor<OrnamentationCleaningItem>
+internal sealed class SixteenthNoteOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
 {
     private static readonly int[] IndicesToCheck = [1, 3, 5];
 
@@ -20,15 +15,13 @@ internal sealed class SixteenthNoteOrnamentationCleaner(
             return;
         }
 
-        var defaultTimeSpan = musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.None, compositionConfiguration.Meter);
-
         if (item.Note > item.OtherNote)
         {
-            item.OtherNote.ResetOrnamentation(defaultTimeSpan);
+            item.OtherNote.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
         }
         else
         {
-            item.Note.ResetOrnamentation(defaultTimeSpan);
+            item.Note.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
         }
     }
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/TurnAlternateTurnOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/TurnAlternateTurnOrnamentationCleaner.cs
@@ -3,14 +3,10 @@ using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Extensions;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 
 namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
 
-internal sealed class TurnAlternateTurnOrnamentationCleaner(
-    IMusicalTimeSpanCalculator musicalTimeSpanCalculator,
-    CompositionConfiguration compositionConfiguration
-) : IProcessor<OrnamentationCleaningItem>
+internal sealed class TurnAlternateTurnOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
 {
     private const int IndexToCheck = 1;
 
@@ -33,8 +29,6 @@ internal sealed class TurnAlternateTurnOrnamentationCleaner(
             return;
         }
 
-        var defaultTimeSpan = musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.None, compositionConfiguration.Meter);
-
-        noteWithAlternateTurnOrnamentation.ResetOrnamentation(defaultTimeSpan);
+        noteWithAlternateTurnOrnamentation.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
     }
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/OrnamentationEngineBuilder.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Engine/OrnamentationEngineBuilder.cs
@@ -32,13 +32,13 @@ internal sealed class OrnamentationEngineBuilder(CompositionConfiguration compos
     private readonly IInputPolicy<OrnamentationItem> _hasNoOrnamentation = new Not<OrnamentationItem>(new HasOrnamentation());
 
     private readonly OrnamentationCleaningEngineBuilder _ornamentationCleaningEngineBuilder = new(
-        new QuarterNoteOrnamentationCleaner(musicalTimeSpanCalculator, compositionConfiguration),
-        new EighthNoteOrnamentationCleaner(musicalTimeSpanCalculator, compositionConfiguration),
-        new QuarterEighthNoteOrnamentationCleaner(musicalTimeSpanCalculator, compositionConfiguration),
-        new TurnAlternateTurnOrnamentationCleaner(musicalTimeSpanCalculator, compositionConfiguration),
-        new SixteenthNoteOrnamentationCleaner(musicalTimeSpanCalculator, compositionConfiguration),
-        new SixteenthEighthNoteOrnamentationCleaner(musicalTimeSpanCalculator, compositionConfiguration),
-        new MordentEighthNoteOrnamentationCleaner(musicalTimeSpanCalculator, compositionConfiguration)
+        new QuarterNoteOrnamentationCleaner(compositionConfiguration),
+        new EighthNoteOrnamentationCleaner(compositionConfiguration),
+        new QuarterEighthNoteOrnamentationCleaner(compositionConfiguration),
+        new TurnAlternateTurnOrnamentationCleaner(compositionConfiguration),
+        new SixteenthNoteOrnamentationCleaner(compositionConfiguration),
+        new SixteenthEighthNoteOrnamentationCleaner(compositionConfiguration),
+        new MordentEighthNoteOrnamentationCleaner(compositionConfiguration)
     );
 
     public IPolicyEngine<OrnamentationItem> BuildOrnamentationEngine() => PolicyEngineBuilder<OrnamentationItem>.Configure()

--- a/src/BaroquenMelody.Library/Compositions/Phrasing/CompositionPhraser.cs
+++ b/src/BaroquenMelody.Library/Compositions/Phrasing/CompositionPhraser.cs
@@ -1,7 +1,6 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Compositions.Rules;
 using BaroquenMelody.Library.Infrastructure.Collections;
 using BaroquenMelody.Library.Infrastructure.Logging;
@@ -16,7 +15,6 @@ internal sealed class CompositionPhraser(
     ICompositionRule compositionRule,
     IThemeSplitter themeSplitter,
     IWeightedRandomBooleanGenerator weightedRandomBooleanGenerator,
-    IMusicalTimeSpanCalculator musicalTimeSpanCalculator,
     ILogger logger,
     CompositionConfiguration compositionConfiguration
 ) : ICompositionPhraser
@@ -43,11 +41,9 @@ internal sealed class CompositionPhraser(
     {
         themePhrasesToRepeat = themeSplitter.SplitThemeIntoPhrases(theme);
 
-        var defaultTimeSpan = musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.None, compositionConfiguration.Meter);
-
         foreach (var themePhraseToRepeat in themePhrasesToRepeat.ToList())
         {
-            ResetPhraseEndOrnamentation(themePhraseToRepeat.Phrase[^1], defaultTimeSpan);
+            ResetPhraseEndOrnamentation(themePhraseToRepeat.Phrase[^1], compositionConfiguration.DefaultNoteTimeSpan);
         }
     }
 
@@ -126,9 +122,7 @@ internal sealed class CompositionPhraser(
 
             phrasesToRepeat.Add(repeatedPhrase);
 
-            var defaultTimeSpan = musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.None, compositionConfiguration.Meter);
-
-            ResetPhraseEndOrnamentation(measures[^1], defaultTimeSpan);
+            ResetPhraseEndOrnamentation(measures[^1], compositionConfiguration.DefaultNoteTimeSpan);
 
             measures.AddRange(lastMeasures.Select(static measure => new Measure(measure)));
 
@@ -158,9 +152,7 @@ internal sealed class CompositionPhraser(
             return false;
         }
 
-        var defaultTimeSpan = musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.None, compositionConfiguration.Meter);
-
-        ResetPhraseEndOrnamentation(measures[^1], defaultTimeSpan);
+        ResetPhraseEndOrnamentation(measures[^1], compositionConfiguration.DefaultNoteTimeSpan);
 
         measures.AddRange(repeatedPhrase.Phrase.Select(static measure => new Measure(measure)).ToList());
         repeatedPhrase.RepetitionCount++;

--- a/src/BaroquenMelody.Library/Compositions/Strategies/CompositionStrategyFactory.cs
+++ b/src/BaroquenMelody.Library/Compositions/Strategies/CompositionStrategyFactory.cs
@@ -1,6 +1,5 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
 using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Compositions.Rules;
 using Microsoft.Extensions.Logging;
 
@@ -10,14 +9,12 @@ namespace BaroquenMelody.Library.Compositions.Strategies;
 internal sealed class CompositionStrategyFactory(
     IChordChoiceRepositoryFactory chordChoiceRepositoryFactory,
     ICompositionRule compositionRule,
-    IMusicalTimeSpanCalculator musicalTimeSpanCalculator,
     ILogger logger
 ) : ICompositionStrategyFactory
 {
     public ICompositionStrategy Create(CompositionConfiguration compositionConfiguration) => new CompositionStrategy(
         chordChoiceRepositoryFactory.Create(compositionConfiguration),
         compositionRule,
-        musicalTimeSpanCalculator,
         logger,
         compositionConfiguration,
         maxLookAheadDepth: 1

--- a/src/BaroquenMelody.Library/Midi/Extensions/PatternBuilderExtensions.cs
+++ b/src/BaroquenMelody.Library/Midi/Extensions/PatternBuilderExtensions.cs
@@ -28,5 +28,6 @@ internal static class PatternBuilderExtensions
     ///     Add a rest to the <see cref="PatternBuilder"/>.
     /// </summary>
     /// <param name="patternBuilder">The <see cref="PatternBuilder"/> to add the rest to.</param>
-    public static void AddRest(this PatternBuilder patternBuilder) => patternBuilder.StepForward(MusicalTimeSpan.Half);
+    /// <param name="length">The length of the rest to add to the <see cref="PatternBuilder"/>.</param>
+    public static void AddRest(this PatternBuilder patternBuilder, MusicalTimeSpan length) => patternBuilder.StepForward(length);
 }

--- a/src/BaroquenMelody.Library/Midi/MidiGenerator.cs
+++ b/src/BaroquenMelody.Library/Midi/MidiGenerator.cs
@@ -36,7 +36,7 @@ internal sealed class MidiGenerator(CompositionConfiguration compositionConfigur
         voiceConfiguration => new PatternBuilder().ProgramChange(voiceConfiguration.Instrument)
     );
 
-    private static void ProcessMeasure(Measure measure, Dictionary<Voice, PatternBuilder> patternBuildersByVoice)
+    private void ProcessMeasure(Measure measure, Dictionary<Voice, PatternBuilder> patternBuildersByVoice)
     {
         foreach (var beat in measure.Beats)
         {
@@ -44,7 +44,7 @@ internal sealed class MidiGenerator(CompositionConfiguration compositionConfigur
         }
     }
 
-    private static void ProcessBeat(Beat beat, Dictionary<Voice, PatternBuilder> patternBuildersByVoice)
+    private void ProcessBeat(Beat beat, Dictionary<Voice, PatternBuilder> patternBuildersByVoice)
     {
         foreach (var (voice, patternBuilder) in patternBuildersByVoice)
         {
@@ -52,11 +52,11 @@ internal sealed class MidiGenerator(CompositionConfiguration compositionConfigur
         }
     }
 
-    private static void ProcessVoice(Voice voice, Beat beat, PatternBuilder patternBuilder)
+    private void ProcessVoice(Voice voice, Beat beat, PatternBuilder patternBuilder)
     {
         if (!beat.ContainsVoice(voice))
         {
-            patternBuilder.AddRest();
+            patternBuilder.AddRest(compositionConfiguration.DefaultNoteTimeSpan);
 
             return;
         }
@@ -77,14 +77,14 @@ internal sealed class MidiGenerator(CompositionConfiguration compositionConfigur
     /// <param name="patternBuilder">The pattern builder to potentially handle a restful ornamentation in.</param>
     /// <param name="note">The note, which might have a restful ornamentation.</param>
     /// <returns>Whether a restful ornamentation was handled.</returns>
-    private static bool HandledRestfulOrnamentation(PatternBuilder patternBuilder, BaroquenNote note)
+    private bool HandledRestfulOrnamentation(PatternBuilder patternBuilder, BaroquenNote note)
     {
         switch (note.OrnamentationType)
         {
             case OrnamentationType.MidSustain:
                 return true;
             case OrnamentationType.Rest:
-                patternBuilder.AddRest();
+                patternBuilder.AddRest(compositionConfiguration.DefaultNoteTimeSpan);
                 return true;
             default:
                 return false;

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -31,6 +31,8 @@ var phrasingConfiguration = new PhrasingConfiguration(
 
 var musicalTimeSpanCalculator = new MusicalTimeSpanCalculator();
 
+var meter = Meter.FourFour;
+
 var compositionConfiguration = new CompositionConfiguration(
     new HashSet<VoiceConfiguration>
     {
@@ -42,8 +44,8 @@ var compositionConfiguration = new CompositionConfiguration(
     phrasingConfiguration,
     AggregateCompositionRuleConfiguration.Default,
     BaroquenScale.Parse("C Ionian"),
-    Meter.FourFour,
-    musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.None, Meter.FourFour),
+    meter,
+    musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.None, meter),
     25
 );
 

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -6,6 +6,7 @@ using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.MusicTheory;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Compositions.Phrasing;
 using BaroquenMelody.Library.Compositions.Rules;
@@ -28,6 +29,8 @@ var phrasingConfiguration = new PhrasingConfiguration(
     PhraseRepetitionProbability: 100
 );
 
+var musicalTimeSpanCalculator = new MusicalTimeSpanCalculator();
+
 var compositionConfiguration = new CompositionConfiguration(
     new HashSet<VoiceConfiguration>
     {
@@ -40,6 +43,7 @@ var compositionConfiguration = new CompositionConfiguration(
     AggregateCompositionRuleConfiguration.Default,
     BaroquenScale.Parse("C Ionian"),
     Meter.FourFour,
+    musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.None, Meter.FourFour),
     25
 );
 
@@ -48,14 +52,12 @@ var logger = factory.CreateLogger<Composer>();
 
 var compositionRuleFactory = new CompositionRuleFactory(compositionConfiguration, new WeightedRandomBooleanGenerator());
 var compositionRule = compositionRuleFactory.CreateAggregate(compositionConfiguration.AggregateCompositionRuleConfiguration);
-var musicalTimeSpanCalculator = new MusicalTimeSpanCalculator();
 
 var compositionStrategyFactory = new CompositionStrategyFactory(
     new ChordChoiceRepositoryFactory(
         new NoteChoiceGenerator()
     ),
     compositionRule,
-    musicalTimeSpanCalculator,
     logger
 );
 
@@ -70,9 +72,9 @@ var compositionDecorator = new CompositionDecorator(
 
 var weightedRandomBooleanGenerator = new WeightedRandomBooleanGenerator();
 var themeSplitter = new ThemeSplitter();
-var compositionPhraser = new CompositionPhraser(compositionRule, themeSplitter, weightedRandomBooleanGenerator, musicalTimeSpanCalculator, logger, compositionConfiguration);
+var compositionPhraser = new CompositionPhraser(compositionRule, themeSplitter, weightedRandomBooleanGenerator, logger, compositionConfiguration);
 var noteTransposer = new NoteTransposer(compositionConfiguration);
-var chordComposer = new ChordComposer(compositionStrategy, musicalTimeSpanCalculator, compositionConfiguration, logger);
+var chordComposer = new ChordComposer(compositionStrategy, compositionConfiguration, logger);
 var chordNumberIdentifier = new ChordNumberIdentifier(compositionConfiguration);
 
 var themeComposer = new ThemeComposer(
@@ -88,7 +90,6 @@ var endingComposer = new EndingComposer(
     compositionStrategy,
     compositionDecorator,
     chordNumberIdentifier,
-    musicalTimeSpanCalculator,
     logger,
     compositionConfiguration
 );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/ChordChoiceRepositoryFactoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/ChordChoiceRepositoryFactoryTests.cs
@@ -1,10 +1,6 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
-using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
-using BaroquenMelody.Library.Compositions.Enums;
-using BaroquenMelody.Library.Compositions.Extensions;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
-using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -32,16 +28,8 @@ internal sealed class ChordChoiceRepositoryFactoryTests
         int numberOfVoices,
         Type expectedType)
     {
-        // arrange
-        var compositionConfiguration = new CompositionConfiguration(
-            GenerateVoiceConfigurations(numberOfVoices),
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
-
         // act
-        var chordChoiceRepository = _chordChoiceRepositoryFactory.Create(compositionConfiguration);
+        var chordChoiceRepository = _chordChoiceRepositoryFactory.Create(Configurations.GetCompositionConfiguration(numberOfVoices));
 
         // assert
         chordChoiceRepository.Should().BeOfType(expectedType);
@@ -50,45 +38,10 @@ internal sealed class ChordChoiceRepositoryFactoryTests
     [Test]
     public void WhenChordChoiceRepositoryIsPassedInvalidConfiguration_ItThrows()
     {
-        // arrange
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                // invalid configuration: only one voice
-                new(Voice.Soprano, 55.ToNote(), 90.ToNote())
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
-
         // act
-        var act = () => _chordChoiceRepositoryFactory.Create(compositionConfiguration);
+        var act = () => _chordChoiceRepositoryFactory.Create(Configurations.GetCompositionConfiguration(1));
 
         // assert
         act.Should().Throw<ArgumentException>();
     }
-
-    private static HashSet<VoiceConfiguration> GenerateVoiceConfigurations(int numberOfVoices) => numberOfVoices switch
-    {
-        2 =>
-        [
-            new VoiceConfiguration(Voice.Soprano, Notes.C4, Notes.C5),
-            new VoiceConfiguration(Voice.Alto, Notes.C3, Notes.C4)
-        ],
-        3 =>
-        [
-            new VoiceConfiguration(Voice.Soprano, Notes.C4, Notes.C5),
-            new VoiceConfiguration(Voice.Alto, Notes.C3, Notes.C4),
-            new VoiceConfiguration(Voice.Tenor, Notes.C2, Notes.C3)
-        ],
-        4 =>
-        [
-            new VoiceConfiguration(Voice.Soprano, Notes.C4, Notes.C5),
-            new VoiceConfiguration(Voice.Alto, Notes.C3, Notes.C4),
-            new VoiceConfiguration(Voice.Tenor, Notes.C2, Notes.C3),
-            new VoiceConfiguration(Voice.Bass, Notes.C1, Notes.C2)
-        ],
-        _ => throw new ArgumentException("Invalid number of voices.")
-    };
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/DuetChordChoiceRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/DuetChordChoiceRepositoryTests.cs
@@ -1,8 +1,6 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
-using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
-using BaroquenMelody.Library.Compositions.Extensions;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
@@ -46,16 +44,7 @@ internal sealed class DuetChordChoiceRepositoryTests
     public void WhenDuetChordChoiceRepositoryIsConstructed_ItGeneratesNoteChoices()
     {
         // arrange
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
-                new(Voice.Alto, 45.ToNote(), 80.ToNote())
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         var duetChordChoiceRepository = new DuetChordChoiceRepository(
             compositionConfiguration,
@@ -85,17 +74,7 @@ internal sealed class DuetChordChoiceRepositoryTests
     public void WhenInvalidCompositionConfigurationIsPassedToDuetChordChoiceRepository_ItThrows()
     {
         // arrange
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
-                new(Voice.Alto, 45.ToNote(), 80.ToNote()),
-                new(Voice.Tenor, 35.ToNote(), 70.ToNote())
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(3);
 
         // act
         var act = () => _ = new DuetChordChoiceRepository(
@@ -111,16 +90,7 @@ internal sealed class DuetChordChoiceRepositoryTests
     public void GetChordChoiceId_ReturnsExpectedId()
     {
         // arrange
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
-                new(Voice.Alto, 45.ToNote(), 80.ToNote())
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         var duetChordChoiceRepository = new DuetChordChoiceRepository(
             compositionConfiguration,

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/QuartetChordChoiceRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/QuartetChordChoiceRepositoryTests.cs
@@ -1,8 +1,6 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
-using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
-using BaroquenMelody.Library.Compositions.Extensions;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
@@ -65,21 +63,10 @@ internal sealed class QuartetChordChoiceRepositoryTests
     }
 
     [Test]
-    public void WhenDuetChordChoiceRepositoryIsConstructed_ItGeneratesNoteChoices()
+    public void WhenQuartetChordChoiceRepositoryIsConstructed_ItGeneratesNoteChoices()
     {
         // arrange
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
-                new(Voice.Alto, 45.ToNote(), 80.ToNote()),
-                new(Voice.Tenor, 35.ToNote(), 70.ToNote()),
-                new(Voice.Bass, 25.ToNote(), 60.ToNote())
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration();
 
         var quartetChordChoiceRepository = new QuartetChordChoiceRepository(
             compositionConfiguration,
@@ -108,19 +95,10 @@ internal sealed class QuartetChordChoiceRepositoryTests
     }
 
     [Test]
-    public void WhenInvalidCompositionConfigurationIsPassedToDuetChordChoiceRepository_ItThrows()
+    public void WhenInvalidCompositionConfigurationIsPassedToQuartetChordChoiceRepository_ItThrows()
     {
         // arrange
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
-                new(Voice.Alto, 45.ToNote(), 80.ToNote())
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         // act
         var act = () => _ = new QuartetChordChoiceRepository(
@@ -136,18 +114,7 @@ internal sealed class QuartetChordChoiceRepositoryTests
     public void GetChordChoiceId_ReturnsExpectedIndex()
     {
         // arrange
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
-                new(Voice.Alto, 45.ToNote(), 80.ToNote()),
-                new(Voice.Tenor, 35.ToNote(), 70.ToNote()),
-                new(Voice.Bass, 25.ToNote(), 60.ToNote())
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration();
 
         var quartetChordChoiceRepository = new QuartetChordChoiceRepository(
             compositionConfiguration,

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/TrioChordChoiceRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/TrioChordChoiceRepositoryTests.cs
@@ -1,8 +1,6 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
-using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
-using BaroquenMelody.Library.Compositions.Extensions;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
@@ -54,20 +52,10 @@ internal sealed class TrioChordChoiceRepositoryTests
     }
 
     [Test]
-    public void WhenDuetChordChoiceRepositoryIsConstructed_ItGeneratesNoteChoices()
+    public void WhenTrioChordChoiceRepositoryIsConstructed_ItGeneratesNoteChoices()
     {
         // arrange
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
-                new(Voice.Alto, 45.ToNote(), 80.ToNote()),
-                new(Voice.Tenor, 35.ToNote(), 70.ToNote())
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(3);
 
         var trioChordChoiceRepository = new TrioChordChoiceRepository(
             compositionConfiguration,
@@ -95,21 +83,10 @@ internal sealed class TrioChordChoiceRepositoryTests
     }
 
     [Test]
-    public void WhenInvalidCompositionConfigurationIsPassedToDuetChordChoiceRepository_ItThrows()
+    public void WhenInvalidCompositionConfigurationIsPassedToQuartetChordChoiceRepository_ItThrows()
     {
         // arrange
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
-                new(Voice.Alto, 45.ToNote(), 80.ToNote()),
-                new(Voice.Tenor, 35.ToNote(), 70.ToNote()),
-                new(Voice.Bass, 25.ToNote(), 60.ToNote())
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration();
 
         // act
         var act = () => _ = new TrioChordChoiceRepository(
@@ -125,17 +102,7 @@ internal sealed class TrioChordChoiceRepositoryTests
     public void GetChordChoiceId_ReturnsExpectedId()
     {
         // arrange
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
-                new(Voice.Alto, 45.ToNote(), 80.ToNote()),
-                new(Voice.Tenor, 35.ToNote(), 70.ToNote())
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(3);
 
         var trioChordChoiceRepository = new TrioChordChoiceRepository(
             compositionConfiguration,

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ChordComposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ChordComposerTests.cs
@@ -3,9 +3,9 @@ using BaroquenMelody.Library.Compositions.Composers;
 using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Compositions.Strategies;
 using BaroquenMelody.Library.Infrastructure.Exceptions;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -32,18 +32,9 @@ internal sealed class ChordComposerTests
         _mockCompositionStrategy = Substitute.For<ICompositionStrategy>();
         _mockLogger = Substitute.For<ILogger>();
 
-        _compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.A4, Notes.A5),
-                new(Voice.Alto, Notes.C3, Notes.C4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        _compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
-        _chordComposer = new ChordComposer(_mockCompositionStrategy, new MusicalTimeSpanCalculator(), _compositionConfiguration, _mockLogger);
+        _chordComposer = new ChordComposer(_mockCompositionStrategy, _compositionConfiguration, _mockLogger);
     }
 
     [Test]

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ComposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ComposerTests.cs
@@ -6,9 +6,9 @@ using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.MusicTheory;
 using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Compositions.Phrasing;
 using BaroquenMelody.Library.Compositions.Strategies;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -23,10 +23,8 @@ namespace BaroquenMelody.Library.Tests.Compositions.Composers;
 internal sealed class ComposerTests
 {
     private static readonly Note MinSopranoNote = Notes.A4;
-    private static readonly Note MaxSopranoNote = Notes.A5;
 
     private static readonly Note MinAltoNote = Notes.C3;
-    private static readonly Note MaxAltoNote = Notes.C4;
 
     private ICompositionStrategy _mockCompositionStrategy = null!;
 
@@ -46,8 +44,6 @@ internal sealed class ComposerTests
 
     private IChordNumberIdentifier _mockChordNumberIdentifier = null!;
 
-    private IMusicalTimeSpanCalculator _musicalTimeSpanCalculator = null!;
-
     private CompositionConfiguration _compositionConfiguration = null!;
 
     private Composer _composer = null!;
@@ -59,26 +55,16 @@ internal sealed class ComposerTests
         _mockCompositionDecorator = Substitute.For<ICompositionDecorator>();
         _mockCompositionPhraser = Substitute.For<ICompositionPhraser>();
         _mockChordNumberIdentifier = Substitute.For<IChordNumberIdentifier>();
-        _musicalTimeSpanCalculator = new MusicalTimeSpanCalculator();
         _mockLogger = Substitute.For<ILogger>();
 
         _mockChordNumberIdentifier.IdentifyChordNumber(Arg.Any<BaroquenChord>()).Returns(ChordNumber.V, ChordNumber.I);
 
-        _compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, MinSopranoNote, MaxSopranoNote),
-                new(Voice.Alto, MinAltoNote, MaxAltoNote)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        _compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         _noteTransposer = new NoteTransposer(_compositionConfiguration);
-        _chordComposer = new ChordComposer(_mockCompositionStrategy, _musicalTimeSpanCalculator, _compositionConfiguration, _mockLogger);
+        _chordComposer = new ChordComposer(_mockCompositionStrategy, _compositionConfiguration, _mockLogger);
         _themeComposer = new ThemeComposer(_mockCompositionStrategy, _mockCompositionDecorator, _chordComposer, _noteTransposer, _mockLogger, _compositionConfiguration);
-        _endingComposer = new EndingComposer(_mockCompositionStrategy, _mockCompositionDecorator, _mockChordNumberIdentifier, _musicalTimeSpanCalculator, _mockLogger, _compositionConfiguration);
+        _endingComposer = new EndingComposer(_mockCompositionStrategy, _mockCompositionDecorator, _mockChordNumberIdentifier, _mockLogger, _compositionConfiguration);
         _composer = new Composer(_mockCompositionDecorator, _mockCompositionPhraser, _chordComposer, _themeComposer, _endingComposer, _mockLogger, _compositionConfiguration);
     }
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Composers/EndingComposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Composers/EndingComposerTests.cs
@@ -6,8 +6,8 @@ using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.MusicTheory;
 using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Compositions.Strategies;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -28,8 +28,6 @@ internal sealed class EndingComposerTests
 
     private IChordNumberIdentifier _mockChordNumberIdentifier = null!;
 
-    private IMusicalTimeSpanCalculator _musicalTimeSpanCalculator = null!;
-
     private ILogger _mockLogger = null!;
 
     private CompositionConfiguration _compositionConfiguration = null!;
@@ -40,25 +38,13 @@ internal sealed class EndingComposerTests
         _mockCompositionStrategy = Substitute.For<ICompositionStrategy>();
         _mockCompositionDecorator = Substitute.For<ICompositionDecorator>();
         _mockChordNumberIdentifier = Substitute.For<IChordNumberIdentifier>();
-        _musicalTimeSpanCalculator = new MusicalTimeSpanCalculator();
         _mockLogger = Substitute.For<ILogger>();
 
-        _compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C4, Notes.C5),
-                new(Voice.Alto, Notes.C3, Notes.C4),
-                new(Voice.Tenor, Notes.C2, Notes.C3),
-                new(Voice.Bass, Notes.C1, Notes.C2)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        _compositionConfiguration = Configurations.GetCompositionConfiguration();
 
         _mockChordNumberIdentifier = Substitute.For<IChordNumberIdentifier>();
 
-        _endingComposer = new EndingComposer(_mockCompositionStrategy, _mockCompositionDecorator, _mockChordNumberIdentifier, _musicalTimeSpanCalculator, _mockLogger, _compositionConfiguration);
+        _endingComposer = new EndingComposer(_mockCompositionStrategy, _mockCompositionDecorator, _mockChordNumberIdentifier, _mockLogger, _compositionConfiguration);
     }
 
     [Test]

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ThemeComposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ThemeComposerTests.cs
@@ -5,6 +5,7 @@ using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.MusicTheory;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Strategies;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -40,18 +41,7 @@ internal sealed class ThemeComposerTests
         _mockNoteTransposer = Substitute.For<INoteTransposer>();
         _mockLogger = Substitute.For<ILogger>();
 
-        _compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C4, Notes.C5),
-                new(Voice.Alto, Notes.C3, Notes.C4),
-                new(Voice.Tenor, Notes.C2, Notes.C3),
-                new(Voice.Bass, Notes.C1, Notes.C2)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        _compositionConfiguration = Configurations.GetCompositionConfiguration();
 
         _themeComposer = new ThemeComposer(_mockCompositionStrategy, _mockCompositionDecorator, _mockChordComposer, _mockNoteTransposer, _mockLogger, _compositionConfiguration);
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/CompositionConfigurationTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/CompositionConfigurationTests.cs
@@ -3,6 +3,7 @@ using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Extensions;
 using FluentAssertions;
+using Melanchall.DryWetMidi.Interaction;
 using NUnit.Framework;
 
 namespace BaroquenMelody.Library.Tests.Compositions.Configuration;
@@ -27,8 +28,11 @@ internal sealed class CompositionConfigurationTests
                 new(Voice.Tenor, 36.ToNote(), 48.ToNote()),
                 new(Voice.Bass, 24.ToNote(), 36.ToNote())
             },
+            PhrasingConfiguration.Default,
+            AggregateCompositionRuleConfiguration.Default,
             BaroquenScale.Parse("C Major"),
             Meter.FourFour,
+            MusicalTimeSpan.Half,
             CompositionLength: 100
         );
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/MusicTheory/ChordNumberIdentifierTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/MusicTheory/ChordNumberIdentifierTests.cs
@@ -1,8 +1,8 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.MusicTheory;
 using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -18,17 +18,7 @@ internal sealed class ChordNumberIdentifierTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.G6),
-                new(Voice.Alto, Notes.C2, Notes.G5),
-                new(Voice.Tenor, Notes.C1, Notes.G4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(3);
 
         _chordNumberIdentifier = new ChordNumberIdentifier(compositionConfiguration);
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/MusicTheory/NoteTransposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/MusicTheory/NoteTransposerTests.cs
@@ -1,8 +1,8 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.MusicTheory;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -18,16 +18,7 @@ internal sealed class NoteTransposerTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C4, Notes.C6),
-                new(Voice.Alto, Notes.G2, Notes.G4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         _noteTransposer = new NoteTransposer(compositionConfiguration);
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/EighthNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/EighthNoteOrnamentationCleanerTests.cs
@@ -3,7 +3,6 @@ using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
@@ -20,7 +19,7 @@ internal sealed class EighthNoteOrnamentationCleanerTests
     [SetUp]
     public void SetUp()
     {
-        _cleaner = new EighthNoteOrnamentationCleaner(new MusicalTimeSpanCalculator(), Configurations.CompositionConfiguration);
+        _cleaner = new EighthNoteOrnamentationCleaner(Configurations.GetCompositionConfiguration());
     }
 
     [Test]

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/MordentEighthNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/MordentEighthNoteOrnamentationCleanerTests.cs
@@ -3,7 +3,6 @@ using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
@@ -18,7 +17,7 @@ internal sealed class MordentEighthNoteOrnamentationCleanerTests
     private MordentEighthNoteOrnamentationCleaner _mordentEighthNoteOrnamentationCleaner = null!;
 
     [SetUp]
-    public void SetUp() => _mordentEighthNoteOrnamentationCleaner = new MordentEighthNoteOrnamentationCleaner(new MusicalTimeSpanCalculator(), Configurations.CompositionConfiguration);
+    public void SetUp() => _mordentEighthNoteOrnamentationCleaner = new MordentEighthNoteOrnamentationCleaner(Configurations.GetCompositionConfiguration());
 
     [Test]
     [TestCaseSource(nameof(TestCases))]

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/QuarterEighthNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/QuarterEighthNoteOrnamentationCleanerTests.cs
@@ -3,7 +3,6 @@ using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
@@ -18,7 +17,7 @@ internal sealed class QuarterEighthNoteOrnamentationCleanerTests
     private QuarterEighthNoteOrnamentationCleaner _cleaner = null!;
 
     [SetUp]
-    public void SetUp() => _cleaner = new QuarterEighthNoteOrnamentationCleaner(new MusicalTimeSpanCalculator(), Configurations.CompositionConfiguration);
+    public void SetUp() => _cleaner = new QuarterEighthNoteOrnamentationCleaner(Configurations.GetCompositionConfiguration());
 
     [Test]
     [TestCaseSource(nameof(TestCases))]

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/QuarterNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/QuarterNoteOrnamentationCleanerTests.cs
@@ -3,7 +3,6 @@ using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
@@ -18,7 +17,7 @@ internal sealed class QuarterNoteOrnamentationCleanerTests
     private QuarterNoteOrnamentationCleaner _cleaner = null!;
 
     [SetUp]
-    public void SetUp() => _cleaner = new QuarterNoteOrnamentationCleaner(new MusicalTimeSpanCalculator(), Configurations.CompositionConfiguration);
+    public void SetUp() => _cleaner = new QuarterNoteOrnamentationCleaner(Configurations.GetCompositionConfiguration());
 
     [Test]
     [TestCaseSource(nameof(TestCases))]

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/SixteenthEighthNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/SixteenthEighthNoteOrnamentationCleanerTests.cs
@@ -3,7 +3,6 @@ using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
@@ -18,7 +17,7 @@ internal sealed class SixteenthEighthNoteOrnamentationCleanerTests
     private SixteenthEighthNoteOrnamentationCleaner _cleaner;
 
     [SetUp]
-    public void SetUp() => _cleaner = new SixteenthEighthNoteOrnamentationCleaner(new MusicalTimeSpanCalculator(), Configurations.CompositionConfiguration);
+    public void SetUp() => _cleaner = new SixteenthEighthNoteOrnamentationCleaner(Configurations.GetCompositionConfiguration());
 
     [Test]
     [TestCaseSource(nameof(TestCases))]

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/SixteenthNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/SixteenthNoteOrnamentationCleanerTests.cs
@@ -3,7 +3,6 @@ using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
@@ -18,7 +17,7 @@ internal sealed class SixteenthNoteOrnamentationCleanerTests
     private SixteenthNoteOrnamentationCleaner _cleaner = null!;
 
     [SetUp]
-    public void SetUp() => _cleaner = new SixteenthNoteOrnamentationCleaner(new MusicalTimeSpanCalculator(), Configurations.CompositionConfiguration);
+    public void SetUp() => _cleaner = new SixteenthNoteOrnamentationCleaner(Configurations.GetCompositionConfiguration());
 
     [Test]
     [TestCaseSource(nameof(TestCases))]

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/TurnAlternateTurnOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/TurnAlternateTurnOrnamentationCleanerTests.cs
@@ -3,7 +3,6 @@ using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
@@ -18,7 +17,7 @@ internal sealed class TurnAlternateTurnOrnamentationCleanerTests
     private TurnAlternateTurnOrnamentationCleaner _cleaner = null!;
 
     [SetUp]
-    public void SetUp() => _cleaner = new TurnAlternateTurnOrnamentationCleaner(new MusicalTimeSpanCalculator(), Configurations.CompositionConfiguration);
+    public void SetUp() => _cleaner = new TurnAlternateTurnOrnamentationCleaner(Configurations.GetCompositionConfiguration());
 
     [Test]
     [TestCaseSource(nameof(TestCases))]

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/CompositionDecoratorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/CompositionDecoratorTests.cs
@@ -1,8 +1,8 @@
 ﻿using Atrea.PolicyEngine;
-using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
+using BaroquenMelody.Library.Tests.TestData;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
@@ -22,16 +22,7 @@ internal sealed class CompositionDecoratorTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.A4, Notes.A5),
-                new(Voice.Alto, Notes.C3, Notes.C4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         _mockOrnamentationEngine = Substitute.For<IPolicyEngine<OrnamentationItem>>();
         _mockSustainEngine = Substitute.For<IPolicyEngine<OrnamentationItem>>();

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsApplicableIntervalTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsApplicableIntervalTests.cs
@@ -1,10 +1,10 @@
 ﻿using Atrea.PolicyEngine.Policies.Input;
-using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies.Input;
 using BaroquenMelody.Library.Infrastructure.Collections;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -20,16 +20,7 @@ internal sealed class IsApplicableIntervalTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.A4, Notes.A5),
-                new(Voice.Alto, Notes.C3, Notes.C4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         _isApplicableInterval = new IsApplicableInterval(compositionConfiguration, Interval: 2);
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsFifthOfChordTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsFifthOfChordTests.cs
@@ -1,11 +1,11 @@
 ﻿using Atrea.PolicyEngine.Policies.Input;
-using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.MusicTheory;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies.Input;
 using BaroquenMelody.Library.Infrastructure.Collections;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -21,17 +21,7 @@ internal sealed class IsFifthOfChordTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.G6),
-                new(Voice.Alto, Notes.C2, Notes.G5),
-                new(Voice.Tenor, Notes.C1, Notes.G4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(3);
 
         var chordNumberIdentifier = new ChordNumberIdentifier(compositionConfiguration);
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsIntervalWithinVoiceRangeTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsIntervalWithinVoiceRangeTests.cs
@@ -1,10 +1,10 @@
 ﻿using Atrea.PolicyEngine.Policies.Input;
-using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies.Input;
 using BaroquenMelody.Library.Infrastructure.Collections;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -20,20 +20,7 @@ internal sealed class IsIntervalWithinVoiceRangeTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C5, Notes.G6),
-                new(Voice.Alto, Notes.G3, Notes.C5),
-                new(Voice.Tenor, Notes.C2, Notes.G3),
-                new(Voice.Bass, Notes.G0, Notes.C2)
-            },
-            PhrasingConfiguration.Default,
-            AggregateCompositionRuleConfiguration.Default,
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            25
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration();
 
         _isIntervalWithinVoiceRange = new IsIntervalWithinVoiceRange(compositionConfiguration, interval: 5);
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsRootOfChordTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsRootOfChordTests.cs
@@ -1,11 +1,11 @@
 ﻿using Atrea.PolicyEngine.Policies.Input;
-using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.MusicTheory;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies.Input;
 using BaroquenMelody.Library.Infrastructure.Collections;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -21,17 +21,7 @@ internal sealed class IsRootOfChordTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.G6),
-                new(Voice.Alto, Notes.C2, Notes.G5),
-                new(Voice.Tenor, Notes.C1, Notes.G4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(3);
 
         var chordNumberIdentifier = new ChordNumberIdentifier(compositionConfiguration);
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsThirdOfChordTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsThirdOfChordTests.cs
@@ -1,11 +1,11 @@
 ﻿using Atrea.PolicyEngine.Policies.Input;
-using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.MusicTheory;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Policies.Input;
 using BaroquenMelody.Library.Infrastructure.Collections;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -21,17 +21,7 @@ internal sealed class IsThirdOfChordTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.G6),
-                new(Voice.Alto, Notes.C2, Notes.G5),
-                new(Voice.Tenor, Notes.C1, Notes.G4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(3);
 
         var chordNumberIdentifier = new ChordNumberIdentifier(compositionConfiguration);
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/AlternateTurnProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/AlternateTurnProcessorTests.cs
@@ -1,11 +1,11 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Infrastructure.Collections;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -21,16 +21,7 @@ internal sealed class AlternateTurnProcessorTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.C5),
-                new(Voice.Alto, Notes.C2, Notes.C4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         _processor = new AlternateTurnProcessor(new MusicalTimeSpanCalculator(), compositionConfiguration);
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DecorateIntervalProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DecorateIntervalProcessorTests.cs
@@ -1,11 +1,11 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Infrastructure.Collections;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -21,16 +21,7 @@ internal sealed class DecorateIntervalProcessorTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.C5),
-                new(Voice.Alto, Notes.C2, Notes.C4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         _processor = new DecorateIntervalProcessor(new MusicalTimeSpanCalculator(), compositionConfiguration, 4);
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DelayedRunProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DelayedRunProcessorTests.cs
@@ -1,11 +1,11 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Infrastructure.Collections;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -21,16 +21,7 @@ internal sealed class DelayedRunProcessorTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.C5),
-                new(Voice.Alto, Notes.C2, Notes.C4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         _processor = new DelayedRunProcessor(new MusicalTimeSpanCalculator(), compositionConfiguration);
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DoublePassingToneProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DoublePassingToneProcessorTests.cs
@@ -1,11 +1,11 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Infrastructure.Collections;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -21,16 +21,7 @@ internal sealed class DoublePassingToneProcessorTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.C5),
-                new(Voice.Alto, Notes.C2, Notes.C4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         _processor = new DoublePassingToneProcessor(new MusicalTimeSpanCalculator(), compositionConfiguration, OrnamentationType.DoublePassingTone);
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DoubleRunProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DoubleRunProcessorTests.cs
@@ -1,11 +1,11 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Infrastructure.Collections;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -21,16 +21,7 @@ internal sealed class DoubleRunProcessorTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.C5),
-                new(Voice.Alto, Notes.C2, Notes.C4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         _processor = new DoubleRunProcessor(new MusicalTimeSpanCalculator(), compositionConfiguration);
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DoubleTurnProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DoubleTurnProcessorTests.cs
@@ -1,11 +1,11 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Infrastructure.Collections;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -21,16 +21,7 @@ internal sealed class DoubleTurnProcessorTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.C5),
-                new(Voice.Alto, Notes.C2, Notes.C4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         _processor = new DoubleTurnProcessor(new MusicalTimeSpanCalculator(), compositionConfiguration);
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/MordentProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/MordentProcessorTests.cs
@@ -1,5 +1,4 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
@@ -7,6 +6,7 @@ using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Infrastructure.Collections;
 using BaroquenMelody.Library.Infrastructure.Random;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -25,16 +25,7 @@ internal sealed class MordentProcessorTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.C5),
-                new(Voice.Alto, Notes.C2, Notes.C4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         _mockWeightedRandomBooleanGenerator = Substitute.For<IWeightedRandomBooleanGenerator>();
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/NeighborToneProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/NeighborToneProcessorTests.cs
@@ -1,5 +1,4 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
@@ -7,6 +6,7 @@ using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Infrastructure.Collections;
 using BaroquenMelody.Library.Infrastructure.Random;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -27,17 +27,7 @@ internal sealed class NeighborToneProcessorTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.G6),
-                new(Voice.Alto, Notes.C2, Notes.G5),
-                new(Voice.Tenor, Notes.C1, Notes.G4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(3);
 
         _mockMusicalTimeSpanCalculator = Substitute.For<IMusicalTimeSpanCalculator>();
         _mockWeightedRandomBooleanGenerator = Substitute.For<IWeightedRandomBooleanGenerator>();

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/PassingToneProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/PassingToneProcessorTests.cs
@@ -1,11 +1,11 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Infrastructure.Collections;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -21,16 +21,7 @@ internal sealed class PassingToneProcessorTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.C5),
-                new(Voice.Alto, Notes.C2, Notes.C4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         _processor = new PassingToneProcessor(new MusicalTimeSpanCalculator(), compositionConfiguration, OrnamentationType.PassingTone);
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/PedalProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/PedalProcessorTests.cs
@@ -1,11 +1,11 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Infrastructure.Collections;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -25,17 +25,7 @@ internal sealed class PedalProcessorTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.G6),
-                new(Voice.Alto, Notes.C2, Notes.G5),
-                new(Voice.Tenor, Notes.C1, Notes.G4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         var musicalTimeSpanCalculator = new MusicalTimeSpanCalculator();
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/RepeatedNoteProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/RepeatedNoteProcessorTests.cs
@@ -1,11 +1,11 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Infrastructure.Collections;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -24,17 +24,7 @@ internal sealed class RepeatedNoteProcessorTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.G6),
-                new(Voice.Alto, Notes.C2, Notes.G5),
-                new(Voice.Tenor, Notes.C1, Notes.G4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(3);
 
         _mockMusicalTimeSpanCalculator = Substitute.For<IMusicalTimeSpanCalculator>();
         _repeatedNoteProcessor = new RepeatedNoteProcessor(_mockMusicalTimeSpanCalculator, compositionConfiguration, OrnamentationType.RepeatedNote);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/RunProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/RunProcessorTests.cs
@@ -1,11 +1,11 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Infrastructure.Collections;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -21,16 +21,7 @@ internal sealed class RunProcessorTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.C5),
-                new(Voice.Alto, Notes.C2, Notes.C4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         _processor = new RunProcessor(new MusicalTimeSpanCalculator(), compositionConfiguration);
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/SustainedNoteProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/SustainedNoteProcessorTests.cs
@@ -1,11 +1,11 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Infrastructure.Collections;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -21,16 +21,7 @@ internal sealed class SustainedNoteProcessorTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.C5),
-                new(Voice.Alto, Notes.C2, Notes.C4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         _sustainedNoteProcessor = new SustainedNoteProcessor(new MusicalTimeSpanCalculator(), compositionConfiguration);
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/TurnProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/TurnProcessorTests.cs
@@ -1,11 +1,11 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation;
 using BaroquenMelody.Library.Compositions.Ornamentation.Engine.Processors;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Infrastructure.Collections;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -21,16 +21,7 @@ internal sealed class TurnProcessorTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.C5),
-                new(Voice.Alto, Notes.C2, Notes.C4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         _processor = new TurnProcessor(new MusicalTimeSpanCalculator(), compositionConfiguration);
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Phrasing/CompositionPhraserTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Phrasing/CompositionPhraserTests.cs
@@ -1,10 +1,10 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Compositions.Phrasing;
 using BaroquenMelody.Library.Compositions.Rules;
 using BaroquenMelody.Library.Infrastructure.Random;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -211,15 +211,8 @@ internal sealed class CompositionPhraserTests
 
     private CompositionPhraser CreatePhraser(PhrasingConfiguration phrasingConfiguration)
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>(),
-            phrasingConfiguration,
-            AggregateCompositionRuleConfiguration.Default,
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            16
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2) with { PhrasingConfiguration = phrasingConfiguration };
 
-        return new CompositionPhraser(_mockCompositionRule, _mockThemeSplitter, _weightedRandomBooleanGenerator, new MusicalTimeSpanCalculator(), _mockLogger, compositionConfiguration);
+        return new CompositionPhraser(_mockCompositionRule, _mockThemeSplitter, _weightedRandomBooleanGenerator, _mockLogger, compositionConfiguration);
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidDissonantLeapTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidDissonantLeapTests.cs
@@ -1,7 +1,7 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Rules;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -15,32 +15,7 @@ internal sealed class AvoidDissonantLeapsTests
     private AvoidDissonantLeaps _avoidDissonantLeaps = null!;
 
     [SetUp]
-    public void SetUp()
-    {
-        var phrasingConfiguration = new PhrasingConfiguration(
-            PhraseLengths: [2, 4, 8],
-            MaxPhraseRepetitions: 4,
-            MinPhraseRepetitionPoolSize: 10,
-            PhraseRepetitionProbability: 90
-        );
-
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.G5, Notes.G6),
-                new(Voice.Alto, Notes.C4, Notes.G5),
-                new(Voice.Tenor, Notes.C3, Notes.C4),
-                new(Voice.Bass, Notes.C2, Notes.C3)
-            },
-            phrasingConfiguration,
-            AggregateCompositionRuleConfiguration.Default,
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            100
-        );
-
-        _avoidDissonantLeaps = new AvoidDissonantLeaps(compositionConfiguration);
-    }
+    public void SetUp() => _avoidDissonantLeaps = new AvoidDissonantLeaps(Configurations.GetCompositionConfiguration());
 
     [Test]
     [TestCaseSource(nameof(TestCases))]

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/CompositionRuleFactoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/CompositionRuleFactoryTests.cs
@@ -1,11 +1,9 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
-using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Rules;
 using BaroquenMelody.Library.Compositions.Rules.Enums;
 using BaroquenMelody.Library.Infrastructure.Random;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
-using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -19,16 +17,7 @@ internal sealed class CompositionRuleFactoryTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.C5),
-                new(Voice.Alto, Notes.C2, Notes.C4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         _factory = new CompositionRuleFactory(compositionConfiguration, Substitute.For<IWeightedRandomBooleanGenerator>());
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/EnsureVoiceRangeTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/EnsureVoiceRangeTests.cs
@@ -1,7 +1,7 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Rules;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -17,18 +17,7 @@ internal sealed class EnsureVoiceRangeTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.C4),
-                new(Voice.Alto, Notes.G2, Notes.G3),
-                new(Voice.Tenor, Notes.C2, Notes.C3),
-                new(Voice.Bass, Notes.G1, Notes.G2)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         _ensureVoiceRange = new EnsureVoiceRange(compositionConfiguration);
     }
@@ -43,7 +32,7 @@ internal sealed class EnsureVoiceRangeTests
         get
         {
             yield return new TestCaseData(
-                new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C3, MusicalTimeSpan.Half)]),
+                new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C5, MusicalTimeSpan.Half)]),
                 true
             ).SetName("Soprano note is in range.");
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/FollowsStandardProgressionTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/FollowsStandardProgressionTests.cs
@@ -1,7 +1,7 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Rules;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -17,17 +17,7 @@ internal sealed class FollowsStandardProgressionTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.G6),
-                new(Voice.Alto, Notes.C2, Notes.G5),
-                new(Voice.Tenor, Notes.C1, Notes.G4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(3);
 
         _followsStandardProgression = new FollowsStandardProgression(compositionConfiguration);
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/HandleAscendingSeventhTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/HandleAscendingSeventhTests.cs
@@ -1,7 +1,7 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Rules;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -17,16 +17,7 @@ internal sealed class HandleAscendingSeventhTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.G5, Notes.G6),
-                new(Voice.Alto, Notes.C4, Notes.G5)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         _handleAscendingSeventh = new HandleAscendingSeventh(compositionConfiguration);
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Strategies/CompositionStrategyFactoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Strategies/CompositionStrategyFactoryTests.cs
@@ -1,11 +1,8 @@
 ﻿using BaroquenMelody.Library.Compositions.Choices;
 using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
-using BaroquenMelody.Library.Compositions.Enums;
-using BaroquenMelody.Library.Compositions.Extensions;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Compositions.Rules;
 using BaroquenMelody.Library.Compositions.Strategies;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -20,8 +17,6 @@ internal sealed class CompositionStrategyFactoryTests
 
     private ICompositionRule _mockCompositionRule = null!;
 
-    private IMusicalTimeSpanCalculator _mockMusicalTimeSpanCalculator = null!;
-
     private ILogger _mockLogger = null!;
 
     private CompositionStrategyFactory _compositionStrategyFactory = null!;
@@ -31,10 +26,9 @@ internal sealed class CompositionStrategyFactoryTests
     {
         _mockChordChoiceRepositoryFactory = Substitute.For<IChordChoiceRepositoryFactory>();
         _mockCompositionRule = Substitute.For<ICompositionRule>();
-        _mockMusicalTimeSpanCalculator = Substitute.For<IMusicalTimeSpanCalculator>();
         _mockLogger = Substitute.For<ILogger>();
 
-        _compositionStrategyFactory = new CompositionStrategyFactory(_mockChordChoiceRepositoryFactory, _mockCompositionRule, _mockMusicalTimeSpanCalculator, _mockLogger);
+        _compositionStrategyFactory = new CompositionStrategyFactory(_mockChordChoiceRepositoryFactory, _mockCompositionRule, _mockLogger);
     }
 
     [Test]
@@ -47,16 +41,7 @@ internal sealed class CompositionStrategyFactoryTests
 
         mockChordChoiceRepository.Count.Returns(500);
 
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, 55.ToNote(), 90.ToNote()),
-                new(Voice.Alto, 45.ToNote(), 80.ToNote())
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         // act
         var compositionStrategy = _compositionStrategyFactory.Create(compositionConfiguration);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Strategies/CompositionStrategyTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Strategies/CompositionStrategyTests.cs
@@ -2,10 +2,9 @@
 using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
-using BaroquenMelody.Library.Compositions.Extensions;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
 using BaroquenMelody.Library.Compositions.Rules;
 using BaroquenMelody.Library.Compositions.Strategies;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -19,29 +18,11 @@ namespace BaroquenMelody.Library.Tests.Compositions.Strategies;
 [TestFixture]
 internal sealed class CompositionStrategyTests
 {
-    private const byte MinSopranoPitch = 60;
-
-    private const byte MaxSopranoPitch = 72;
-
-    private const byte MinAltoPitch = 48;
-
-    private const byte MaxAltoPitch = 60;
-
-    private const byte MinTenorPitch = 36;
-
-    private const byte MaxTenorPitch = 48;
-
-    private const byte MinBassPitch = 24;
-
-    private const byte MaxBassPitch = 36;
-
     private static readonly BigInteger MockChordChoiceCount = 5;
 
     private IChordChoiceRepository _mockChordChoiceRepository = default!;
 
     private ICompositionRule _mockCompositionRule = default!;
-
-    private IMusicalTimeSpanCalculator _mockMusicalTimeSpanCalculator = default!;
 
     private ILogger _mockLogger = default!;
 
@@ -54,28 +35,15 @@ internal sealed class CompositionStrategyTests
     {
         _mockChordChoiceRepository = Substitute.For<IChordChoiceRepository>();
         _mockCompositionRule = Substitute.For<ICompositionRule>();
-        _mockMusicalTimeSpanCalculator = Substitute.For<IMusicalTimeSpanCalculator>();
         _mockLogger = Substitute.For<ILogger>();
 
         _mockChordChoiceRepository.Count.Returns(MockChordChoiceCount);
 
-        _compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, MinSopranoPitch.ToNote(), MaxSopranoPitch.ToNote()),
-                new(Voice.Alto, MinAltoPitch.ToNote(), MaxAltoPitch.ToNote()),
-                new(Voice.Tenor, MinTenorPitch.ToNote(), MaxTenorPitch.ToNote()),
-                new(Voice.Bass, MinBassPitch.ToNote(), MaxBassPitch.ToNote())
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        _compositionConfiguration = Configurations.GetCompositionConfiguration();
 
         _compositionStrategy = new CompositionStrategy(
             _mockChordChoiceRepository,
             _mockCompositionRule,
-            _mockMusicalTimeSpanCalculator,
             _mockLogger,
             _compositionConfiguration
         );

--- a/tests/BaroquenMelody.Library.Tests/Midi/MidiGeneratorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Midi/MidiGeneratorTests.cs
@@ -1,8 +1,8 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
+﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Midi;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -18,16 +18,7 @@ internal sealed class MidiGeneratorTests
     [SetUp]
     public void SetUp()
     {
-        var compositionConfiguration = new CompositionConfiguration(
-            new HashSet<VoiceConfiguration>
-            {
-                new(Voice.Soprano, Notes.C3, Notes.C5),
-                new(Voice.Alto, Notes.C2, Notes.C4)
-            },
-            BaroquenScale.Parse("C Major"),
-            Meter.FourFour,
-            CompositionLength: 100
-        );
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2);
 
         _midiGenerator = new MidiGenerator(compositionConfiguration);
     }

--- a/tests/BaroquenMelody.Library.Tests/TestData/Configurations.cs
+++ b/tests/BaroquenMelody.Library.Tests/TestData/Configurations.cs
@@ -1,22 +1,47 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
+using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
 
 namespace BaroquenMelody.Library.Tests.TestData;
 
 internal static class Configurations
 {
-    public static CompositionConfiguration CompositionConfiguration => new(
-        new HashSet<VoiceConfiguration>
-        {
-            new(Voice.Soprano, Notes.C4, Notes.C5),
-            new(Voice.Alto, Notes.C3, Notes.C4),
-            new(Voice.Tenor, Notes.C2, Notes.C3),
-            new(Voice.Bass, Notes.C1, Notes.C2)
-        },
+    public static CompositionConfiguration GetCompositionConfiguration(int numberOfVoices = 4) => new(
+        GenerateVoiceConfigurations(numberOfVoices),
+        PhrasingConfiguration.Default,
+        AggregateCompositionRuleConfiguration.Default,
         BaroquenScale.Parse("C Major"),
         Meter.FourFour,
+        MusicalTimeSpan.Half,
         CompositionLength: 100
     );
+
+    private static HashSet<VoiceConfiguration> GenerateVoiceConfigurations(int numberOfVoices) => numberOfVoices switch
+    {
+        1 =>
+        [
+            new VoiceConfiguration(Voice.Soprano, Notes.C4, Notes.C6)
+        ],
+        2 =>
+        [
+            new VoiceConfiguration(Voice.Soprano, Notes.C4, Notes.C6),
+            new VoiceConfiguration(Voice.Alto, Notes.G2, Notes.G4)
+        ],
+        3 =>
+        [
+            new VoiceConfiguration(Voice.Soprano, Notes.C4, Notes.C6),
+            new VoiceConfiguration(Voice.Alto, Notes.G2, Notes.G4),
+            new VoiceConfiguration(Voice.Tenor, Notes.C2, Notes.C3)
+        ],
+        4 =>
+        [
+            new VoiceConfiguration(Voice.Soprano, Notes.C4, Notes.C6),
+            new VoiceConfiguration(Voice.Alto, Notes.G2, Notes.G4),
+            new VoiceConfiguration(Voice.Tenor, Notes.C2, Notes.C3),
+            new VoiceConfiguration(Voice.Bass, Notes.C1, Notes.C2)
+        ],
+        _ => throw new ArgumentException("Invalid number of voices.")
+    };
 }


### PR DESCRIPTION
## Description

Add a default note time span to the composition configuration, since it is needed broadly and won't change over the course of a composition.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
