### PR TITLE
Support 3/4 Time

### DIFF
--- a/src/BaroquenMelody.Library/Compositions/Enums/Extensions/MeterExtensions.cs
+++ b/src/BaroquenMelody.Library/Compositions/Enums/Extensions/MeterExtensions.cs
@@ -14,6 +14,7 @@ internal static class MeterExtensions
     public static int BeatsPerMeasure(this Meter meter) => meter switch
     {
         Meter.FourFour => 4,
+        Meter.ThreeFour => 3,
         _ => throw new ArgumentOutOfRangeException(nameof(meter), meter, null)
     };
 }

--- a/src/BaroquenMelody.Library/Compositions/Enums/Meter.cs
+++ b/src/BaroquenMelody.Library/Compositions/Enums/Meter.cs
@@ -5,5 +5,10 @@ internal enum Meter
     /// <summary>
     ///     4/4 time.
     /// </summary>
-    FourFour
+    FourFour,
+
+    /// <summary>
+    ///     3/4 time.
+    /// </summary>
+    ThreeFour
 }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/FourFourOrnamentationCleaningEngineBuilder.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/FourFourOrnamentationCleaningEngineBuilder.cs
@@ -7,14 +7,15 @@ using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 
 namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine;
 
-internal sealed class OrnamentationCleaningEngineBuilder(
+internal sealed class FourFourOrnamentationCleaningEngineBuilder(
     IProcessor<OrnamentationCleaningItem> passingToneOrnamentationCleaner,
     IProcessor<OrnamentationCleaningItem> eighthNoteOrnamentationCleaner,
     IProcessor<OrnamentationCleaningItem> quarterEighthNoteOrnamentationCleaner,
     IProcessor<OrnamentationCleaningItem> turnAlternateTurnOrnamentationCleaner,
     IProcessor<OrnamentationCleaningItem> sixteenthNoteOrnamentationCleaner,
     IProcessor<OrnamentationCleaningItem> sixteenthEighthNoteOrnamentationCleaner,
-    IProcessor<OrnamentationCleaningItem> mordentEighthNoteOrnamentationCleaner)
+    IProcessor<OrnamentationCleaningItem> mordentEighthNoteOrnamentationCleaner
+) : IOrnamentationCleaningEngineBuilder
 {
     public IPolicyEngine<OrnamentationCleaningItem> Build() => PolicyEngineBuilder<OrnamentationCleaningItem>.Configure()
         .WithoutInputPolicies()

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/IOrnamentationCleaningEngineBuilder.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/IOrnamentationCleaningEngineBuilder.cs
@@ -1,0 +1,15 @@
+﻿using Atrea.PolicyEngine;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine;
+
+/// <summary>
+///     Builds a policy engine for cleaning ornamentations.
+/// </summary>
+internal interface IOrnamentationCleaningEngineBuilder
+{
+    /// <summary>
+    ///     Build a policy engine for cleaning ornamentations.
+    /// </summary>
+    /// <returns>The policy engine for cleaning ornamentations.</returns>
+    IPolicyEngine<OrnamentationCleaningItem> Build();
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/MordentEighthNoteOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/MordentEighthNoteOrnamentationCleaner.cs
@@ -3,7 +3,7 @@ using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Extensions;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 
-namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.FourFour;
 
 internal sealed class MordentEighthNoteOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
 {

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/QuarterEighthNoteOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/QuarterEighthNoteOrnamentationCleaner.cs
@@ -4,7 +4,7 @@ using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Extensions;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 
-namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.FourFour;
 
 internal sealed class QuarterEighthNoteOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
 {

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/QuarterNoteOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/QuarterNoteOrnamentationCleaner.cs
@@ -4,7 +4,7 @@ using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Extensions;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 
-namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.FourFour;
 
 internal sealed class QuarterNoteOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
 {

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/SixteenthEighthNoteOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/SixteenthEighthNoteOrnamentationCleaner.cs
@@ -4,7 +4,7 @@ using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Extensions;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 
-namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.FourFour;
 
 internal sealed class SixteenthEighthNoteOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
 {

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/TurnAlternateTurnOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/TurnAlternateTurnOrnamentationCleaner.cs
@@ -4,7 +4,7 @@ using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Extensions;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 
-namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.FourFour;
 
 internal sealed class TurnAlternateTurnOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
 {

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/MeterAgnostic/EighthNoteOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/MeterAgnostic/EighthNoteOrnamentationCleaner.cs
@@ -2,15 +2,15 @@
 using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Extensions;
 
-namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.MeterAgnostic;
 
-internal sealed class SixteenthNoteOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
+internal sealed class EighthNoteOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
 {
-    private static readonly int[] IndicesToCheck = [1, 3, 5];
+    private static readonly int[] _ornamentationIndices = [0, 1, 2];
 
     public void Process(OrnamentationCleaningItem item)
     {
-        if (!IndicesToCheck.Any(index => item.Note.Ornamentations[index].IsDissonantWith(item.OtherNote.Ornamentations[index])))
+        if (!_ornamentationIndices.Any(index => item.Note.Ornamentations[index].IsDissonantWith(item.OtherNote.Ornamentations[index])))
         {
             return;
         }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/MeterAgnostic/SixteenthNoteOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/MeterAgnostic/SixteenthNoteOrnamentationCleaner.cs
@@ -1,0 +1,27 @@
+﻿using Atrea.PolicyEngine.Processors;
+using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Extensions;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.MeterAgnostic;
+
+internal sealed class SixteenthNoteOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
+{
+    private static readonly int[] IndicesToCheck = [1, 3, 5];
+
+    public void Process(OrnamentationCleaningItem item)
+    {
+        if (!IndicesToCheck.Any(index => item.Note.Ornamentations[index].IsDissonantWith(item.OtherNote.Ornamentations[index])))
+        {
+            return;
+        }
+
+        if (item.Note > item.OtherNote)
+        {
+            item.OtherNote.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
+        }
+        else
+        {
+            item.Note.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
+        }
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DelayedRunEighthOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DelayedRunEighthOrnamentationCleaner.cs
@@ -1,0 +1,41 @@
+﻿using Atrea.PolicyEngine.Processors;
+using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Extensions;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+
+internal sealed class DelayedRunEighthOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
+{
+    private static readonly (int DelayedRunIndex, int EighthNoteIndex)[] _indicesToCheck = [(1, 0), (2, 1), (3, 2)];
+
+    public void Process(OrnamentationCleaningItem item)
+    {
+        if (item.Note.OrnamentationType is OrnamentationType.DelayedRun)
+        {
+            Clean(item.Note, item.OtherNote);
+        }
+        else
+        {
+            Clean(item.OtherNote, item.Note);
+        }
+    }
+
+    private void Clean(BaroquenNote noteWithDelayedRun, BaroquenNote noteWithEighthNotes)
+    {
+        if (!_indicesToCheck.Any(i => noteWithDelayedRun.Ornamentations[i.DelayedRunIndex].IsDissonantWith(noteWithEighthNotes.Ornamentations[i.EighthNoteIndex])))
+        {
+            return;
+        }
+
+        if (noteWithEighthNotes > noteWithDelayedRun)
+        {
+            noteWithDelayedRun.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
+        }
+        else
+        {
+            noteWithEighthNotes.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
+        }
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DoublePassingToneDelayedRunOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DoublePassingToneDelayedRunOrnamentationCleaner.cs
@@ -1,0 +1,34 @@
+﻿using Atrea.PolicyEngine.Processors;
+using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Extensions;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+
+internal sealed class DoublePassingToneDelayedRunOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
+{
+    private static readonly (int PassingToneIndex, int DelayedRunIndex)[] _indicesToCheck = [(0, 0), (1, 2)];
+
+    public void Process(OrnamentationCleaningItem item)
+    {
+        if (item.Note.OrnamentationType is OrnamentationType.DoublePassingTone)
+        {
+            Clean(item.Note, item.OtherNote);
+        }
+        else
+        {
+            Clean(item.OtherNote, item.Note);
+        }
+    }
+
+    private void Clean(BaroquenNote noteWithPassingTone, BaroquenNote noteWithDelayedRun)
+    {
+        if (!_indicesToCheck.Any(i => noteWithPassingTone.Ornamentations[i.PassingToneIndex].IsDissonantWith(noteWithDelayedRun.Ornamentations[i.DelayedRunIndex])))
+        {
+            return;
+        }
+
+        noteWithPassingTone.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DoublePassingToneOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DoublePassingToneOrnamentationCleaner.cs
@@ -2,15 +2,15 @@
 using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Extensions;
 
-namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
 
-internal sealed class EighthNoteOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
+internal sealed class DoublePassingToneOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
 {
-    private static readonly int[] _ornamentationIndices = [0, 1, 2];
+    private static readonly int[] IndicesToCheck = [0, 1];
 
     public void Process(OrnamentationCleaningItem item)
     {
-        if (!_ornamentationIndices.Any(index => item.Note.Ornamentations[index].IsDissonantWith(item.OtherNote.Ornamentations[index])))
+        if (!IndicesToCheck.Any(index => item.Note.Ornamentations[index].IsDissonantWith(item.OtherNote.Ornamentations[index])))
         {
             return;
         }

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DoublePassingToneQuarterOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DoublePassingToneQuarterOrnamentationCleaner.cs
@@ -1,0 +1,36 @@
+﻿using Atrea.PolicyEngine.Processors;
+using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Extensions;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+
+internal sealed class DoublePassingToneQuarterOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
+{
+    private const int DoublePassingToneIndexToCheck = 1;
+
+    private const int HalfQuarterNoteIndexToCheck = 0;
+
+    public void Process(OrnamentationCleaningItem item)
+    {
+        if (item.Note.OrnamentationType is OrnamentationType.DoublePassingTone)
+        {
+            Clean(item.Note, item.OtherNote);
+        }
+        else
+        {
+            Clean(item.OtherNote, item.Note);
+        }
+    }
+
+    private void Clean(BaroquenNote noteWithDoublePassingTone, BaroquenNote noteWithHalfQuarter)
+    {
+        if (!noteWithDoublePassingTone.Ornamentations[DoublePassingToneIndexToCheck].IsDissonantWith(noteWithHalfQuarter.Ornamentations[HalfQuarterNoteIndexToCheck]))
+        {
+            return;
+        }
+
+        noteWithHalfQuarter.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/HalfEighthNoteOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/HalfEighthNoteOrnamentationCleaner.cs
@@ -1,0 +1,45 @@
+﻿using Atrea.PolicyEngine.Processors;
+using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Extensions;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+
+internal sealed class HalfEighthNoteOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
+{
+    private const int IndexToCheck = 0;
+
+    public void Process(OrnamentationCleaningItem item)
+    {
+        if (!item.Note.Ornamentations[IndexToCheck].IsDissonantWith(item.OtherNote.Ornamentations[IndexToCheck]))
+        {
+            return;
+        }
+
+        if (ShouldCleanNoteBasedOnOrnamentation(item.Note, item.OtherNote))
+        {
+            item.OtherNote.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
+        }
+        else if (ShouldCleanNoteBasedOnOrnamentation(item.OtherNote, item.Note))
+        {
+            item.Note.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
+        }
+        else if (item.Note > item.OtherNote)
+        {
+            item.OtherNote.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
+        }
+        else
+        {
+            item.Note.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
+        }
+    }
+
+    private static bool ShouldCleanNoteBasedOnOrnamentation(BaroquenNote note, BaroquenNote otherNote) => (note.OrnamentationType, otherNote.OrnamentationType) switch
+    {
+        (OrnamentationType.DelayedPassingTone, OrnamentationType.DelayedRepeatedNote) => true,
+        (OrnamentationType.DelayedPassingTone, OrnamentationType.DelayedNeighborTone) => true,
+        (OrnamentationType.DelayedNeighborTone, OrnamentationType.DelayedRepeatedNote) => true,
+        _ => false
+    };
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/HalfQuarterEighthOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/HalfQuarterEighthOrnamentationCleaner.cs
@@ -1,0 +1,38 @@
+﻿using Atrea.PolicyEngine.Processors;
+using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Extensions;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+
+internal sealed class HalfQuarterEighthOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
+{
+    private static readonly (int QuarterNoteIndex, int EighthNoteIndex)[] _indicesToCheck = [(0, 1)];
+
+    public void Process(OrnamentationCleaningItem item)
+    {
+        if (item.Note.OrnamentationType is
+            OrnamentationType.PassingTone or
+            OrnamentationType.DelayedDoublePassingTone or
+            OrnamentationType.RepeatedNote or
+            OrnamentationType.NeighborTone)
+        {
+            Clean(item.Note, item.OtherNote);
+        }
+        else
+        {
+            Clean(item.OtherNote, item.Note);
+        }
+    }
+
+    private void Clean(BaroquenNote noteWithHalfQuarter, BaroquenNote noteWithEighths)
+    {
+        if (!_indicesToCheck.Any(i => noteWithHalfQuarter.Ornamentations[i.QuarterNoteIndex].IsDissonantWith(noteWithEighths.Ornamentations[i.EighthNoteIndex])))
+        {
+            return;
+        }
+
+        noteWithHalfQuarter.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/HalfQuarterOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/HalfQuarterOrnamentationCleaner.cs
@@ -1,0 +1,48 @@
+﻿using Atrea.PolicyEngine.Processors;
+using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Extensions;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+
+internal sealed class HalfQuarterOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
+{
+    private const int IndexToCheck = 0;
+
+    public void Process(OrnamentationCleaningItem item)
+    {
+        if (!item.Note.Ornamentations[IndexToCheck].IsDissonantWith(item.OtherNote.Ornamentations[IndexToCheck]))
+        {
+            return;
+        }
+
+        if (ShouldCleanNoteBasedOnOrnamentation(item.Note, item.OtherNote))
+        {
+            item.OtherNote.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
+        }
+        else if (ShouldCleanNoteBasedOnOrnamentation(item.OtherNote, item.Note))
+        {
+            item.Note.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
+        }
+        else if (item.Note > item.OtherNote)
+        {
+            item.OtherNote.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
+        }
+        else
+        {
+            item.Note.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
+        }
+    }
+
+    private static bool ShouldCleanNoteBasedOnOrnamentation(BaroquenNote note, BaroquenNote otherNote) => (note.OrnamentationType, otherNote.OrnamentationType) switch
+    {
+        (OrnamentationType.DelayedDoublePassingTone, OrnamentationType.PassingTone) => true,
+        (OrnamentationType.DelayedDoublePassingTone, OrnamentationType.NeighborTone) => true,
+        (OrnamentationType.DelayedDoublePassingTone, OrnamentationType.RepeatedNote) => true,
+        (OrnamentationType.PassingTone, OrnamentationType.NeighborTone) => true,
+        (OrnamentationType.PassingTone, OrnamentationType.RepeatedNote) => true,
+        (OrnamentationType.NeighborTone, OrnamentationType.RepeatedNote) => true,
+        _ => false
+    };
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/QuarterQuarterEighthOrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/QuarterQuarterEighthOrnamentationCleaner.cs
@@ -1,0 +1,34 @@
+﻿using Atrea.PolicyEngine.Processors;
+using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Extensions;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+
+internal sealed class QuarterQuarterEighthOrnamentationCleaner(CompositionConfiguration compositionConfiguration) : IProcessor<OrnamentationCleaningItem>
+{
+    private static readonly (int QuarterNoteIndex, int EighthNoteIndex)[] _indicesToCheck = [(1, 1)];
+
+    public void Process(OrnamentationCleaningItem item)
+    {
+        if (item.Note.OrnamentationType is OrnamentationType.DoublePassingTone)
+        {
+            Clean(item.Note, item.OtherNote);
+        }
+        else
+        {
+            Clean(item.OtherNote, item.Note);
+        }
+    }
+
+    private void Clean(BaroquenNote noteWithQuarters, BaroquenNote noteWithEighths)
+    {
+        if (!_indicesToCheck.Any(i => noteWithQuarters.Ornamentations[i.QuarterNoteIndex].IsDissonantWith(noteWithEighths.Ornamentations[i.EighthNoteIndex])))
+        {
+            return;
+        }
+
+        noteWithQuarters.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/ThreeFourOrnamentationCleaningEngineBuilder.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Cleaning/Engine/ThreeFourOrnamentationCleaningEngineBuilder.cs
@@ -1,0 +1,178 @@
+﻿using Atrea.PolicyEngine;
+using Atrea.PolicyEngine.Builders;
+using Atrea.PolicyEngine.Policies.Input;
+using Atrea.PolicyEngine.Processors;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Policies.Input;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+
+namespace BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine;
+
+internal sealed class ThreeFourOrnamentationCleaningEngineBuilder(
+    IProcessor<OrnamentationCleaningItem> halfQuarterOrnamentationCleaner,
+    IProcessor<OrnamentationCleaningItem> eighthNoteOrnamentationCleaner,
+    IProcessor<OrnamentationCleaningItem> halfEighthNoteOrnamentationCleaner,
+    IProcessor<OrnamentationCleaningItem> sixteenthNoteOrnamentationCleaner,
+    IProcessor<OrnamentationCleaningItem> delayedRunEighthOrnamentationCleaner,
+    IProcessor<OrnamentationCleaningItem> doublePassingToneQuarterOrnamentationCleaner,
+    IProcessor<OrnamentationCleaningItem> doublePassingToneOrnamentationCleaner,
+    IProcessor<OrnamentationCleaningItem> halfQuarterEighthOrnamentationCleaner,
+    IProcessor<OrnamentationCleaningItem> quarterQuarterEighthOrnamentationCleaner,
+    IProcessor<OrnamentationCleaningItem> doublePassingToneDelayedRunOrnamentationCleaner
+) : IOrnamentationCleaningEngineBuilder
+{
+    public IPolicyEngine<OrnamentationCleaningItem> Build() => PolicyEngineBuilder<OrnamentationCleaningItem>.Configure()
+        .WithoutInputPolicies()
+        .WithProcessors(
+            BuildHalfQuarterOrnamentationCleanerEngine(),
+            BuildEighthNoteOrnamentationCleanerEngine(),
+            BuildHalfEighthNoteOrnamentationCleanerEngine(),
+            BuildSixteenthNoteOrnamentationCleanerEngine(),
+            BuildDelayedRunEighthOrnamentationCleanerEngine(),
+            BuildDoublePassingToneQuarterOrnamentationCleanerEngine(),
+            BuildDoublePassingToneOrnamentationCleanerEngine(),
+            BuildHalfQuarterEighthOrnamentationCleanerEngine(),
+            BuildQuarterQuarterEighthOrnamentationCleanerEngine(),
+            BuildDoublePassingToneDelayedRunOrnamentationCleanerEngine()
+        )
+        .WithoutOutputPolicies()
+        .Build();
+
+    private IProcessor<OrnamentationCleaningItem> BuildHalfQuarterOrnamentationCleanerEngine() => PolicyEngineBuilder<OrnamentationCleaningItem>.Configure()
+        .WithInputPolicies(
+            new HasTargetOrnamentations(OrnamentationType.PassingTone, OrnamentationType.PassingTone)
+                .Or(new HasTargetOrnamentations(OrnamentationType.PassingTone, OrnamentationType.DelayedDoublePassingTone))
+                .Or(new HasTargetOrnamentations(OrnamentationType.PassingTone, OrnamentationType.NeighborTone))
+                .Or(new HasTargetOrnamentations(OrnamentationType.PassingTone, OrnamentationType.RepeatedNote))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DelayedDoublePassingTone, OrnamentationType.DelayedDoublePassingTone))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DelayedDoublePassingTone, OrnamentationType.NeighborTone))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DelayedDoublePassingTone, OrnamentationType.RepeatedNote))
+                .Or(new HasTargetOrnamentations(OrnamentationType.NeighborTone, OrnamentationType.NeighborTone))
+                .Or(new HasTargetOrnamentations(OrnamentationType.NeighborTone, OrnamentationType.RepeatedNote))
+                .Or(new HasTargetOrnamentations(OrnamentationType.RepeatedNote, OrnamentationType.RepeatedNote))
+        )
+        .WithProcessors(halfQuarterOrnamentationCleaner)
+        .WithoutOutputPolicies()
+        .Build();
+
+    private IProcessor<OrnamentationCleaningItem> BuildEighthNoteOrnamentationCleanerEngine() => PolicyEngineBuilder<OrnamentationCleaningItem>.Configure()
+        .WithInputPolicies(
+            new HasTargetOrnamentations(OrnamentationType.Run, OrnamentationType.Run)
+                .Or(new HasTargetOrnamentations(OrnamentationType.Run, OrnamentationType.Turn))
+                .Or(new HasTargetOrnamentations(OrnamentationType.Run, OrnamentationType.AlternateTurn))
+                .Or(new HasTargetOrnamentations(OrnamentationType.Run, OrnamentationType.DecorateInterval))
+                .Or(new HasTargetOrnamentations(OrnamentationType.Run, OrnamentationType.Pedal))
+                .Or(new HasTargetOrnamentations(OrnamentationType.Turn, OrnamentationType.Turn))
+                .Or(new HasTargetOrnamentations(OrnamentationType.Turn, OrnamentationType.AlternateTurn))
+                .Or(new HasTargetOrnamentations(OrnamentationType.Turn, OrnamentationType.DecorateInterval))
+                .Or(new HasTargetOrnamentations(OrnamentationType.Turn, OrnamentationType.Pedal))
+                .Or(new HasTargetOrnamentations(OrnamentationType.AlternateTurn, OrnamentationType.AlternateTurn))
+                .Or(new HasTargetOrnamentations(OrnamentationType.AlternateTurn, OrnamentationType.DecorateInterval))
+                .Or(new HasTargetOrnamentations(OrnamentationType.AlternateTurn, OrnamentationType.Pedal))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DecorateInterval, OrnamentationType.DecorateInterval))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DecorateInterval, OrnamentationType.Pedal))
+                .Or(new HasTargetOrnamentations(OrnamentationType.Pedal, OrnamentationType.Pedal))
+        )
+        .WithProcessors(eighthNoteOrnamentationCleaner)
+        .WithoutOutputPolicies()
+        .Build();
+
+    private IProcessor<OrnamentationCleaningItem> BuildHalfEighthNoteOrnamentationCleanerEngine() => PolicyEngineBuilder<OrnamentationCleaningItem>.Configure()
+        .WithInputPolicies(
+            new HasTargetOrnamentations(OrnamentationType.DelayedPassingTone, OrnamentationType.DelayedPassingTone)
+                .Or(new HasTargetOrnamentations(OrnamentationType.DelayedPassingTone, OrnamentationType.DelayedNeighborTone))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DelayedPassingTone, OrnamentationType.DelayedRepeatedNote))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DelayedNeighborTone, OrnamentationType.DelayedNeighborTone))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DelayedNeighborTone, OrnamentationType.DelayedRepeatedNote))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DelayedRepeatedNote, OrnamentationType.DelayedRepeatedNote))
+        )
+        .WithProcessors(halfEighthNoteOrnamentationCleaner)
+        .WithoutOutputPolicies()
+        .Build();
+
+    private IProcessor<OrnamentationCleaningItem> BuildSixteenthNoteOrnamentationCleanerEngine() => PolicyEngineBuilder<OrnamentationCleaningItem>.Configure()
+        .WithInputPolicies(
+            new HasTargetOrnamentations(OrnamentationType.DoubleRun, OrnamentationType.DoubleRun)
+                .Or(new HasTargetOrnamentations(OrnamentationType.DoubleRun, OrnamentationType.DoubleTurn))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DoubleTurn, OrnamentationType.DoubleTurn))
+        )
+        .WithProcessors(sixteenthNoteOrnamentationCleaner)
+        .WithoutOutputPolicies()
+        .Build();
+
+    private IProcessor<OrnamentationCleaningItem> BuildDelayedRunEighthOrnamentationCleanerEngine() => PolicyEngineBuilder<OrnamentationCleaningItem>.Configure()
+        .WithInputPolicies(
+            new HasTargetOrnamentations(OrnamentationType.DelayedRun, OrnamentationType.Run)
+                .Or(new HasTargetOrnamentations(OrnamentationType.DelayedRun, OrnamentationType.Turn))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DelayedRun, OrnamentationType.AlternateTurn))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DelayedRun, OrnamentationType.DecorateInterval))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DelayedRun, OrnamentationType.Pedal))
+        )
+        .WithProcessors(delayedRunEighthOrnamentationCleaner)
+        .WithoutOutputPolicies()
+        .Build();
+
+    private IProcessor<OrnamentationCleaningItem> BuildDoublePassingToneQuarterOrnamentationCleanerEngine() => PolicyEngineBuilder<OrnamentationCleaningItem>.Configure()
+        .WithInputPolicies(
+            new HasTargetOrnamentations(OrnamentationType.DoublePassingTone, OrnamentationType.PassingTone)
+                .Or(new HasTargetOrnamentations(OrnamentationType.DoublePassingTone, OrnamentationType.RepeatedNote))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DoublePassingTone, OrnamentationType.NeighborTone))
+        )
+        .WithProcessors(doublePassingToneQuarterOrnamentationCleaner)
+        .WithoutOutputPolicies()
+        .Build();
+
+    private IProcessor<OrnamentationCleaningItem> BuildDoublePassingToneOrnamentationCleanerEngine() => PolicyEngineBuilder<OrnamentationCleaningItem>.Configure()
+        .WithInputPolicies(
+            new HasTargetOrnamentations(OrnamentationType.DoublePassingTone, OrnamentationType.DoublePassingTone)
+        )
+        .WithProcessors(doublePassingToneOrnamentationCleaner)
+        .WithoutOutputPolicies()
+        .Build();
+
+    private IProcessor<OrnamentationCleaningItem> BuildHalfQuarterEighthOrnamentationCleanerEngine() => PolicyEngineBuilder<OrnamentationCleaningItem>.Configure()
+        .WithInputPolicies(
+            new HasTargetOrnamentations(OrnamentationType.PassingTone, OrnamentationType.Run)
+                .Or(new HasTargetOrnamentations(OrnamentationType.PassingTone, OrnamentationType.Turn))
+                .Or(new HasTargetOrnamentations(OrnamentationType.PassingTone, OrnamentationType.AlternateTurn))
+                .Or(new HasTargetOrnamentations(OrnamentationType.PassingTone, OrnamentationType.DecorateInterval))
+                .Or(new HasTargetOrnamentations(OrnamentationType.PassingTone, OrnamentationType.Pedal))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DelayedDoublePassingTone, OrnamentationType.Run))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DelayedDoublePassingTone, OrnamentationType.Turn))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DelayedDoublePassingTone, OrnamentationType.AlternateTurn))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DelayedDoublePassingTone, OrnamentationType.DecorateInterval))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DelayedDoublePassingTone, OrnamentationType.Pedal))
+                .Or(new HasTargetOrnamentations(OrnamentationType.RepeatedNote, OrnamentationType.Run))
+                .Or(new HasTargetOrnamentations(OrnamentationType.RepeatedNote, OrnamentationType.Turn))
+                .Or(new HasTargetOrnamentations(OrnamentationType.RepeatedNote, OrnamentationType.AlternateTurn))
+                .Or(new HasTargetOrnamentations(OrnamentationType.RepeatedNote, OrnamentationType.DecorateInterval))
+                .Or(new HasTargetOrnamentations(OrnamentationType.RepeatedNote, OrnamentationType.Pedal))
+                .Or(new HasTargetOrnamentations(OrnamentationType.NeighborTone, OrnamentationType.Run))
+                .Or(new HasTargetOrnamentations(OrnamentationType.NeighborTone, OrnamentationType.Turn))
+                .Or(new HasTargetOrnamentations(OrnamentationType.NeighborTone, OrnamentationType.AlternateTurn))
+                .Or(new HasTargetOrnamentations(OrnamentationType.NeighborTone, OrnamentationType.DecorateInterval))
+                .Or(new HasTargetOrnamentations(OrnamentationType.NeighborTone, OrnamentationType.Pedal))
+        )
+        .WithProcessors(halfQuarterEighthOrnamentationCleaner)
+        .WithoutOutputPolicies()
+        .Build();
+
+    private IProcessor<OrnamentationCleaningItem> BuildQuarterQuarterEighthOrnamentationCleanerEngine() => PolicyEngineBuilder<OrnamentationCleaningItem>.Configure()
+        .WithInputPolicies(
+            new HasTargetOrnamentations(OrnamentationType.DoublePassingTone, OrnamentationType.Run)
+                .Or(new HasTargetOrnamentations(OrnamentationType.DoublePassingTone, OrnamentationType.Turn))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DoublePassingTone, OrnamentationType.AlternateTurn))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DoublePassingTone, OrnamentationType.DecorateInterval))
+                .Or(new HasTargetOrnamentations(OrnamentationType.DoublePassingTone, OrnamentationType.Pedal))
+        )
+        .WithProcessors(quarterQuarterEighthOrnamentationCleaner)
+        .WithoutOutputPolicies()
+        .Build();
+
+    private IProcessor<OrnamentationCleaningItem> BuildDoublePassingToneDelayedRunOrnamentationCleanerEngine() => PolicyEngineBuilder<OrnamentationCleaningItem>.Configure()
+        .WithInputPolicies(
+            new HasTargetOrnamentations(OrnamentationType.DoublePassingTone, OrnamentationType.DelayedRun)
+        )
+        .WithProcessors(doublePassingToneDelayedRunOrnamentationCleaner)
+        .WithoutOutputPolicies()
+        .Build();
+}

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculator.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculator.cs
@@ -9,54 +9,132 @@ internal sealed class MusicalTimeSpanCalculator : IMusicalTimeSpanCalculator
 {
     private static MusicalTimeSpan Zero => new();
 
+#pragma warning disable MA0051 // Method is too long
     public MusicalTimeSpan CalculatePrimaryNoteTimeSpan(OrnamentationType ornamentationType, Meter meter) => ornamentationType switch
     {
         OrnamentationType.None when meter == Meter.FourFour => MusicalTimeSpan.Half,
+        OrnamentationType.None when meter == Meter.ThreeFour => MusicalTimeSpan.Half.Dotted(1),
+
         OrnamentationType.PassingTone when meter == Meter.FourFour => MusicalTimeSpan.Quarter,
+        OrnamentationType.PassingTone when meter == Meter.ThreeFour => MusicalTimeSpan.Half,
+
         OrnamentationType.Run when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
+        OrnamentationType.Run when meter == Meter.ThreeFour => MusicalTimeSpan.Quarter.Dotted(1),
+
         OrnamentationType.DelayedPassingTone when meter == Meter.FourFour => MusicalTimeSpan.Quarter.Dotted(1),
+        OrnamentationType.DelayedPassingTone when meter == Meter.ThreeFour => MusicalTimeSpan.Half + MusicalTimeSpan.Eighth,
+
         OrnamentationType.Turn when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
+        OrnamentationType.Turn when meter == Meter.ThreeFour => MusicalTimeSpan.Quarter.Dotted(1),
+
         OrnamentationType.AlternateTurn when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
+        OrnamentationType.AlternateTurn when meter == Meter.ThreeFour => MusicalTimeSpan.Quarter.Dotted(1),
+
         OrnamentationType.Sustain when meter == Meter.FourFour => MusicalTimeSpan.Whole,
+        OrnamentationType.Sustain when meter == Meter.ThreeFour => MusicalTimeSpan.Half.Dotted(1) + MusicalTimeSpan.Half.Dotted(1),
+
         OrnamentationType.DoubleTurn when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
+        OrnamentationType.DoubleTurn when meter == Meter.ThreeFour => MusicalTimeSpan.Quarter + MusicalTimeSpan.Sixteenth,
+
         OrnamentationType.DelayedRun when meter == Meter.FourFour => MusicalTimeSpan.Quarter,
+        OrnamentationType.DelayedRun when meter == Meter.ThreeFour => MusicalTimeSpan.Quarter,
+
         OrnamentationType.DoublePassingTone when meter == Meter.FourFour => MusicalTimeSpan.Quarter,
+        OrnamentationType.DoublePassingTone when meter == Meter.ThreeFour => MusicalTimeSpan.Quarter,
+
         OrnamentationType.DelayedDoublePassingTone when meter == Meter.FourFour => MusicalTimeSpan.Quarter.Dotted(1),
+        OrnamentationType.DelayedDoublePassingTone when meter == Meter.ThreeFour => MusicalTimeSpan.Half,
+
         OrnamentationType.DecorateInterval when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
+        OrnamentationType.DecorateInterval when meter == Meter.ThreeFour => MusicalTimeSpan.Quarter.Dotted(1),
+
         OrnamentationType.DoubleRun when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
+        OrnamentationType.DoubleRun when meter == Meter.ThreeFour => MusicalTimeSpan.Quarter + MusicalTimeSpan.Sixteenth,
+
         OrnamentationType.Pedal when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
+        OrnamentationType.Pedal when meter == Meter.ThreeFour => MusicalTimeSpan.Quarter.Dotted(1),
+
         OrnamentationType.Mordent when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
+        OrnamentationType.Mordent when meter == Meter.ThreeFour => MusicalTimeSpan.Sixteenth,
+
         OrnamentationType.RepeatedNote when meter == Meter.FourFour => MusicalTimeSpan.Quarter,
+        OrnamentationType.RepeatedNote when meter == Meter.ThreeFour => MusicalTimeSpan.Half,
+
         OrnamentationType.DelayedRepeatedNote when meter == Meter.FourFour => MusicalTimeSpan.Quarter.Dotted(1),
+        OrnamentationType.DelayedRepeatedNote when meter == Meter.ThreeFour => MusicalTimeSpan.Half + MusicalTimeSpan.Eighth,
+
         OrnamentationType.NeighborTone when meter == Meter.FourFour => MusicalTimeSpan.Quarter,
+        OrnamentationType.NeighborTone when meter == Meter.ThreeFour => MusicalTimeSpan.Half,
+
         OrnamentationType.DelayedNeighborTone when meter == Meter.FourFour => MusicalTimeSpan.Quarter.Dotted(1),
+        OrnamentationType.DelayedNeighborTone when meter == Meter.ThreeFour => MusicalTimeSpan.Half + MusicalTimeSpan.Eighth,
+
         OrnamentationType.MidSustain => Zero,
         OrnamentationType.Rest => Zero,
         _ => throw new ArgumentOutOfRangeException(nameof(ornamentationType), ornamentationType, $"Invalid {nameof(OrnamentationType)}")
     };
 
+#pragma warning disable MA0051 // Method is too long
     public MusicalTimeSpan CalculateOrnamentationTimeSpan(OrnamentationType ornamentationType, Meter meter, int ornamentationStep = 1) => ornamentationType switch
     {
         OrnamentationType.None => throw new NotSupportedException($"{nameof(OrnamentationType.None)} cannot be applied to an ornamentation."),
+
         OrnamentationType.PassingTone when meter == Meter.FourFour => MusicalTimeSpan.Quarter,
+        OrnamentationType.PassingTone when meter == Meter.ThreeFour => MusicalTimeSpan.Quarter,
+
         OrnamentationType.Run when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
+        OrnamentationType.Run when meter == Meter.ThreeFour => MusicalTimeSpan.Eighth,
+
         OrnamentationType.DelayedPassingTone when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
+        OrnamentationType.DelayedPassingTone when meter == Meter.ThreeFour => MusicalTimeSpan.Eighth,
+
         OrnamentationType.Turn when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
+        OrnamentationType.Turn when meter == Meter.ThreeFour => MusicalTimeSpan.Eighth,
+
         OrnamentationType.AlternateTurn when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
+        OrnamentationType.AlternateTurn when meter == Meter.ThreeFour => MusicalTimeSpan.Eighth,
+
         OrnamentationType.Sustain => throw new NotSupportedException($"{nameof(OrnamentationType.Sustain)} cannot be applied to an ornamentation."),
+
         OrnamentationType.DoubleTurn when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
+        OrnamentationType.DoubleTurn when meter == Meter.ThreeFour => MusicalTimeSpan.Sixteenth,
+
         OrnamentationType.DelayedRun when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
+        OrnamentationType.DelayedRun when meter == Meter.ThreeFour => MusicalTimeSpan.Eighth,
+
         OrnamentationType.DoublePassingTone when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
+        OrnamentationType.DoublePassingTone when meter == Meter.ThreeFour => MusicalTimeSpan.Quarter,
+
         OrnamentationType.DelayedDoublePassingTone when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
+        OrnamentationType.DelayedDoublePassingTone when meter == Meter.ThreeFour => MusicalTimeSpan.Eighth,
+
         OrnamentationType.DecorateInterval when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
+        OrnamentationType.DecorateInterval when meter == Meter.ThreeFour => MusicalTimeSpan.Eighth,
+
         OrnamentationType.DoubleRun when meter == Meter.FourFour => MusicalTimeSpan.Sixteenth,
+        OrnamentationType.DoubleRun when meter == Meter.ThreeFour => MusicalTimeSpan.Sixteenth,
+
         OrnamentationType.Pedal when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
+        OrnamentationType.Pedal when meter == Meter.ThreeFour => MusicalTimeSpan.Eighth,
+
         OrnamentationType.Mordent when meter == Meter.FourFour && ornamentationStep == 1 => MusicalTimeSpan.Sixteenth,
+        OrnamentationType.Mordent when meter == Meter.ThreeFour && ornamentationStep == 1 => MusicalTimeSpan.Sixteenth,
+
         OrnamentationType.Mordent when meter == Meter.FourFour && ornamentationStep == 2 => MusicalTimeSpan.Quarter.Dotted(1),
+        OrnamentationType.Mordent when meter == Meter.ThreeFour && ornamentationStep == 2 => MusicalTimeSpan.Half + MusicalTimeSpan.Eighth,
+
         OrnamentationType.RepeatedNote when meter == Meter.FourFour => MusicalTimeSpan.Quarter,
+        OrnamentationType.RepeatedNote when meter == Meter.ThreeFour => MusicalTimeSpan.Quarter,
+
         OrnamentationType.DelayedRepeatedNote when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
+        OrnamentationType.DelayedRepeatedNote when meter == Meter.ThreeFour => MusicalTimeSpan.Eighth,
+
         OrnamentationType.NeighborTone when meter == Meter.FourFour => MusicalTimeSpan.Quarter,
+        OrnamentationType.NeighborTone when meter == Meter.ThreeFour => MusicalTimeSpan.Quarter,
+
         OrnamentationType.DelayedNeighborTone when meter == Meter.FourFour => MusicalTimeSpan.Eighth,
+        OrnamentationType.DelayedNeighborTone when meter == Meter.ThreeFour => MusicalTimeSpan.Eighth,
+
         OrnamentationType.MidSustain => Zero,
         OrnamentationType.Rest => Zero,
         _ => throw new ArgumentOutOfRangeException(nameof(ornamentationType), ornamentationType, $"Invalid {nameof(OrnamentationType)}")

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -31,7 +31,7 @@ var phrasingConfiguration = new PhrasingConfiguration(
 
 var musicalTimeSpanCalculator = new MusicalTimeSpanCalculator();
 
-var meter = Meter.FourFour;
+const Meter meter = Meter.ThreeFour;
 
 var compositionConfiguration = new CompositionConfiguration(
     new HashSet<VoiceConfiguration>
@@ -43,10 +43,10 @@ var compositionConfiguration = new CompositionConfiguration(
     },
     phrasingConfiguration,
     AggregateCompositionRuleConfiguration.Default,
-    BaroquenScale.Parse("C Ionian"),
+    BaroquenScale.Parse("E Phrygian"),
     meter,
     musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.None, meter),
-    25
+    30
 );
 
 using var factory = LoggerFactory.Create(builder => builder.AddConsole());

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Enums/Extensions/MeterExtensionsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Enums/Extensions/MeterExtensionsTests.cs
@@ -10,6 +10,7 @@ internal sealed class MeterExtensionsTests
 {
     [Test]
     [TestCase(Meter.FourFour, 4)]
+    [TestCase(Meter.ThreeFour, 3)]
     public void BeatsPerMeasure_returns_expected_value(Meter meter, int expectedBeatsPerMeasure) =>
         meter.BeatsPerMeasure().Should().Be(expectedBeatsPerMeasure);
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/FourFourOrnamentationCleaningEngineBuilderTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/FourFourOrnamentationCleaningEngineBuilderTests.cs
@@ -3,7 +3,8 @@ using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine;
-using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.FourFour;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.MeterAgnostic;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -13,7 +14,7 @@ using NUnit.Framework;
 namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine;
 
 [TestFixture]
-internal sealed class OrnamentationCleaningEngineBuilderTests
+internal sealed class FourFourOrnamentationCleaningEngineBuilderTests
 {
     private IProcessor<OrnamentationCleaningItem> _mockPassingToneOrnamentationCleaner = null!;
 
@@ -31,7 +32,7 @@ internal sealed class OrnamentationCleaningEngineBuilderTests
 
     private Dictionary<string, IProcessor<OrnamentationCleaningItem>> _processorsByName = null!;
 
-    private OrnamentationCleaningEngineBuilder _ornamentationCleaningEngineBuilder;
+    private FourFourOrnamentationCleaningEngineBuilder _fourFourOrnamentationCleaningEngineBuilder;
 
     [SetUp]
     public void SetUp()
@@ -55,7 +56,7 @@ internal sealed class OrnamentationCleaningEngineBuilderTests
             { nameof(MordentEighthNoteOrnamentationCleaner), _mockMordentEighthNoteOrnamentationCleaner }
         };
 
-        _ornamentationCleaningEngineBuilder = new OrnamentationCleaningEngineBuilder(
+        _fourFourOrnamentationCleaningEngineBuilder = new FourFourOrnamentationCleaningEngineBuilder(
             _mockPassingToneOrnamentationCleaner,
             _mockEighthNoteOrnamentationCleaner,
             _mockPassingToneEighthNoteOrnamentationCleaner,
@@ -187,7 +188,7 @@ internal sealed class OrnamentationCleaningEngineBuilderTests
             new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half) { OrnamentationType = ornamentationTypeB }
         );
 
-        var ornamentationCleaningEngine = _ornamentationCleaningEngineBuilder.Build();
+        var ornamentationCleaningEngine = _fourFourOrnamentationCleaningEngineBuilder.Build();
 
         // act
         ornamentationCleaningEngine.Process(ornamentationCleaningItem);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/MordentEighthNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/MordentEighthNoteOrnamentationCleanerTests.cs
@@ -1,7 +1,7 @@
 ﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
-using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.FourFour;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
@@ -9,7 +9,7 @@ using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
 using NUnit.Framework;
 
-namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors;
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors.FourFour;
 
 [TestFixture]
 internal sealed class MordentEighthNoteOrnamentationCleanerTests

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/QuarterEighthNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/QuarterEighthNoteOrnamentationCleanerTests.cs
@@ -1,7 +1,7 @@
 ﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
-using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.FourFour;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
@@ -9,7 +9,7 @@ using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
 using NUnit.Framework;
 
-namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors;
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors.FourFour;
 
 [TestFixture]
 internal sealed class QuarterEighthNoteOrnamentationCleanerTests

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/QuarterNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/QuarterNoteOrnamentationCleanerTests.cs
@@ -1,7 +1,7 @@
 ﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
-using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.FourFour;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
@@ -9,7 +9,7 @@ using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
 using NUnit.Framework;
 
-namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors;
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors.FourFour;
 
 [TestFixture]
 internal sealed class QuarterNoteOrnamentationCleanerTests

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/SixteenthEighthNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/SixteenthEighthNoteOrnamentationCleanerTests.cs
@@ -1,7 +1,7 @@
 ﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
-using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.FourFour;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
@@ -9,15 +9,15 @@ using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
 using NUnit.Framework;
 
-namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors;
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors.FourFour;
 
 [TestFixture]
-internal sealed class SixteenthNoteOrnamentationCleanerTests
+internal sealed class SixteenthEighthNoteOrnamentationCleanerTests
 {
-    private SixteenthNoteOrnamentationCleaner _cleaner = null!;
+    private SixteenthEighthNoteOrnamentationCleaner _cleaner;
 
     [SetUp]
-    public void SetUp() => _cleaner = new SixteenthNoteOrnamentationCleaner(Configurations.GetCompositionConfiguration());
+    public void SetUp() => _cleaner = new SixteenthEighthNoteOrnamentationCleaner(Configurations.GetCompositionConfiguration());
 
     [Test]
     [TestCaseSource(nameof(TestCases))]
@@ -48,7 +48,6 @@ internal sealed class SixteenthNoteOrnamentationCleanerTests
             var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half);
             var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
             var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half);
-            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half);
 
             var sopranoWithAscendingDoubleRun = new BaroquenNote(sopranoC4)
             {
@@ -67,61 +66,45 @@ internal sealed class SixteenthNoteOrnamentationCleanerTests
 
             var altoC3WithoutDissonantNotes = new BaroquenNote(altoC3)
             {
-                OrnamentationType = OrnamentationType.DoubleRun,
+                OrnamentationType = OrnamentationType.Run,
                 Ornamentations =
                 {
-                    new BaroquenNote(altoD3),
                     new BaroquenNote(altoE3),
+                    new BaroquenNote(altoD3),
+                    new BaroquenNote(altoF3)
+                }
+            };
+
+            var altoC3WithDissonantFirstNote = new BaroquenNote(altoC3)
+            {
+                OrnamentationType = OrnamentationType.Run,
+                Ornamentations =
+                {
                     new BaroquenNote(altoF3),
                     new BaroquenNote(altoD3),
-                    new BaroquenNote(altoE3),
-                    new BaroquenNote(altoF3),
-                    new BaroquenNote(altoG3)
+                    new BaroquenNote(altoF3)
                 }
             };
 
             var altoC3WithDissonantSecondNote = new BaroquenNote(altoC3)
             {
-                OrnamentationType = OrnamentationType.DoubleRun,
+                OrnamentationType = OrnamentationType.Run,
                 Ornamentations =
                 {
-                    new BaroquenNote(altoD3),
-                    new BaroquenNote(altoD3),
-                    new BaroquenNote(altoF3),
-                    new BaroquenNote(altoD3),
                     new BaroquenNote(altoE3),
-                    new BaroquenNote(altoF3),
-                    new BaroquenNote(altoG3)
+                    new BaroquenNote(altoE3),
+                    new BaroquenNote(altoF3)
                 }
             };
 
-            var altoC3WithDissonantFourthNote = new BaroquenNote(altoC3)
+            var altoC3WithDissonantThirdNote = new BaroquenNote(altoC3)
             {
-                OrnamentationType = OrnamentationType.DoubleRun,
+                OrnamentationType = OrnamentationType.Run,
                 Ornamentations =
                 {
+                    new BaroquenNote(altoE3),
                     new BaroquenNote(altoD3),
-                    new BaroquenNote(altoE3),
-                    new BaroquenNote(altoF3),
-                    new BaroquenNote(altoC3),
-                    new BaroquenNote(altoE3),
-                    new BaroquenNote(altoF3),
-                    new BaroquenNote(altoG3)
-                }
-            };
-
-            var altoC3WithDissonantSixthNote = new BaroquenNote(altoC3)
-            {
-                OrnamentationType = OrnamentationType.DoubleRun,
-                Ornamentations =
-                {
-                    new BaroquenNote(altoD3),
-                    new BaroquenNote(altoE3),
-                    new BaroquenNote(altoF3),
-                    new BaroquenNote(altoD3),
-                    new BaroquenNote(altoE3),
-                    new BaroquenNote(altoG3),
-                    new BaroquenNote(altoG3)
+                    new BaroquenNote(altoE3)
                 }
             };
 
@@ -130,49 +113,56 @@ internal sealed class SixteenthNoteOrnamentationCleanerTests
                 new BaroquenNote(altoC3WithoutDissonantNotes),
                 new BaroquenNote(sopranoWithAscendingDoubleRun),
                 new BaroquenNote(altoC3WithoutDissonantNotes)
-            ).SetName("When double run notes don't conflict, no notes are cleaned.");
+            ).SetName("When double run notes don't conflict with sixteenth notes, no notes are cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoC3WithoutDissonantNotes),
+                new BaroquenNote(sopranoWithAscendingDoubleRun),
+                new BaroquenNote(altoC3WithoutDissonantNotes),
+                new BaroquenNote(sopranoWithAscendingDoubleRun)
+            ).SetName("When double run notes don't conflict with sixteenth notes, no notes are cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoWithAscendingDoubleRun),
+                new BaroquenNote(altoC3WithDissonantFirstNote),
+                new BaroquenNote(sopranoWithAscendingDoubleRun),
+                new BaroquenNote(altoC3)
+            ).SetName("When double run notes conflict with sixteenth notes, then lower note is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoC3WithDissonantFirstNote),
+                new BaroquenNote(sopranoWithAscendingDoubleRun),
+                new BaroquenNote(altoC3),
+                new BaroquenNote(sopranoWithAscendingDoubleRun)
+            ).SetName("When double run notes conflict with sixteenth notes, then lower note is cleaned.");
 
             yield return new TestCaseData(
                 new BaroquenNote(sopranoWithAscendingDoubleRun),
                 new BaroquenNote(altoC3WithDissonantSecondNote),
                 new BaroquenNote(sopranoWithAscendingDoubleRun),
                 new BaroquenNote(altoC3)
-            ).SetName("When double run notes conflict, lower note is cleaned.");
+            ).SetName("When double run notes conflict with sixteenth notes, then lower note is cleaned.");
 
             yield return new TestCaseData(
                 new BaroquenNote(altoC3WithDissonantSecondNote),
                 new BaroquenNote(sopranoWithAscendingDoubleRun),
                 new BaroquenNote(altoC3),
                 new BaroquenNote(sopranoWithAscendingDoubleRun)
-            ).SetName("When double run notes conflict, lower note is cleaned.");
+            ).SetName("When double run notes conflict with sixteenth notes, then lower note is cleaned.");
 
             yield return new TestCaseData(
                 new BaroquenNote(sopranoWithAscendingDoubleRun),
-                new BaroquenNote(altoC3WithDissonantFourthNote),
+                new BaroquenNote(altoC3WithDissonantThirdNote),
                 new BaroquenNote(sopranoWithAscendingDoubleRun),
                 new BaroquenNote(altoC3)
-            ).SetName("When double run notes conflict, lower note is cleaned.");
+            ).SetName("When double run notes conflict with sixteenth notes, then lower note is cleaned.");
 
             yield return new TestCaseData(
-                new BaroquenNote(altoC3WithDissonantFourthNote),
+                new BaroquenNote(altoC3WithDissonantThirdNote),
                 new BaroquenNote(sopranoWithAscendingDoubleRun),
                 new BaroquenNote(altoC3),
                 new BaroquenNote(sopranoWithAscendingDoubleRun)
-            ).SetName("When double run notes conflict, lower note is cleaned.");
-
-            yield return new TestCaseData(
-                new BaroquenNote(sopranoWithAscendingDoubleRun),
-                new BaroquenNote(altoC3WithDissonantSixthNote),
-                new BaroquenNote(sopranoWithAscendingDoubleRun),
-                new BaroquenNote(altoC3)
-            ).SetName("When double run notes conflict, lower note is cleaned.");
-
-            yield return new TestCaseData(
-                new BaroquenNote(altoC3WithDissonantSixthNote),
-                new BaroquenNote(sopranoWithAscendingDoubleRun),
-                new BaroquenNote(altoC3),
-                new BaroquenNote(sopranoWithAscendingDoubleRun)
-            ).SetName("When double run notes conflict, lower note is cleaned.");
+            ).SetName("When double run notes conflict with sixteenth notes, then lower note is cleaned.");
         }
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/TurnAlternateTurnOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/TurnAlternateTurnOrnamentationCleanerTests.cs
@@ -1,7 +1,7 @@
 ﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
-using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.FourFour;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
@@ -9,7 +9,7 @@ using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
 using NUnit.Framework;
 
-namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors;
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors.FourFour;
 
 [TestFixture]
 internal sealed class TurnAlternateTurnOrnamentationCleanerTests

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/MeterAgnostic/EighthNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/MeterAgnostic/EighthNoteOrnamentationCleanerTests.cs
@@ -1,7 +1,7 @@
 ﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
-using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.MeterAgnostic;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
@@ -9,7 +9,7 @@ using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
 using NUnit.Framework;
 
-namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors;
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors.MeterAgnostic;
 
 [TestFixture]
 internal sealed class EighthNoteOrnamentationCleanerTests

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/MeterAgnostic/SixteenthNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/MeterAgnostic/SixteenthNoteOrnamentationCleanerTests.cs
@@ -1,7 +1,7 @@
 ﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
-using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.MeterAgnostic;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
@@ -9,15 +9,15 @@ using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
 using NUnit.Framework;
 
-namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors;
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors.MeterAgnostic;
 
 [TestFixture]
-internal sealed class SixteenthEighthNoteOrnamentationCleanerTests
+internal sealed class SixteenthNoteOrnamentationCleanerTests
 {
-    private SixteenthEighthNoteOrnamentationCleaner _cleaner;
+    private SixteenthNoteOrnamentationCleaner _cleaner = null!;
 
     [SetUp]
-    public void SetUp() => _cleaner = new SixteenthEighthNoteOrnamentationCleaner(Configurations.GetCompositionConfiguration());
+    public void SetUp() => _cleaner = new SixteenthNoteOrnamentationCleaner(Configurations.GetCompositionConfiguration());
 
     [Test]
     [TestCaseSource(nameof(TestCases))]
@@ -48,6 +48,7 @@ internal sealed class SixteenthEighthNoteOrnamentationCleanerTests
             var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half);
             var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
             var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half);
+            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half);
 
             var sopranoWithAscendingDoubleRun = new BaroquenNote(sopranoC4)
             {
@@ -66,45 +67,61 @@ internal sealed class SixteenthEighthNoteOrnamentationCleanerTests
 
             var altoC3WithoutDissonantNotes = new BaroquenNote(altoC3)
             {
-                OrnamentationType = OrnamentationType.Run,
+                OrnamentationType = OrnamentationType.DoubleRun,
                 Ornamentations =
                 {
-                    new BaroquenNote(altoE3),
                     new BaroquenNote(altoD3),
-                    new BaroquenNote(altoF3)
-                }
-            };
-
-            var altoC3WithDissonantFirstNote = new BaroquenNote(altoC3)
-            {
-                OrnamentationType = OrnamentationType.Run,
-                Ornamentations =
-                {
+                    new BaroquenNote(altoE3),
                     new BaroquenNote(altoF3),
                     new BaroquenNote(altoD3),
-                    new BaroquenNote(altoF3)
+                    new BaroquenNote(altoE3),
+                    new BaroquenNote(altoF3),
+                    new BaroquenNote(altoG3)
                 }
             };
 
             var altoC3WithDissonantSecondNote = new BaroquenNote(altoC3)
             {
-                OrnamentationType = OrnamentationType.Run,
+                OrnamentationType = OrnamentationType.DoubleRun,
                 Ornamentations =
                 {
+                    new BaroquenNote(altoD3),
+                    new BaroquenNote(altoD3),
+                    new BaroquenNote(altoF3),
+                    new BaroquenNote(altoD3),
                     new BaroquenNote(altoE3),
-                    new BaroquenNote(altoE3),
-                    new BaroquenNote(altoF3)
+                    new BaroquenNote(altoF3),
+                    new BaroquenNote(altoG3)
                 }
             };
 
-            var altoC3WithDissonantThirdNote = new BaroquenNote(altoC3)
+            var altoC3WithDissonantFourthNote = new BaroquenNote(altoC3)
             {
-                OrnamentationType = OrnamentationType.Run,
+                OrnamentationType = OrnamentationType.DoubleRun,
                 Ornamentations =
                 {
-                    new BaroquenNote(altoE3),
                     new BaroquenNote(altoD3),
-                    new BaroquenNote(altoE3)
+                    new BaroquenNote(altoE3),
+                    new BaroquenNote(altoF3),
+                    new BaroquenNote(altoC3),
+                    new BaroquenNote(altoE3),
+                    new BaroquenNote(altoF3),
+                    new BaroquenNote(altoG3)
+                }
+            };
+
+            var altoC3WithDissonantSixthNote = new BaroquenNote(altoC3)
+            {
+                OrnamentationType = OrnamentationType.DoubleRun,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoD3),
+                    new BaroquenNote(altoE3),
+                    new BaroquenNote(altoF3),
+                    new BaroquenNote(altoD3),
+                    new BaroquenNote(altoE3),
+                    new BaroquenNote(altoG3),
+                    new BaroquenNote(altoG3)
                 }
             };
 
@@ -113,56 +130,49 @@ internal sealed class SixteenthEighthNoteOrnamentationCleanerTests
                 new BaroquenNote(altoC3WithoutDissonantNotes),
                 new BaroquenNote(sopranoWithAscendingDoubleRun),
                 new BaroquenNote(altoC3WithoutDissonantNotes)
-            ).SetName("When double run notes don't conflict with sixteenth notes, no notes are cleaned.");
-
-            yield return new TestCaseData(
-                new BaroquenNote(altoC3WithoutDissonantNotes),
-                new BaroquenNote(sopranoWithAscendingDoubleRun),
-                new BaroquenNote(altoC3WithoutDissonantNotes),
-                new BaroquenNote(sopranoWithAscendingDoubleRun)
-            ).SetName("When double run notes don't conflict with sixteenth notes, no notes are cleaned.");
-
-            yield return new TestCaseData(
-                new BaroquenNote(sopranoWithAscendingDoubleRun),
-                new BaroquenNote(altoC3WithDissonantFirstNote),
-                new BaroquenNote(sopranoWithAscendingDoubleRun),
-                new BaroquenNote(altoC3)
-            ).SetName("When double run notes conflict with sixteenth notes, then lower note is cleaned.");
-
-            yield return new TestCaseData(
-                new BaroquenNote(altoC3WithDissonantFirstNote),
-                new BaroquenNote(sopranoWithAscendingDoubleRun),
-                new BaroquenNote(altoC3),
-                new BaroquenNote(sopranoWithAscendingDoubleRun)
-            ).SetName("When double run notes conflict with sixteenth notes, then lower note is cleaned.");
+            ).SetName("When double run notes don't conflict, no notes are cleaned.");
 
             yield return new TestCaseData(
                 new BaroquenNote(sopranoWithAscendingDoubleRun),
                 new BaroquenNote(altoC3WithDissonantSecondNote),
                 new BaroquenNote(sopranoWithAscendingDoubleRun),
                 new BaroquenNote(altoC3)
-            ).SetName("When double run notes conflict with sixteenth notes, then lower note is cleaned.");
+            ).SetName("When double run notes conflict, lower note is cleaned.");
 
             yield return new TestCaseData(
                 new BaroquenNote(altoC3WithDissonantSecondNote),
                 new BaroquenNote(sopranoWithAscendingDoubleRun),
                 new BaroquenNote(altoC3),
                 new BaroquenNote(sopranoWithAscendingDoubleRun)
-            ).SetName("When double run notes conflict with sixteenth notes, then lower note is cleaned.");
+            ).SetName("When double run notes conflict, lower note is cleaned.");
 
             yield return new TestCaseData(
                 new BaroquenNote(sopranoWithAscendingDoubleRun),
-                new BaroquenNote(altoC3WithDissonantThirdNote),
+                new BaroquenNote(altoC3WithDissonantFourthNote),
                 new BaroquenNote(sopranoWithAscendingDoubleRun),
                 new BaroquenNote(altoC3)
-            ).SetName("When double run notes conflict with sixteenth notes, then lower note is cleaned.");
+            ).SetName("When double run notes conflict, lower note is cleaned.");
 
             yield return new TestCaseData(
-                new BaroquenNote(altoC3WithDissonantThirdNote),
+                new BaroquenNote(altoC3WithDissonantFourthNote),
                 new BaroquenNote(sopranoWithAscendingDoubleRun),
                 new BaroquenNote(altoC3),
                 new BaroquenNote(sopranoWithAscendingDoubleRun)
-            ).SetName("When double run notes conflict with sixteenth notes, then lower note is cleaned.");
+            ).SetName("When double run notes conflict, lower note is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoWithAscendingDoubleRun),
+                new BaroquenNote(altoC3WithDissonantSixthNote),
+                new BaroquenNote(sopranoWithAscendingDoubleRun),
+                new BaroquenNote(altoC3)
+            ).SetName("When double run notes conflict, lower note is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoC3WithDissonantSixthNote),
+                new BaroquenNote(sopranoWithAscendingDoubleRun),
+                new BaroquenNote(altoC3),
+                new BaroquenNote(sopranoWithAscendingDoubleRun)
+            ).SetName("When double run notes conflict, lower note is cleaned.");
         }
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DelayedRunEighthOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DelayedRunEighthOrnamentationCleanerTests.cs
@@ -1,0 +1,213 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using BaroquenMelody.Library.Tests.TestData;
+using FluentAssertions;
+using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+
+[TestFixture]
+internal sealed class DelayedRunEighthOrnamentationCleanerTests
+{
+    private DelayedRunEighthOrnamentationCleaner _delayedRunEighthOrnamentationCleaner = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2) with { DefaultNoteTimeSpan = MusicalTimeSpan.Half.Dotted(1) };
+
+        _delayedRunEighthOrnamentationCleaner = new DelayedRunEighthOrnamentationCleaner(compositionConfiguration);
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void When_Process_is_invoked_item_is_cleaned_if_necessary(BaroquenNote noteA, BaroquenNote noteB, BaroquenNote expectedNoteA, BaroquenNote expectedNoteB)
+    {
+        // arrange
+        var ornamentationCleaningItem = new OrnamentationCleaningItem(noteA, noteB);
+
+        // act
+        _delayedRunEighthOrnamentationCleaner.Process(ornamentationCleaningItem);
+
+        // assert
+        noteA.Should().BeEquivalentTo(expectedNoteA);
+        noteB.Should().BeEquivalentTo(expectedNoteB);
+    }
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            var sopranoG4 = new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoF4 = new BaroquenNote(Voice.Soprano, Notes.F4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
+
+            var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half.Dotted(1));
+            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
+            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
+            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half.Dotted(1));
+            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half.Dotted(1));
+
+            var sopranoC4WithAscendingDelayedRun = new BaroquenNote(sopranoC4)
+            {
+                OrnamentationType = OrnamentationType.DelayedRun,
+                Ornamentations =
+                {
+                    new BaroquenNote(sopranoD4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(sopranoE4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(sopranoF4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(sopranoG4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Quarter
+            };
+
+            var sopranoG4WithDescendingRun = new BaroquenNote(sopranoG4)
+            {
+                OrnamentationType = OrnamentationType.Run,
+                Ornamentations =
+                {
+                    new BaroquenNote(sopranoF4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(sopranoE4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(sopranoD4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Quarter.Dotted(1)
+            };
+
+            var altoF3WithDescendingRun = new BaroquenNote(altoF3)
+            {
+                OrnamentationType = OrnamentationType.Run,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoE3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoD3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoC3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Quarter.Dotted(1)
+            };
+
+            var altoG3WithDescendingRun = new BaroquenNote(altoG3)
+            {
+                OrnamentationType = OrnamentationType.Run,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoF3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoE3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoD3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Quarter.Dotted(1)
+            };
+
+            var altoC3WithAscendingDelayedRun = new BaroquenNote(altoC3)
+            {
+                OrnamentationType = OrnamentationType.DelayedRun,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoD3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoE3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoF3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoG3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                }
+            };
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithAscendingDelayedRun),
+                new BaroquenNote(altoF3WithDescendingRun),
+                new BaroquenNote(sopranoC4WithAscendingDelayedRun),
+                new BaroquenNote(altoF3WithDescendingRun)
+            ).SetName("When notes don't conflict, neither are cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithAscendingDelayedRun),
+                new BaroquenNote(altoF3WithDescendingRun),
+                new BaroquenNote(sopranoC4WithAscendingDelayedRun),
+                new BaroquenNote(altoF3WithDescendingRun)
+            ).SetName("When notes don't conflict, neither are cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithAscendingDelayedRun),
+                new BaroquenNote(altoG3WithDescendingRun),
+                new BaroquenNote(sopranoC4WithAscendingDelayedRun),
+                new BaroquenNote(altoG3)
+            ).SetName("When notes conflict, lower note is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoG3WithDescendingRun),
+                new BaroquenNote(sopranoC4WithAscendingDelayedRun),
+                new BaroquenNote(altoG3),
+                new BaroquenNote(sopranoC4WithAscendingDelayedRun)
+            ).SetName("When notes conflict, lower note is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoG4WithDescendingRun),
+                new BaroquenNote(altoC3WithAscendingDelayedRun),
+                new BaroquenNote(sopranoG4WithDescendingRun),
+                new BaroquenNote(altoC3)
+            ).SetName("When notes conflict, lower note is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoC3WithAscendingDelayedRun),
+                new BaroquenNote(sopranoG4WithDescendingRun),
+                new BaroquenNote(altoC3),
+                new BaroquenNote(sopranoG4WithDescendingRun)
+            ).SetName("When notes conflict, lower note is cleaned");
+        }
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DoublePassingToneDelayedRunOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DoublePassingToneDelayedRunOrnamentationCleanerTests.cs
@@ -1,0 +1,193 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using BaroquenMelody.Library.Tests.TestData;
+using FluentAssertions;
+using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+
+[TestFixture]
+internal sealed class DoublePassingToneDelayedRunOrnamentationCleanerTests
+{
+    private DoublePassingToneDelayedRunOrnamentationCleaner _doublePassingToneDelayedRunOrnamentationCleaner = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2) with { DefaultNoteTimeSpan = MusicalTimeSpan.Half.Dotted(1) };
+
+        _doublePassingToneDelayedRunOrnamentationCleaner = new DoublePassingToneDelayedRunOrnamentationCleaner(compositionConfiguration);
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void When_Process_is_invoked_item_is_cleaned_if_necessary(BaroquenNote noteA, BaroquenNote noteB, BaroquenNote expectedNoteA, BaroquenNote expectedNoteB)
+    {
+        // arrange
+        var ornamentationCleaningItem = new OrnamentationCleaningItem(noteA, noteB);
+
+        // act
+        _doublePassingToneDelayedRunOrnamentationCleaner.Process(ornamentationCleaningItem);
+
+        // assert
+        noteA.Should().BeEquivalentTo(expectedNoteA);
+        noteB.Should().BeEquivalentTo(expectedNoteB);
+    }
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
+
+            var altoB2 = new BaroquenNote(Voice.Alto, Notes.B2, MusicalTimeSpan.Half.Dotted(1));
+            var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half.Dotted(1));
+            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
+            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
+            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half.Dotted(1));
+            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half.Dotted(1));
+            var altoA3 = new BaroquenNote(Voice.Alto, Notes.A3, MusicalTimeSpan.Half.Dotted(1));
+
+            var sopranoC4WithAscendingDoublePassingTone = new BaroquenNote(sopranoC4)
+            {
+                OrnamentationType = OrnamentationType.DoublePassingTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(sopranoD4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    },
+                    new BaroquenNote(sopranoE4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Quarter
+            };
+
+            var altoA3WithDescendingDelayedRun = new BaroquenNote(altoA3)
+            {
+                OrnamentationType = OrnamentationType.DelayedRun,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoG3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoF3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoE3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoD3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Quarter
+            };
+
+            var altoG3WithDescendingDelayedRun = new BaroquenNote(altoG3)
+            {
+                OrnamentationType = OrnamentationType.DelayedRun,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoF3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoE3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoD3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoC3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Quarter
+            };
+
+            var altoF3WithDescendingDelayedRun = new BaroquenNote(altoF3)
+            {
+                OrnamentationType = OrnamentationType.DelayedRun,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoE3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoD3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoC3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoB2)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Quarter
+            };
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoA3WithDescendingDelayedRun),
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoA3WithDescendingDelayedRun)
+            ).SetName("When notes don't conflict, neither are cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoA3WithDescendingDelayedRun),
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoA3WithDescendingDelayedRun),
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone)
+            ).SetName("When notes don't conflict, neither are cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoF3WithDescendingDelayedRun),
+                new BaroquenNote(sopranoC4),
+                new BaroquenNote(altoF3WithDescendingDelayedRun)
+            ).SetName("When first note of double passing tone conflicts with first note of delayed run, double passing tone is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoF3WithDescendingDelayedRun),
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoF3WithDescendingDelayedRun),
+                new BaroquenNote(sopranoC4)
+            ).SetName("When first note of double passing tone conflicts with first note of delayed run, double passing tone is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoG3WithDescendingDelayedRun),
+                new BaroquenNote(sopranoC4),
+                new BaroquenNote(altoG3WithDescendingDelayedRun)
+            ).SetName("When second note of double passing tone conflicts with third note of delayed run, double passing tone is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoG3WithDescendingDelayedRun),
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoG3WithDescendingDelayedRun),
+                new BaroquenNote(sopranoC4)
+            ).SetName("When second note of double passing tone conflicts with third note of delayed run, double passing tone is cleaned");
+        }
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DoublePassingToneOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DoublePassingToneOrnamentationCleanerTests.cs
@@ -1,0 +1,128 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using BaroquenMelody.Library.Tests.TestData;
+using FluentAssertions;
+using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+
+[TestFixture]
+internal sealed class DoublePassingToneOrnamentationCleanerTests
+{
+    private DoublePassingToneOrnamentationCleaner _doublePassingToneOrnamentationCleaner;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2) with { DefaultNoteTimeSpan = MusicalTimeSpan.Half.Dotted(1) };
+
+        _doublePassingToneOrnamentationCleaner = new DoublePassingToneOrnamentationCleaner(compositionConfiguration);
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void When_Process_is_invoked_item_is_cleaned_if_necessary(BaroquenNote noteA, BaroquenNote noteB, BaroquenNote expectedNoteA, BaroquenNote expectedNoteB)
+    {
+        // arrange
+        var ornamentationCleaningItem = new OrnamentationCleaningItem(noteA, noteB);
+
+        // act
+        _doublePassingToneOrnamentationCleaner.Process(ornamentationCleaningItem);
+
+        // assert
+        noteA.Should().BeEquivalentTo(expectedNoteA);
+        noteB.Should().BeEquivalentTo(expectedNoteB);
+    }
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half.Dotted(1));
+
+            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
+            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
+            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half.Dotted(1));
+            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half.Dotted(1));
+
+            var sopranoC4WithAscendingDoublePassingTone = new BaroquenNote(sopranoC4)
+            {
+                OrnamentationType = OrnamentationType.DoublePassingTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(sopranoD4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    },
+                    new BaroquenNote(sopranoE4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Quarter
+            };
+
+            var altoG3WithDescendingDoublePassingTone = new BaroquenNote(altoG3)
+            {
+                OrnamentationType = OrnamentationType.DoublePassingTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoF3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    },
+                    new BaroquenNote(altoE3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Quarter
+            };
+
+            var altoF3WithDescendingDoublePassingTone = new BaroquenNote(altoF3)
+            {
+                OrnamentationType = OrnamentationType.DoublePassingTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoE3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    },
+                    new BaroquenNote(altoD3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Quarter
+            };
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoG3WithDescendingDoublePassingTone),
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoG3WithDescendingDoublePassingTone)
+            ).SetName("When notes don't conflict, no notes are cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoF3WithDescendingDoublePassingTone),
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoF3)
+            ).SetName("When notes conflict, lower note is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoF3WithDescendingDoublePassingTone),
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoF3),
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone)
+            ).SetName("When notes conflict, lower note is cleaned");
+        }
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DoublePassingToneQuarterOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DoublePassingToneQuarterOrnamentationCleanerTests.cs
@@ -1,0 +1,126 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using BaroquenMelody.Library.Tests.TestData;
+using FluentAssertions;
+using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+
+[TestFixture]
+internal sealed class DoublePassingToneQuarterOrnamentationCleanerTests
+{
+    private DoublePassingToneQuarterOrnamentationCleaner _doublePassingToneQuarterOrnamentationCleaner = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2) with { DefaultNoteTimeSpan = MusicalTimeSpan.Half.Dotted(1) };
+
+        _doublePassingToneQuarterOrnamentationCleaner = new DoublePassingToneQuarterOrnamentationCleaner(compositionConfiguration);
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void When_Process_is_invoked_item_is_cleaned_if_necessary(BaroquenNote noteA, BaroquenNote noteB, BaroquenNote expectedNoteA, BaroquenNote expectedNoteB)
+    {
+        // arrange
+        var ornamentationCleaningItem = new OrnamentationCleaningItem(noteA, noteB);
+
+        // act
+        _doublePassingToneQuarterOrnamentationCleaner.Process(ornamentationCleaningItem);
+
+        // assert
+        noteA.Should().BeEquivalentTo(expectedNoteA);
+        noteB.Should().BeEquivalentTo(expectedNoteB);
+    }
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half.Dotted(1));
+
+            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
+            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
+            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half.Dotted(1));
+
+            var sopranoC4WithAscendingDoublePassingTone = new BaroquenNote(sopranoC4)
+            {
+                OrnamentationType = OrnamentationType.DoublePassingTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(sopranoD4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    },
+                    new BaroquenNote(sopranoE4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Quarter
+            };
+
+            var altoD3WithAscendingPassingTone = new BaroquenNote(altoD3)
+            {
+                OrnamentationType = OrnamentationType.PassingTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoE3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half
+            };
+
+            var altoE3WithAscendingPassingTone = new BaroquenNote(altoE3)
+            {
+                OrnamentationType = OrnamentationType.PassingTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoF3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half
+            };
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoD3WithAscendingPassingTone),
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoD3WithAscendingPassingTone)
+            ).SetName("When notes don't conflict, neither are cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoD3WithAscendingPassingTone),
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoD3WithAscendingPassingTone),
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone)
+            ).SetName("When notes don't conflict, neither are cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoE3WithAscendingPassingTone),
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoE3)
+            ).SetName("When notes conflict, non-double passing tone is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoE3WithAscendingPassingTone),
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoE3),
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone)
+            ).SetName("When notes conflict, non-double passing tone is cleaned");
+        }
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/HalfEighthNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/HalfEighthNoteOrnamentationCleanerTests.cs
@@ -1,0 +1,235 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using BaroquenMelody.Library.Tests.TestData;
+using FluentAssertions;
+using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+
+[TestFixture]
+internal sealed class HalfEighthNoteOrnamentationCleanerTests
+{
+    private HalfEighthNoteOrnamentationCleaner _halfEighthNoteOrnamentationCleaner = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2) with { DefaultNoteTimeSpan = MusicalTimeSpan.Half.Dotted(1) };
+
+        _halfEighthNoteOrnamentationCleaner = new HalfEighthNoteOrnamentationCleaner(compositionConfiguration);
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void When_Process_is_invoked_item_is_cleaned_if_necessary(BaroquenNote noteA, BaroquenNote noteB, BaroquenNote expectedNoteA, BaroquenNote expectedNoteB)
+    {
+        // arrange
+        var ornamentationCleaningItem = new OrnamentationCleaningItem(noteA, noteB);
+
+        // act
+        _halfEighthNoteOrnamentationCleaner.Process(ornamentationCleaningItem);
+
+        // assert
+        noteA.Should().BeEquivalentTo(expectedNoteA);
+        noteB.Should().BeEquivalentTo(expectedNoteB);
+    }
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoB3 = new BaroquenNote(Voice.Soprano, Notes.B3, MusicalTimeSpan.Half.Dotted(1));
+
+            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
+            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
+
+            var sopranoC4WithDelayedRepeatedNote = new BaroquenNote(sopranoC4)
+            {
+                OrnamentationType = OrnamentationType.DelayedRepeatedNote,
+                Ornamentations =
+                {
+                    new BaroquenNote(sopranoC4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half + MusicalTimeSpan.Eighth
+            };
+
+            var altoE3WithDelayedRepeatedNote = new BaroquenNote(altoE3)
+            {
+                OrnamentationType = OrnamentationType.DelayedRepeatedNote,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoE3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half + MusicalTimeSpan.Eighth
+            };
+
+            var altoD3WithDelayedRepeatedNote = new BaroquenNote(altoD3)
+            {
+                OrnamentationType = OrnamentationType.DelayedRepeatedNote,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoD3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half + MusicalTimeSpan.Eighth
+            };
+
+            var sopranoB3WithAscendingDelayedPassingTone = new BaroquenNote(sopranoB3)
+            {
+                OrnamentationType = OrnamentationType.DelayedPassingTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(sopranoC4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half + MusicalTimeSpan.Eighth
+            };
+
+            var altoE3WithDescendingDelayedPassingTone = new BaroquenNote(altoE3)
+            {
+                OrnamentationType = OrnamentationType.DelayedPassingTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoD3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half + MusicalTimeSpan.Eighth
+            };
+
+            var sopranoB3WithDelayedUpperNeighborTone = new BaroquenNote(sopranoB3)
+            {
+                OrnamentationType = OrnamentationType.DelayedNeighborTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(sopranoC4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half + MusicalTimeSpan.Eighth
+            };
+
+            var altoE3WithDelayedLowerNeighborTone = new BaroquenNote(altoE3)
+            {
+                OrnamentationType = OrnamentationType.DelayedNeighborTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoD3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half + MusicalTimeSpan.Eighth
+            };
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithDelayedRepeatedNote),
+                new BaroquenNote(altoE3WithDelayedRepeatedNote),
+                new BaroquenNote(sopranoC4WithDelayedRepeatedNote),
+                new BaroquenNote(altoE3WithDelayedRepeatedNote)
+            ).SetName("When notes don't conflict, neither are cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithDelayedRepeatedNote),
+                new BaroquenNote(altoD3WithDelayedRepeatedNote),
+                new BaroquenNote(sopranoC4WithDelayedRepeatedNote),
+                new BaroquenNote(altoD3)
+            ).SetName("When repeated notes conflict, lower note is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoD3WithDelayedRepeatedNote),
+                new BaroquenNote(sopranoC4WithDelayedRepeatedNote),
+                new BaroquenNote(altoD3),
+                new BaroquenNote(sopranoC4WithDelayedRepeatedNote)
+            ).SetName("When repeated notes conflict, lower note is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoB3WithAscendingDelayedPassingTone),
+                new BaroquenNote(altoE3WithDescendingDelayedPassingTone),
+                new BaroquenNote(sopranoB3WithAscendingDelayedPassingTone),
+                new BaroquenNote(altoE3)
+            ).SetName("When passing tones conflict, lower note is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoE3WithDescendingDelayedPassingTone),
+                new BaroquenNote(sopranoB3WithAscendingDelayedPassingTone),
+                new BaroquenNote(altoE3),
+                new BaroquenNote(sopranoB3WithAscendingDelayedPassingTone)
+            ).SetName("When passing tones conflict, lower note is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoB3WithDelayedUpperNeighborTone),
+                new BaroquenNote(altoE3WithDelayedLowerNeighborTone),
+                new BaroquenNote(sopranoB3WithDelayedUpperNeighborTone),
+                new BaroquenNote(altoE3)
+            ).SetName("When neighbor tones conflict, lower note is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoE3WithDelayedLowerNeighborTone),
+                new BaroquenNote(sopranoB3WithDelayedUpperNeighborTone),
+                new BaroquenNote(altoE3),
+                new BaroquenNote(sopranoB3WithDelayedUpperNeighborTone)
+            ).SetName("When neighbor tones conflict, lower note is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoB3WithAscendingDelayedPassingTone),
+                new BaroquenNote(altoE3WithDelayedLowerNeighborTone),
+                new BaroquenNote(sopranoB3WithAscendingDelayedPassingTone),
+                new BaroquenNote(altoE3)
+            ).SetName("When passing tone conflicts with neighbor tone, neighbor tone is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoE3WithDelayedLowerNeighborTone),
+                new BaroquenNote(sopranoB3WithAscendingDelayedPassingTone),
+                new BaroquenNote(altoE3),
+                new BaroquenNote(sopranoB3WithAscendingDelayedPassingTone)
+            ).SetName("When passing tone conflicts with neighbor tone, neighbor tone is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoB3WithAscendingDelayedPassingTone),
+                new BaroquenNote(altoD3WithDelayedRepeatedNote),
+                new BaroquenNote(sopranoB3WithAscendingDelayedPassingTone),
+                new BaroquenNote(altoD3)
+            ).SetName("When passing tone conflicts with repeated note, repeated note is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoD3WithDelayedRepeatedNote),
+                new BaroquenNote(sopranoB3WithAscendingDelayedPassingTone),
+                new BaroquenNote(altoD3),
+                new BaroquenNote(sopranoB3WithAscendingDelayedPassingTone)
+            ).SetName("When passing tone conflicts with repeated note, repeated note is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoB3WithDelayedUpperNeighborTone),
+                new BaroquenNote(altoD3WithDelayedRepeatedNote),
+                new BaroquenNote(sopranoB3WithDelayedUpperNeighborTone),
+                new BaroquenNote(altoD3)
+            ).SetName("When neighbor tone conflicts with repeated note, repeated note is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoD3WithDelayedRepeatedNote),
+                new BaroquenNote(sopranoB3WithDelayedUpperNeighborTone),
+                new BaroquenNote(altoD3),
+                new BaroquenNote(sopranoB3WithDelayedUpperNeighborTone)
+            ).SetName("When neighbor tone conflicts with repeated note, repeated note is cleaned");
+        }
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/HalfQuarterEighthOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/HalfQuarterEighthOrnamentationCleanerTests.cs
@@ -1,0 +1,225 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using BaroquenMelody.Library.Tests.TestData;
+using FluentAssertions;
+using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+
+[TestFixture]
+internal sealed class HalfQuarterEighthOrnamentationCleanerTests
+{
+    private HalfQuarterEighthOrnamentationCleaner _halfQuarterEighthOrnamentationCleaner = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2) with { DefaultNoteTimeSpan = MusicalTimeSpan.Half.Dotted(1) };
+
+        _halfQuarterEighthOrnamentationCleaner = new HalfQuarterEighthOrnamentationCleaner(compositionConfiguration);
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void When_Process_is_invoked_item_is_cleaned_if_necessary(BaroquenNote noteA, BaroquenNote noteB, BaroquenNote expectedNoteA, BaroquenNote expectedNoteB)
+    {
+        // arrange
+        var ornamentationCleaningItem = new OrnamentationCleaningItem(noteA, noteB);
+
+        // act
+        _halfQuarterEighthOrnamentationCleaner.Process(ornamentationCleaningItem);
+
+        // assert
+        noteA.Should().BeEquivalentTo(expectedNoteA);
+        noteB.Should().BeEquivalentTo(expectedNoteB);
+    }
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half.Dotted(1));
+
+            var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half.Dotted(1));
+            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
+            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
+            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half.Dotted(1));
+            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half.Dotted(1));
+
+            var sopranoC4WithAscendingPassingTone = new BaroquenNote(sopranoC4)
+            {
+                OrnamentationType = OrnamentationType.PassingTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(sopranoD4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half
+            };
+
+            var sopranoC4WithUpperNeighborTone = new BaroquenNote(sopranoC4)
+            {
+                OrnamentationType = OrnamentationType.NeighborTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(sopranoD4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half
+            };
+
+            var sopranoD4WithRepeatedNote = new BaroquenNote(sopranoD4)
+            {
+                OrnamentationType = OrnamentationType.RepeatedNote,
+                Ornamentations =
+                {
+                    new BaroquenNote(sopranoD4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half
+            };
+
+            var sopranoC4WithAscendingDelayedDoublePassingTone = new BaroquenNote(sopranoC4)
+            {
+                OrnamentationType = OrnamentationType.DelayedDoublePassingTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(sopranoD4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(sopranoE4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half
+            };
+
+            var altoF3WithDescendingRun = new BaroquenNote(altoF3)
+            {
+                OrnamentationType = OrnamentationType.Run,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoE3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoD3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoC3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Quarter.Dotted(1)
+            };
+
+            var altoG3WithDescendingRun = new BaroquenNote(altoG3)
+            {
+                OrnamentationType = OrnamentationType.Run,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoF3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoE3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoD3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Quarter.Dotted(1)
+            };
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithAscendingPassingTone),
+                new BaroquenNote(altoF3WithDescendingRun),
+                new BaroquenNote(sopranoC4WithAscendingPassingTone),
+                new BaroquenNote(altoF3WithDescendingRun)
+            ).SetName("When notes don't conflict, neither are cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoF3WithDescendingRun),
+                new BaroquenNote(sopranoC4WithAscendingPassingTone),
+                new BaroquenNote(altoF3WithDescendingRun),
+                new BaroquenNote(sopranoC4WithAscendingPassingTone)
+            ).SetName("When notes don't conflict, neither are cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithAscendingPassingTone),
+                new BaroquenNote(altoG3WithDescendingRun),
+                new BaroquenNote(sopranoC4),
+                new BaroquenNote(altoG3WithDescendingRun)
+            ).SetName("When passing tone conflicts with descending run, passing tone is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoG3WithDescendingRun),
+                new BaroquenNote(sopranoC4WithAscendingPassingTone),
+                new BaroquenNote(altoG3WithDescendingRun),
+                new BaroquenNote(sopranoC4)
+            ).SetName("When passing tone conflicts with descending run, passing tone is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithUpperNeighborTone),
+                new BaroquenNote(altoG3WithDescendingRun),
+                new BaroquenNote(sopranoC4),
+                new BaroquenNote(altoG3WithDescendingRun)
+            ).SetName("When neighbor tone conflicts with descending run, neighbor tone is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoG3WithDescendingRun),
+                new BaroquenNote(sopranoC4WithUpperNeighborTone),
+                new BaroquenNote(altoG3WithDescendingRun),
+                new BaroquenNote(sopranoC4)
+            ).SetName("When neighbor tone conflicts with descending run, neighbor tone is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoD4WithRepeatedNote),
+                new BaroquenNote(altoG3WithDescendingRun),
+                new BaroquenNote(sopranoD4),
+                new BaroquenNote(altoG3WithDescendingRun)
+            ).SetName("When repeated note conflicts with descending run, repeated note is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoG3WithDescendingRun),
+                new BaroquenNote(sopranoD4WithRepeatedNote),
+                new BaroquenNote(altoG3WithDescendingRun),
+                new BaroquenNote(sopranoD4)
+            ).SetName("When repeated note conflicts with descending run, repeated note is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithAscendingDelayedDoublePassingTone),
+                new BaroquenNote(altoG3WithDescendingRun),
+                new BaroquenNote(sopranoC4),
+                new BaroquenNote(altoG3WithDescendingRun)
+            ).SetName("When delayed double passing tone conflicts with descending run, delayed double passing tone is cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoG3WithDescendingRun),
+                new BaroquenNote(sopranoC4WithAscendingDelayedDoublePassingTone),
+                new BaroquenNote(altoG3WithDescendingRun),
+                new BaroquenNote(sopranoC4)
+            ).SetName("When delayed double passing tone conflicts with descending run, delayed double passing tone is cleaned");
+        }
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/HalfQuarterOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/HalfQuarterOrnamentationCleanerTests.cs
@@ -1,0 +1,328 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using BaroquenMelody.Library.Tests.TestData;
+using FluentAssertions;
+using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+
+[TestFixture]
+internal sealed class HalfQuarterOrnamentationCleanerTests
+{
+    private HalfQuarterOrnamentationCleaner _halfQuarterOrnamentationCleaner = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2) with { DefaultNoteTimeSpan = MusicalTimeSpan.Half.Dotted(1) };
+
+        _halfQuarterOrnamentationCleaner = new HalfQuarterOrnamentationCleaner(compositionConfiguration);
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void When_Process_is_invoked_item_is_cleaned_if_necessary(BaroquenNote noteA, BaroquenNote noteB, BaroquenNote expectedNoteA, BaroquenNote expectedNoteB)
+    {
+        // arrange
+        var ornamentationCleaningItem = new OrnamentationCleaningItem(noteA, noteB);
+
+        // act
+        _halfQuarterOrnamentationCleaner.Process(ornamentationCleaningItem);
+
+        // assert
+        noteA.Should().BeEquivalentTo(expectedNoteA);
+        noteB.Should().BeEquivalentTo(expectedNoteB);
+    }
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoB3 = new BaroquenNote(Voice.Soprano, Notes.B3, MusicalTimeSpan.Half.Dotted(1));
+
+            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
+            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
+            var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half.Dotted(1));
+
+            var sopranoC4WithRepeatedNote = new BaroquenNote(sopranoC4)
+            {
+                OrnamentationType = OrnamentationType.RepeatedNote,
+                Ornamentations =
+                {
+                    new BaroquenNote(sopranoC4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half
+            };
+
+            var sopranoB3WithAscendingPassingTone = new BaroquenNote(sopranoB3)
+            {
+                OrnamentationType = OrnamentationType.PassingTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(sopranoC4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half
+            };
+
+            var sopranoB3WithAscendingDelayedDoublePassingTone = new BaroquenNote(sopranoB3)
+            {
+                OrnamentationType = OrnamentationType.DelayedDoublePassingTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(sopranoC4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(sopranoD4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half
+            };
+
+            var sopranoB3WithUpperNeighborTone = new BaroquenNote(sopranoB3)
+            {
+                OrnamentationType = OrnamentationType.NeighborTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(sopranoC4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half
+            };
+
+            var altoD3WithRepeatedNote = new BaroquenNote(altoD3)
+            {
+                OrnamentationType = OrnamentationType.RepeatedNote,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoD3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half
+            };
+
+            var altoE3WithDescendingPassingTone = new BaroquenNote(altoE3)
+            {
+                OrnamentationType = OrnamentationType.PassingTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoD3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half
+            };
+
+            var altoE3WithDescendingDelayedDoublePassingTone = new BaroquenNote(altoE3)
+            {
+                OrnamentationType = OrnamentationType.DelayedDoublePassingTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoD3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoC3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half
+            };
+
+            var altoE3WithLowerNeighborTone = new BaroquenNote(altoE3)
+            {
+                OrnamentationType = OrnamentationType.NeighborTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoD3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half
+            };
+
+            var altoE3WithRepeatedNote = new BaroquenNote(altoE3)
+            {
+                OrnamentationType = OrnamentationType.RepeatedNote,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoE3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Half
+            };
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithRepeatedNote),
+                new BaroquenNote(altoD3WithRepeatedNote),
+                new BaroquenNote(sopranoC4WithRepeatedNote),
+                new BaroquenNote(altoD3)
+            ).SetName("When repeated notes conflict, lower note is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoD3WithRepeatedNote),
+                new BaroquenNote(sopranoC4WithRepeatedNote),
+                new BaroquenNote(altoD3),
+                new BaroquenNote(sopranoC4WithRepeatedNote)
+            ).SetName("When repeated notes conflict, lower note is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoB3WithAscendingPassingTone),
+                new BaroquenNote(altoE3WithDescendingPassingTone),
+                new BaroquenNote(sopranoB3WithAscendingPassingTone),
+                new BaroquenNote(altoE3)
+            ).SetName("When passing tones conflict, lower note is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoE3WithDescendingPassingTone),
+                new BaroquenNote(sopranoB3WithAscendingPassingTone),
+                new BaroquenNote(altoE3),
+                new BaroquenNote(sopranoB3WithAscendingPassingTone)
+            ).SetName("When passing tones conflict, lower note is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoB3WithAscendingDelayedDoublePassingTone),
+                new BaroquenNote(altoE3WithDescendingDelayedDoublePassingTone),
+                new BaroquenNote(sopranoB3WithAscendingDelayedDoublePassingTone),
+                new BaroquenNote(altoE3)
+            ).SetName("When delayed double passing tones conflict, lower note is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoE3WithDescendingDelayedDoublePassingTone),
+                new BaroquenNote(sopranoB3WithAscendingDelayedDoublePassingTone),
+                new BaroquenNote(altoE3),
+                new BaroquenNote(sopranoB3WithAscendingDelayedDoublePassingTone)
+            ).SetName("When delayed double passing tones conflict, lower note is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoB3WithUpperNeighborTone),
+                new BaroquenNote(altoE3WithLowerNeighborTone),
+                new BaroquenNote(sopranoB3WithUpperNeighborTone),
+                new BaroquenNote(altoE3)
+            ).SetName("When neighbor tones conflict, lower note is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoE3WithLowerNeighborTone),
+                new BaroquenNote(sopranoB3WithUpperNeighborTone),
+                new BaroquenNote(altoE3),
+                new BaroquenNote(sopranoB3WithUpperNeighborTone)
+            ).SetName("When neighbor tones conflict, lower note is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithRepeatedNote),
+                new BaroquenNote(altoE3WithDescendingPassingTone),
+                new BaroquenNote(sopranoC4),
+                new BaroquenNote(altoE3WithDescendingPassingTone)
+            ).SetName("When repeated note conflicts with passing tone, repeated note is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoE3WithDescendingPassingTone),
+                new BaroquenNote(sopranoC4WithRepeatedNote),
+                new BaroquenNote(altoE3WithDescendingPassingTone),
+                new BaroquenNote(sopranoC4)
+            ).SetName("When repeated note conflicts with passing tone, repeated note is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithRepeatedNote),
+                new BaroquenNote(altoE3WithDescendingDelayedDoublePassingTone),
+                new BaroquenNote(sopranoC4),
+                new BaroquenNote(altoE3WithDescendingDelayedDoublePassingTone)
+            ).SetName("When repeated note conflicts with delayed double passing tone, repeated note is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoE3WithDescendingDelayedDoublePassingTone),
+                new BaroquenNote(sopranoC4WithRepeatedNote),
+                new BaroquenNote(altoE3WithDescendingDelayedDoublePassingTone),
+                new BaroquenNote(sopranoC4)
+            ).SetName("When repeated note conflicts with delayed double passing tone, repeated note is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithRepeatedNote),
+                new BaroquenNote(altoE3WithLowerNeighborTone),
+                new BaroquenNote(sopranoC4),
+                new BaroquenNote(altoE3WithLowerNeighborTone)
+            ).SetName("When repeated note conflicts with neighbor tone, repeated note is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoE3WithLowerNeighborTone),
+                new BaroquenNote(sopranoC4WithRepeatedNote),
+                new BaroquenNote(altoE3WithLowerNeighborTone),
+                new BaroquenNote(sopranoC4)
+            ).SetName("When repeated note conflicts with neighbor tone, repeated note is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoB3WithUpperNeighborTone),
+                new BaroquenNote(altoE3WithDescendingPassingTone),
+                new BaroquenNote(sopranoB3),
+                new BaroquenNote(altoE3WithDescendingPassingTone)
+            ).SetName("When neighbor tone conflicts with passing tone, neighbor tone is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoE3WithDescendingPassingTone),
+                new BaroquenNote(sopranoB3WithUpperNeighborTone),
+                new BaroquenNote(altoE3WithDescendingPassingTone),
+                new BaroquenNote(sopranoB3)
+            ).SetName("When neighbor tone conflicts with passing tone, neighbor tone is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoB3WithUpperNeighborTone),
+                new BaroquenNote(altoE3WithDescendingDelayedDoublePassingTone),
+                new BaroquenNote(sopranoB3),
+                new BaroquenNote(altoE3WithDescendingDelayedDoublePassingTone)
+            ).SetName("When neighbor tone conflicts with delayed double passing tone, neighbor tone is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoE3WithDescendingDelayedDoublePassingTone),
+                new BaroquenNote(sopranoB3WithUpperNeighborTone),
+                new BaroquenNote(altoE3WithDescendingDelayedDoublePassingTone),
+                new BaroquenNote(sopranoB3)
+            ).SetName("When neighbor tone conflicts with delayed double passing tone, neighbor tone is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoB3WithAscendingPassingTone),
+                new BaroquenNote(altoE3WithDescendingDelayedDoublePassingTone),
+                new BaroquenNote(sopranoB3),
+                new BaroquenNote(altoE3WithDescendingDelayedDoublePassingTone)
+            ).SetName("When passing tone conflicts with delayed double passing tone, passing tone is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoE3WithDescendingDelayedDoublePassingTone),
+                new BaroquenNote(sopranoB3WithAscendingPassingTone),
+                new BaroquenNote(altoE3WithDescendingDelayedDoublePassingTone),
+                new BaroquenNote(sopranoB3)
+            ).SetName("When passing tone conflicts with delayed double passing tone, passing tone is cleaned.");
+
+            // when notes don't conflict, neither is cleaned
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithRepeatedNote),
+                new BaroquenNote(altoE3WithRepeatedNote),
+                new BaroquenNote(sopranoC4WithRepeatedNote),
+                new BaroquenNote(altoE3WithRepeatedNote)
+            ).SetName("When notes don't conflict, neither is cleaned.");
+        }
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/QuarterQuarterEighthOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/QuarterQuarterEighthOrnamentationCleanerTests.cs
@@ -1,0 +1,144 @@
+﻿using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using BaroquenMelody.Library.Tests.TestData;
+using FluentAssertions;
+using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.MusicTheory;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+
+[TestFixture]
+internal sealed class QuarterQuarterEighthOrnamentationCleanerTests
+{
+    private QuarterQuarterEighthOrnamentationCleaner _quarterQuarterEighthOrnamentationCleaner = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var compositionConfiguration = Configurations.GetCompositionConfiguration(2) with { DefaultNoteTimeSpan = MusicalTimeSpan.Half.Dotted(1) };
+
+        _quarterQuarterEighthOrnamentationCleaner = new QuarterQuarterEighthOrnamentationCleaner(compositionConfiguration);
+    }
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void When_Process_is_invoked_item_is_cleaned_if_necessary(BaroquenNote noteA, BaroquenNote noteB, BaroquenNote expectedNoteA, BaroquenNote expectedNoteB)
+    {
+        // arrange
+        var ornamentationCleaningItem = new OrnamentationCleaningItem(noteA, noteB);
+
+        // act
+        _quarterQuarterEighthOrnamentationCleaner.Process(ornamentationCleaningItem);
+
+        // assert
+        noteA.Should().BeEquivalentTo(expectedNoteA);
+        noteB.Should().BeEquivalentTo(expectedNoteB);
+    }
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half.Dotted(1));
+
+            var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half.Dotted(1));
+            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
+            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
+            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half.Dotted(1));
+            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half.Dotted(1));
+
+            var sopranoC4WithAscendingDoublePassingTone = new BaroquenNote(sopranoC4)
+            {
+                OrnamentationType = OrnamentationType.DoublePassingTone,
+                Ornamentations =
+                {
+                    new BaroquenNote(sopranoD4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    },
+                    new BaroquenNote(sopranoE4)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Quarter
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Quarter
+            };
+
+            var altoG3WithDescendingRun = new BaroquenNote(altoG3)
+            {
+                OrnamentationType = OrnamentationType.Run,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoF3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoE3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoD3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Quarter.Dotted(1)
+            };
+
+            var altoF3WithDescendingRun = new BaroquenNote(altoF3)
+            {
+                OrnamentationType = OrnamentationType.Run,
+                Ornamentations =
+                {
+                    new BaroquenNote(altoE3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoD3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    },
+                    new BaroquenNote(altoC3)
+                    {
+                        MusicalTimeSpan = MusicalTimeSpan.Eighth
+                    }
+                },
+                MusicalTimeSpan = MusicalTimeSpan.Quarter.Dotted(1)
+            };
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoG3WithDescendingRun),
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoG3WithDescendingRun)
+            ).SetName("When notes don't conflict, neither are cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoG3WithDescendingRun),
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoG3WithDescendingRun),
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone)
+            ).SetName("When notes don't conflict, neither are cleaned");
+
+            yield return new TestCaseData(
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoF3WithDescendingRun),
+                new BaroquenNote(sopranoC4),
+                new BaroquenNote(altoF3WithDescendingRun)
+            ).SetName("When double passing tone conflicts with run, double passing tone is cleaned.");
+
+            yield return new TestCaseData(
+                new BaroquenNote(altoF3WithDescendingRun),
+                new BaroquenNote(sopranoC4WithAscendingDoublePassingTone),
+                new BaroquenNote(altoF3WithDescendingRun),
+                new BaroquenNote(sopranoC4)
+            ).SetName("When double passing tone conflicts with run, double passing tone is cleaned.");
+        }
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/ThreeFourOrnamentationCleaningEngineBuilderTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/ThreeFourOrnamentationCleaningEngineBuilderTests.cs
@@ -1,0 +1,176 @@
+﻿using Atrea.PolicyEngine.Processors;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.MeterAgnostic;
+using BaroquenMelody.Library.Compositions.Ornamentation.Cleaning.Engine.Processors.ThreeFour;
+using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.MusicTheory;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Ornamentation.Cleaning.Engine;
+
+[TestFixture]
+internal sealed class ThreeFourOrnamentationCleaningEngineBuilderTests
+{
+    private IProcessor<OrnamentationCleaningItem> _mockQuarterHalfOrnamentationCleaner = null!;
+
+    private IProcessor<OrnamentationCleaningItem> _mockEighthNoteOrnamentationCleaner = null!;
+
+    private IProcessor<OrnamentationCleaningItem> _mockHalfEighthOrnamentationCleaner = null!;
+
+    private IProcessor<OrnamentationCleaningItem> _mockSixteenthNoteOrnamentationCleaner = null!;
+
+    private IProcessor<OrnamentationCleaningItem> _mockDelayedRunEighthOrnamentationCleaner = null!;
+
+    private IProcessor<OrnamentationCleaningItem> _mockDoublePassingToneQuarterOrnamentationCleaner = null!;
+
+    private IProcessor<OrnamentationCleaningItem> _mockDoublePassingToneOrnamentationCleaner = null!;
+
+    private IProcessor<OrnamentationCleaningItem> _mockHalfQuarterEighthOrnamentationCleaner = null!;
+
+    private IProcessor<OrnamentationCleaningItem> _mockQuarterQuarterEighthOrnamentationCleaner = null!;
+
+    private IProcessor<OrnamentationCleaningItem> _mockDoublePassingToneDelayedRunOrnamentationCleaner = null!;
+
+    private Dictionary<string, IProcessor<OrnamentationCleaningItem>> _processorsByName = null!;
+
+    private ThreeFourOrnamentationCleaningEngineBuilder _threeFourOrnamentationCleaningEngineBuilder = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockQuarterHalfOrnamentationCleaner = Substitute.For<IProcessor<OrnamentationCleaningItem>>();
+        _mockEighthNoteOrnamentationCleaner = Substitute.For<IProcessor<OrnamentationCleaningItem>>();
+        _mockHalfEighthOrnamentationCleaner = Substitute.For<IProcessor<OrnamentationCleaningItem>>();
+        _mockSixteenthNoteOrnamentationCleaner = Substitute.For<IProcessor<OrnamentationCleaningItem>>();
+        _mockDelayedRunEighthOrnamentationCleaner = Substitute.For<IProcessor<OrnamentationCleaningItem>>();
+        _mockDoublePassingToneQuarterOrnamentationCleaner = Substitute.For<IProcessor<OrnamentationCleaningItem>>();
+        _mockDoublePassingToneOrnamentationCleaner = Substitute.For<IProcessor<OrnamentationCleaningItem>>();
+        _mockHalfQuarterEighthOrnamentationCleaner = Substitute.For<IProcessor<OrnamentationCleaningItem>>();
+        _mockQuarterQuarterEighthOrnamentationCleaner = Substitute.For<IProcessor<OrnamentationCleaningItem>>();
+        _mockDoublePassingToneDelayedRunOrnamentationCleaner = Substitute.For<IProcessor<OrnamentationCleaningItem>>();
+
+        _processorsByName = new Dictionary<string, IProcessor<OrnamentationCleaningItem>>
+        {
+            { nameof(HalfQuarterOrnamentationCleaner), _mockQuarterHalfOrnamentationCleaner },
+            { nameof(EighthNoteOrnamentationCleaner), _mockEighthNoteOrnamentationCleaner },
+            { nameof(HalfEighthNoteOrnamentationCleaner), _mockHalfEighthOrnamentationCleaner },
+            { nameof(SixteenthNoteOrnamentationCleaner), _mockSixteenthNoteOrnamentationCleaner },
+            { nameof(DelayedRunEighthOrnamentationCleaner), _mockDelayedRunEighthOrnamentationCleaner },
+            { nameof(DoublePassingToneQuarterOrnamentationCleaner), _mockDoublePassingToneQuarterOrnamentationCleaner },
+            { nameof(DoublePassingToneOrnamentationCleaner), _mockDoublePassingToneOrnamentationCleaner },
+            { nameof(HalfQuarterEighthOrnamentationCleaner), _mockHalfQuarterEighthOrnamentationCleaner },
+            { nameof(QuarterQuarterEighthOrnamentationCleaner), _mockQuarterQuarterEighthOrnamentationCleaner },
+            { nameof(DoublePassingToneDelayedRunOrnamentationCleaner), _mockDoublePassingToneDelayedRunOrnamentationCleaner }
+        };
+
+        _threeFourOrnamentationCleaningEngineBuilder = new ThreeFourOrnamentationCleaningEngineBuilder(
+            _mockQuarterHalfOrnamentationCleaner,
+            _mockEighthNoteOrnamentationCleaner,
+            _mockHalfEighthOrnamentationCleaner,
+            _mockSixteenthNoteOrnamentationCleaner,
+            _mockDelayedRunEighthOrnamentationCleaner,
+            _mockDoublePassingToneQuarterOrnamentationCleaner,
+            _mockDoublePassingToneOrnamentationCleaner,
+            _mockHalfQuarterEighthOrnamentationCleaner,
+            _mockQuarterQuarterEighthOrnamentationCleaner,
+            _mockDoublePassingToneDelayedRunOrnamentationCleaner
+        );
+    }
+
+    [Test]
+    [TestCase(OrnamentationType.PassingTone, OrnamentationType.PassingTone, nameof(HalfQuarterOrnamentationCleaner))]
+    [TestCase(OrnamentationType.PassingTone, OrnamentationType.DelayedDoublePassingTone, nameof(HalfQuarterOrnamentationCleaner))]
+    [TestCase(OrnamentationType.PassingTone, OrnamentationType.NeighborTone, nameof(HalfQuarterOrnamentationCleaner))]
+    [TestCase(OrnamentationType.PassingTone, OrnamentationType.RepeatedNote, nameof(HalfQuarterOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DelayedDoublePassingTone, OrnamentationType.DelayedDoublePassingTone, nameof(HalfQuarterOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DelayedDoublePassingTone, OrnamentationType.NeighborTone, nameof(HalfQuarterOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DelayedDoublePassingTone, OrnamentationType.RepeatedNote, nameof(HalfQuarterOrnamentationCleaner))]
+    [TestCase(OrnamentationType.NeighborTone, OrnamentationType.NeighborTone, nameof(HalfQuarterOrnamentationCleaner))]
+    [TestCase(OrnamentationType.NeighborTone, OrnamentationType.RepeatedNote, nameof(HalfQuarterOrnamentationCleaner))]
+    [TestCase(OrnamentationType.RepeatedNote, OrnamentationType.RepeatedNote, nameof(HalfQuarterOrnamentationCleaner))]
+    [TestCase(OrnamentationType.Run, OrnamentationType.Run, nameof(EighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.Run, OrnamentationType.Turn, nameof(EighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.Run, OrnamentationType.AlternateTurn, nameof(EighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.Run, OrnamentationType.DecorateInterval, nameof(EighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.Run, OrnamentationType.Pedal, nameof(EighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.Turn, OrnamentationType.Turn, nameof(EighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.Turn, OrnamentationType.AlternateTurn, nameof(EighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.Turn, OrnamentationType.DecorateInterval, nameof(EighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.Turn, OrnamentationType.Pedal, nameof(EighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.AlternateTurn, OrnamentationType.AlternateTurn, nameof(EighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.AlternateTurn, OrnamentationType.DecorateInterval, nameof(EighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.AlternateTurn, OrnamentationType.Pedal, nameof(EighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DecorateInterval, OrnamentationType.DecorateInterval, nameof(EighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DecorateInterval, OrnamentationType.Pedal, nameof(EighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.Pedal, OrnamentationType.Pedal, nameof(EighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DelayedPassingTone, OrnamentationType.DelayedPassingTone, nameof(HalfEighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DelayedPassingTone, OrnamentationType.DelayedNeighborTone, nameof(HalfEighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DelayedPassingTone, OrnamentationType.DelayedRepeatedNote, nameof(HalfEighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DelayedNeighborTone, OrnamentationType.DelayedNeighborTone, nameof(HalfEighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DelayedNeighborTone, OrnamentationType.DelayedRepeatedNote, nameof(HalfEighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DelayedRepeatedNote, OrnamentationType.DelayedRepeatedNote, nameof(HalfEighthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DoubleRun, OrnamentationType.DoubleRun, nameof(SixteenthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DoubleRun, OrnamentationType.DoubleTurn, nameof(SixteenthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DoubleTurn, OrnamentationType.DoubleTurn, nameof(SixteenthNoteOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DelayedRun, OrnamentationType.Run, nameof(DelayedRunEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DelayedRun, OrnamentationType.Turn, nameof(DelayedRunEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DelayedRun, OrnamentationType.AlternateTurn, nameof(DelayedRunEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DelayedRun, OrnamentationType.DecorateInterval, nameof(DelayedRunEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DelayedRun, OrnamentationType.Pedal, nameof(DelayedRunEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DoublePassingTone, OrnamentationType.PassingTone, nameof(DoublePassingToneQuarterOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DoublePassingTone, OrnamentationType.RepeatedNote, nameof(DoublePassingToneQuarterOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DoublePassingTone, OrnamentationType.NeighborTone, nameof(DoublePassingToneQuarterOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DoublePassingTone, OrnamentationType.DoublePassingTone, nameof(DoublePassingToneOrnamentationCleaner))]
+    [TestCase(OrnamentationType.PassingTone, OrnamentationType.Run, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.PassingTone, OrnamentationType.Turn, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.PassingTone, OrnamentationType.AlternateTurn, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.PassingTone, OrnamentationType.DecorateInterval, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.PassingTone, OrnamentationType.Pedal, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DelayedDoublePassingTone, OrnamentationType.Run, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DelayedDoublePassingTone, OrnamentationType.Turn, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DelayedDoublePassingTone, OrnamentationType.AlternateTurn, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DelayedDoublePassingTone, OrnamentationType.DecorateInterval, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DelayedDoublePassingTone, OrnamentationType.Pedal, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.RepeatedNote, OrnamentationType.Run, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.RepeatedNote, OrnamentationType.Turn, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.RepeatedNote, OrnamentationType.AlternateTurn, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.RepeatedNote, OrnamentationType.DecorateInterval, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.RepeatedNote, OrnamentationType.Pedal, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.NeighborTone, OrnamentationType.Run, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.NeighborTone, OrnamentationType.Turn, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.NeighborTone, OrnamentationType.AlternateTurn, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.NeighborTone, OrnamentationType.DecorateInterval, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.NeighborTone, OrnamentationType.Pedal, nameof(HalfQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DoublePassingTone, OrnamentationType.Run, nameof(QuarterQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DoublePassingTone, OrnamentationType.Turn, nameof(QuarterQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DoublePassingTone, OrnamentationType.AlternateTurn, nameof(QuarterQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DoublePassingTone, OrnamentationType.DecorateInterval, nameof(QuarterQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DoublePassingTone, OrnamentationType.Pedal, nameof(QuarterQuarterEighthOrnamentationCleaner))]
+    [TestCase(OrnamentationType.DoublePassingTone, OrnamentationType.DelayedRun, nameof(DoublePassingToneDelayedRunOrnamentationCleaner))]
+    public void Process_invokes_expected_ornamentation_cleaner(OrnamentationType ornamentationTypeA, OrnamentationType ornamentationTypeB, string expectedProcessorName)
+    {
+        // arrange
+        var ornamentationCleaningItem = new OrnamentationCleaningItem(
+            new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half) { OrnamentationType = ornamentationTypeA },
+            new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half) { OrnamentationType = ornamentationTypeB }
+        );
+
+        var ornamentationCleaningEngine = _threeFourOrnamentationCleaningEngineBuilder.Build();
+
+        // act
+        ornamentationCleaningEngine.Process(ornamentationCleaningItem);
+
+        // assert
+        _processorsByName[expectedProcessorName].Received(1).Process(ornamentationCleaningItem);
+
+        _processorsByName.Keys
+            .Where(key => key != expectedProcessorName)
+            .ToList()
+            .ForEach(key => _processorsByName[key].DidNotReceive().Process(ornamentationCleaningItem));
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculatorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Utilities/MusicalTimeSpanCalculatorTests.cs
@@ -86,45 +86,87 @@ internal sealed class MusicalTimeSpanCalculatorTests
         {
             yield return new TestCaseData(OrnamentationType.None, Meter.FourFour, MusicalTimeSpan.Half);
 
+            yield return new TestCaseData(OrnamentationType.None, Meter.ThreeFour, MusicalTimeSpan.Half.Dotted(1));
+
             yield return new TestCaseData(OrnamentationType.PassingTone, Meter.FourFour, MusicalTimeSpan.Quarter);
+
+            yield return new TestCaseData(OrnamentationType.PassingTone, Meter.ThreeFour, MusicalTimeSpan.Half);
 
             yield return new TestCaseData(OrnamentationType.Run, Meter.FourFour, MusicalTimeSpan.Eighth);
 
+            yield return new TestCaseData(OrnamentationType.Run, Meter.ThreeFour, MusicalTimeSpan.Quarter.Dotted(1));
+
             yield return new TestCaseData(OrnamentationType.DelayedPassingTone, Meter.FourFour, MusicalTimeSpan.Quarter.Dotted(1));
+
+            yield return new TestCaseData(OrnamentationType.DelayedPassingTone, Meter.ThreeFour, MusicalTimeSpan.Half + MusicalTimeSpan.Eighth);
 
             yield return new TestCaseData(OrnamentationType.Turn, Meter.FourFour, MusicalTimeSpan.Eighth);
 
+            yield return new TestCaseData(OrnamentationType.Turn, Meter.ThreeFour, MusicalTimeSpan.Quarter.Dotted(1));
+
             yield return new TestCaseData(OrnamentationType.AlternateTurn, Meter.FourFour, MusicalTimeSpan.Eighth);
+
+            yield return new TestCaseData(OrnamentationType.AlternateTurn, Meter.ThreeFour, MusicalTimeSpan.Quarter.Dotted(1));
 
             yield return new TestCaseData(OrnamentationType.Sustain, Meter.FourFour, MusicalTimeSpan.Whole);
 
+            yield return new TestCaseData(OrnamentationType.Sustain, Meter.ThreeFour, MusicalTimeSpan.Half.Dotted(1) + MusicalTimeSpan.Half.Dotted(1));
+
             yield return new TestCaseData(OrnamentationType.MidSustain, Meter.FourFour, new MusicalTimeSpan());
+
+            yield return new TestCaseData(OrnamentationType.MidSustain, Meter.ThreeFour, new MusicalTimeSpan());
 
             yield return new TestCaseData(OrnamentationType.DoubleTurn, Meter.FourFour, MusicalTimeSpan.Sixteenth);
 
+            yield return new TestCaseData(OrnamentationType.DoubleTurn, Meter.ThreeFour, MusicalTimeSpan.Quarter + MusicalTimeSpan.Sixteenth);
+
             yield return new TestCaseData(OrnamentationType.DelayedRun, Meter.FourFour, MusicalTimeSpan.Quarter);
+
+            yield return new TestCaseData(OrnamentationType.DelayedRun, Meter.ThreeFour, MusicalTimeSpan.Quarter);
 
             yield return new TestCaseData(OrnamentationType.DoublePassingTone, Meter.FourFour, MusicalTimeSpan.Quarter);
 
+            yield return new TestCaseData(OrnamentationType.DoublePassingTone, Meter.ThreeFour, MusicalTimeSpan.Quarter);
+
             yield return new TestCaseData(OrnamentationType.DelayedDoublePassingTone, Meter.FourFour, MusicalTimeSpan.Quarter.Dotted(1));
+
+            yield return new TestCaseData(OrnamentationType.DelayedDoublePassingTone, Meter.ThreeFour, MusicalTimeSpan.Half);
 
             yield return new TestCaseData(OrnamentationType.DecorateInterval, Meter.FourFour, MusicalTimeSpan.Eighth);
 
+            yield return new TestCaseData(OrnamentationType.DecorateInterval, Meter.ThreeFour, MusicalTimeSpan.Quarter.Dotted(1));
+
             yield return new TestCaseData(OrnamentationType.DoubleRun, Meter.FourFour, MusicalTimeSpan.Sixteenth);
+
+            yield return new TestCaseData(OrnamentationType.DoubleRun, Meter.ThreeFour, MusicalTimeSpan.Quarter + MusicalTimeSpan.Sixteenth);
 
             yield return new TestCaseData(OrnamentationType.Pedal, Meter.FourFour, MusicalTimeSpan.Eighth);
 
+            yield return new TestCaseData(OrnamentationType.Pedal, Meter.ThreeFour, MusicalTimeSpan.Quarter.Dotted(1));
+
             yield return new TestCaseData(OrnamentationType.Mordent, Meter.FourFour, MusicalTimeSpan.Sixteenth);
+
+            yield return new TestCaseData(OrnamentationType.Mordent, Meter.ThreeFour, MusicalTimeSpan.Sixteenth);
 
             yield return new TestCaseData(OrnamentationType.Rest, Meter.FourFour, new MusicalTimeSpan());
 
+            yield return new TestCaseData(OrnamentationType.Rest, Meter.ThreeFour, new MusicalTimeSpan());
+
             yield return new TestCaseData(OrnamentationType.RepeatedNote, Meter.FourFour, MusicalTimeSpan.Quarter);
+
+            yield return new TestCaseData(OrnamentationType.RepeatedNote, Meter.ThreeFour, MusicalTimeSpan.Half);
 
             yield return new TestCaseData(OrnamentationType.DelayedRepeatedNote, Meter.FourFour, MusicalTimeSpan.Quarter.Dotted(1));
 
+            yield return new TestCaseData(OrnamentationType.DelayedRepeatedNote, Meter.ThreeFour, MusicalTimeSpan.Half + MusicalTimeSpan.Eighth);
+
             yield return new TestCaseData(OrnamentationType.NeighborTone, Meter.FourFour, MusicalTimeSpan.Quarter);
 
+            yield return new TestCaseData(OrnamentationType.NeighborTone, Meter.ThreeFour, MusicalTimeSpan.Half);
+
             yield return new TestCaseData(OrnamentationType.DelayedNeighborTone, Meter.FourFour, MusicalTimeSpan.Quarter.Dotted(1));
+
+            yield return new TestCaseData(OrnamentationType.DelayedNeighborTone, Meter.ThreeFour, MusicalTimeSpan.Half + MusicalTimeSpan.Eighth);
         }
     }
 
@@ -134,43 +176,83 @@ internal sealed class MusicalTimeSpanCalculatorTests
         {
             yield return new TestCaseData(OrnamentationType.PassingTone, Meter.FourFour, MusicalTimeSpan.Quarter, 1);
 
+            yield return new TestCaseData(OrnamentationType.PassingTone, Meter.ThreeFour, MusicalTimeSpan.Quarter, 1);
+
             yield return new TestCaseData(OrnamentationType.Run, Meter.FourFour, MusicalTimeSpan.Eighth, 1);
+
+            yield return new TestCaseData(OrnamentationType.Run, Meter.ThreeFour, MusicalTimeSpan.Eighth, 1);
 
             yield return new TestCaseData(OrnamentationType.DelayedPassingTone, Meter.FourFour, MusicalTimeSpan.Eighth, 1);
 
+            yield return new TestCaseData(OrnamentationType.DelayedPassingTone, Meter.ThreeFour, MusicalTimeSpan.Eighth, 1);
+
             yield return new TestCaseData(OrnamentationType.Turn, Meter.FourFour, MusicalTimeSpan.Eighth, 1);
+
+            yield return new TestCaseData(OrnamentationType.Turn, Meter.ThreeFour, MusicalTimeSpan.Eighth, 1);
 
             yield return new TestCaseData(OrnamentationType.AlternateTurn, Meter.FourFour, MusicalTimeSpan.Eighth, 1);
 
+            yield return new TestCaseData(OrnamentationType.AlternateTurn, Meter.ThreeFour, MusicalTimeSpan.Eighth, 1);
+
             yield return new TestCaseData(OrnamentationType.MidSustain, Meter.FourFour, new MusicalTimeSpan(), 1);
+
+            yield return new TestCaseData(OrnamentationType.MidSustain, Meter.ThreeFour, new MusicalTimeSpan(), 1);
 
             yield return new TestCaseData(OrnamentationType.DoubleTurn, Meter.FourFour, MusicalTimeSpan.Sixteenth, 1);
 
+            yield return new TestCaseData(OrnamentationType.DoubleTurn, Meter.ThreeFour, MusicalTimeSpan.Sixteenth, 1);
+
             yield return new TestCaseData(OrnamentationType.DelayedRun, Meter.FourFour, MusicalTimeSpan.Sixteenth, 1);
+
+            yield return new TestCaseData(OrnamentationType.DelayedRun, Meter.ThreeFour, MusicalTimeSpan.Eighth, 1);
 
             yield return new TestCaseData(OrnamentationType.DoublePassingTone, Meter.FourFour, MusicalTimeSpan.Eighth, 1);
 
+            yield return new TestCaseData(OrnamentationType.DoublePassingTone, Meter.ThreeFour, MusicalTimeSpan.Quarter, 1);
+
             yield return new TestCaseData(OrnamentationType.DelayedDoublePassingTone, Meter.FourFour, MusicalTimeSpan.Sixteenth, 1);
+
+            yield return new TestCaseData(OrnamentationType.DelayedDoublePassingTone, Meter.ThreeFour, MusicalTimeSpan.Eighth, 1);
 
             yield return new TestCaseData(OrnamentationType.DecorateInterval, Meter.FourFour, MusicalTimeSpan.Eighth, 1);
 
+            yield return new TestCaseData(OrnamentationType.DecorateInterval, Meter.ThreeFour, MusicalTimeSpan.Eighth, 1);
+
             yield return new TestCaseData(OrnamentationType.DoubleRun, Meter.FourFour, MusicalTimeSpan.Sixteenth, 1);
+
+            yield return new TestCaseData(OrnamentationType.DoubleRun, Meter.ThreeFour, MusicalTimeSpan.Sixteenth, 1);
 
             yield return new TestCaseData(OrnamentationType.Pedal, Meter.FourFour, MusicalTimeSpan.Eighth, 1);
 
+            yield return new TestCaseData(OrnamentationType.Pedal, Meter.ThreeFour, MusicalTimeSpan.Eighth, 1);
+
             yield return new TestCaseData(OrnamentationType.Mordent, Meter.FourFour, MusicalTimeSpan.Sixteenth, 1);
+
+            yield return new TestCaseData(OrnamentationType.Mordent, Meter.ThreeFour, MusicalTimeSpan.Sixteenth, 1);
 
             yield return new TestCaseData(OrnamentationType.Mordent, Meter.FourFour, MusicalTimeSpan.Quarter.Dotted(1), 2);
 
+            yield return new TestCaseData(OrnamentationType.Mordent, Meter.ThreeFour, MusicalTimeSpan.Eighth + MusicalTimeSpan.Half, 2);
+
             yield return new TestCaseData(OrnamentationType.Rest, Meter.FourFour, new MusicalTimeSpan(), 1);
+
+            yield return new TestCaseData(OrnamentationType.Rest, Meter.ThreeFour, new MusicalTimeSpan(), 1);
 
             yield return new TestCaseData(OrnamentationType.RepeatedNote, Meter.FourFour, MusicalTimeSpan.Quarter, 1);
 
+            yield return new TestCaseData(OrnamentationType.RepeatedNote, Meter.ThreeFour, MusicalTimeSpan.Quarter, 1);
+
             yield return new TestCaseData(OrnamentationType.DelayedRepeatedNote, Meter.FourFour, MusicalTimeSpan.Eighth, 1);
+
+            yield return new TestCaseData(OrnamentationType.DelayedRepeatedNote, Meter.ThreeFour, MusicalTimeSpan.Eighth, 1);
 
             yield return new TestCaseData(OrnamentationType.NeighborTone, Meter.FourFour, MusicalTimeSpan.Quarter, 1);
 
+            yield return new TestCaseData(OrnamentationType.NeighborTone, Meter.ThreeFour, MusicalTimeSpan.Quarter, 1);
+
             yield return new TestCaseData(OrnamentationType.DelayedNeighborTone, Meter.FourFour, MusicalTimeSpan.Eighth, 1);
+
+            yield return new TestCaseData(OrnamentationType.DelayedNeighborTone, Meter.ThreeFour, MusicalTimeSpan.Eighth, 1);
         }
     }
 }


### PR DESCRIPTION
## Description

Support 3/4 time:

- New entries for `MusicalTimespanCalculator` for primary note and ornamentation duration
- New ornamentation cleaners to handle the different ornamentation combinations present in 3/4 time
- Specify ornamentation cleaner builder for 3/4 and 4/4 time respectively

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
