### PR TITLE
Baroquen Melody Configurator

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -64,6 +64,9 @@ dotnet_diagnostic.SA1642.severity = none
 # force static members to appear before non-static
 dotnet_diagnostic.SA1204.severity = none
 
+# force abstraction over implementation
+dotnet_diagnostic.MA0016.severity = none
+
 [*.csproj]
 indent_style = space
 indent_size = 2

--- a/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
+++ b/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
@@ -37,7 +37,6 @@
     <InternalsVisibleTo Include="$(AssemblyName).Tests" />
     <InternalsVisibleTo Include="BaroquenMelody.Benchmarks" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
-    <InternalsVisibleTo Include="baroquen-melody" />
   </ItemGroup>
 
 </Project>

--- a/src/BaroquenMelody.Library/BaroquenMelody.cs
+++ b/src/BaroquenMelody.Library/BaroquenMelody.cs
@@ -1,0 +1,9 @@
+﻿using Melanchall.DryWetMidi.Core;
+
+namespace BaroquenMelody.Library;
+
+/// <summary>
+///     A Baroquen melody.
+/// </summary>
+/// <param name="MidiFile">The MIDI file representing the Baroquen melody.</param>
+public record BaroquenMelody(MidiFile MidiFile);

--- a/src/BaroquenMelody.Library/BaroquenMelodyComposerConfigurator.cs
+++ b/src/BaroquenMelody.Library/BaroquenMelodyComposerConfigurator.cs
@@ -1,0 +1,50 @@
+﻿using BaroquenMelody.Library.Compositions.Choices;
+using BaroquenMelody.Library.Compositions.Composers;
+using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Midi;
+using BaroquenMelody.Library.Compositions.MusicTheory;
+using BaroquenMelody.Library.Compositions.Ornamentation;
+using BaroquenMelody.Library.Compositions.Ornamentation.Engine;
+using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
+using BaroquenMelody.Library.Compositions.Phrasing;
+using BaroquenMelody.Library.Compositions.Rules;
+using BaroquenMelody.Library.Compositions.Strategies;
+using BaroquenMelody.Library.Infrastructure.Random;
+using Microsoft.Extensions.Logging;
+
+namespace BaroquenMelody.Library;
+
+/// <summary>
+///     Centralized logic for configuring a <see cref="BaroquenMelodyComposer"/> which can generate a <see cref="BaroquenMelody"/>.
+/// </summary>
+/// <param name="logger">A logger to be used throughout the composition process.</param>
+public sealed class BaroquenMelodyComposerConfigurator(ILogger logger) : IBaroquenMelodyComposerConfigurator
+{
+    private readonly IMusicalTimeSpanCalculator _musicalTimeSpanCalculator = new MusicalTimeSpanCalculator();
+
+    private readonly IChordChoiceRepositoryFactory _chordChoiceRepositoryFactory = new ChordChoiceRepositoryFactory(new NoteChoiceGenerator());
+
+    private readonly IWeightedRandomBooleanGenerator _weightedRandomBooleanGenerator = new WeightedRandomBooleanGenerator();
+
+    private readonly IThemeSplitter _themeSplitter = new ThemeSplitter();
+
+    public IBaroquenMelodyComposer Configure(CompositionConfiguration compositionConfiguration)
+    {
+        var compositionRuleFactory = new CompositionRuleFactory(compositionConfiguration, _weightedRandomBooleanGenerator);
+        var compositionRule = compositionRuleFactory.CreateAggregate(compositionConfiguration.AggregateCompositionRuleConfiguration);
+        var compositionStrategyFactory = new CompositionStrategyFactory(_chordChoiceRepositoryFactory, compositionRule, logger);
+        var compositionStrategy = compositionStrategyFactory.Create(compositionConfiguration);
+        var ornamentationEngineBuilder = new OrnamentationEngineBuilder(compositionConfiguration, _musicalTimeSpanCalculator, logger);
+        var compositionDecorator = new CompositionDecorator(ornamentationEngineBuilder.BuildOrnamentationEngine(), ornamentationEngineBuilder.BuildSustainedNoteEngine(), compositionConfiguration);
+        var compositionPhraser = new CompositionPhraser(compositionRule, _themeSplitter, _weightedRandomBooleanGenerator, logger, compositionConfiguration);
+        var noteTransposer = new NoteTransposer(compositionConfiguration);
+        var chordComposer = new ChordComposer(compositionStrategy, compositionConfiguration, logger);
+        var chordNumberIdentifier = new ChordNumberIdentifier(compositionConfiguration);
+        var themeComposer = new ThemeComposer(compositionStrategy, compositionDecorator, chordComposer, noteTransposer, logger, compositionConfiguration);
+        var endingComposer = new EndingComposer(compositionStrategy, compositionDecorator, chordNumberIdentifier, logger, compositionConfiguration);
+        var composer = new Composer(compositionDecorator, compositionPhraser, chordComposer, themeComposer, endingComposer, logger, compositionConfiguration);
+        var midiGenerator = new MidiGenerator(compositionConfiguration);
+
+        return new BaroquenMelodyComposer(composer, midiGenerator);
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Composers/BaroquenMelodyComposer.cs
+++ b/src/BaroquenMelody.Library/Compositions/Composers/BaroquenMelodyComposer.cs
@@ -1,0 +1,14 @@
+﻿using BaroquenMelody.Library.Compositions.Midi;
+
+namespace BaroquenMelody.Library.Compositions.Composers;
+
+internal sealed class BaroquenMelodyComposer(IComposer composer, IMidiGenerator midiGenerator) : IBaroquenMelodyComposer
+{
+    public BaroquenMelody Compose()
+    {
+        var composition = composer.Compose();
+        var midiFile = midiGenerator.Generate(composition);
+
+        return new BaroquenMelody(midiFile);
+    }
+}

--- a/src/BaroquenMelody.Library/Compositions/Composers/IBaroquenMelodyComposer.cs
+++ b/src/BaroquenMelody.Library/Compositions/Composers/IBaroquenMelodyComposer.cs
@@ -1,0 +1,13 @@
+﻿namespace BaroquenMelody.Library.Compositions.Composers;
+
+/// <summary>
+///    A composer that generates Baroquen melodies.
+/// </summary>
+public interface IBaroquenMelodyComposer
+{
+    /// <summary>
+    ///     Compose a Baroquen melody.
+    /// </summary>
+    /// <returns>The composed Baroquen melody.</returns>
+    BaroquenMelody Compose();
+}

--- a/src/BaroquenMelody.Library/Compositions/Configurations/AggregateCompositionRuleConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/AggregateCompositionRuleConfiguration.cs
@@ -3,7 +3,7 @@ using BaroquenMelody.Library.Compositions.Rules.Enums;
 
 namespace BaroquenMelody.Library.Compositions.Configurations;
 
-internal sealed record AggregateCompositionRuleConfiguration(ISet<CompositionRuleConfiguration> Configurations)
+public sealed record AggregateCompositionRuleConfiguration(ISet<CompositionRuleConfiguration> Configurations)
 {
     public static AggregateCompositionRuleConfiguration Default { get; } = new(
         EnumUtils<CompositionRule>

--- a/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
@@ -18,7 +18,7 @@ namespace BaroquenMelody.Library.Compositions.Configurations;
 /// <param name="DefaultNoteTimeSpan"> The default note time span to be used in the composition. </param>
 /// <param name="CompositionContextSize"> The size of the context to be used in the composition. </param>
 /// <param name="Tempo"> The tempo of the composition, in beats per minute. </param>
-internal sealed record CompositionConfiguration(
+public sealed record CompositionConfiguration(
     ISet<VoiceConfiguration> VoiceConfigurations,
     PhrasingConfiguration PhrasingConfiguration,
     AggregateCompositionRuleConfiguration AggregateCompositionRuleConfiguration,

--- a/src/BaroquenMelody.Library/Compositions/Configurations/CompositionRuleConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/CompositionRuleConfiguration.cs
@@ -7,4 +7,4 @@ namespace BaroquenMelody.Library.Compositions.Configurations;
 /// </summary>
 /// <param name="Rule">The composition rule type.</param>
 /// <param name="Strictness">How strictly the rule should be enforced.</param>
-internal sealed record CompositionRuleConfiguration(CompositionRule Rule, int Strictness = int.MaxValue);
+public sealed record CompositionRuleConfiguration(CompositionRule Rule, int Strictness = int.MaxValue);

--- a/src/BaroquenMelody.Library/Compositions/Configurations/PhrasingConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/PhrasingConfiguration.cs
@@ -7,7 +7,7 @@
 /// <param name="MaxPhraseRepetitions"> The maximum number of times a phrase can be repeated in the composition. </param>
 /// <param name="MinPhraseRepetitionPoolSize"> The minimum number of phrases that must be available for repetition in the composition. </param>
 /// <param name="PhraseRepetitionProbability"> The probability that a phrase will be repeated in the composition. </param>
-internal sealed record PhrasingConfiguration(
+public sealed record PhrasingConfiguration(
     IList<int> PhraseLengths,
     int MaxPhraseRepetitions = 8,
     int MinPhraseRepetitionPoolSize = 2,

--- a/src/BaroquenMelody.Library/Compositions/Configurations/VoiceConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/VoiceConfiguration.cs
@@ -11,7 +11,7 @@ namespace BaroquenMelody.Library.Compositions.Configurations;
 /// <param name="MinNote"> The voice's minimum note value. </param>
 /// <param name="MaxNote"> The voice's maximum note value. </param>
 /// <param name="Instrument"> The voice's instrument. </param>
-internal sealed record VoiceConfiguration(
+public sealed record VoiceConfiguration(
     Voice Voice,
     Note MinNote,
     Note MaxNote,

--- a/src/BaroquenMelody.Library/Compositions/Domain/BaroquenNote.cs
+++ b/src/BaroquenMelody.Library/Compositions/Domain/BaroquenNote.cs
@@ -13,7 +13,7 @@ namespace BaroquenMelody.Library.Compositions.Domain;
 /// <param name="voice">The voice that the note is played in.</param>
 /// <param name="raw">The raw note that is played.</param>
 /// <param name="musicalTimeSpan">The musical time span of the note. May be modified if the note is ornamented.</param>
-internal sealed class BaroquenNote(Voice voice, Note raw, MusicalTimeSpan musicalTimeSpan) : IEquatable<BaroquenNote>
+public sealed class BaroquenNote(Voice voice, Note raw, MusicalTimeSpan musicalTimeSpan) : IEquatable<BaroquenNote>
 {
     /// <summary>
     ///     The voice that the note is played in.

--- a/src/BaroquenMelody.Library/Compositions/Domain/BaroquenScale.cs
+++ b/src/BaroquenMelody.Library/Compositions/Domain/BaroquenScale.cs
@@ -5,7 +5,7 @@ namespace BaroquenMelody.Library.Compositions.Domain;
 /// <summary>
 ///    Represents a scale in a musical composition.
 /// </summary>
-internal sealed class BaroquenScale
+public sealed class BaroquenScale
 {
     private readonly List<Note> _notes;
 

--- a/src/BaroquenMelody.Library/Compositions/Enums/Extensions/MeterExtensions.cs
+++ b/src/BaroquenMelody.Library/Compositions/Enums/Extensions/MeterExtensions.cs
@@ -1,9 +1,11 @@
-﻿namespace BaroquenMelody.Library.Compositions.Enums.Extensions;
+﻿using Melanchall.DryWetMidi.Interaction;
+
+namespace BaroquenMelody.Library.Compositions.Enums.Extensions;
 
 /// <summary>
 ///     A place for extensions for <see cref="Meter"/>.
 /// </summary>
-internal static class MeterExtensions
+public static class MeterExtensions
 {
     /// <summary>
     ///    Gets the number of beats per measure for the given <see cref="Meter"/>.
@@ -15,6 +17,19 @@ internal static class MeterExtensions
     {
         Meter.FourFour => 4,
         Meter.ThreeFour => 3,
-        _ => throw new ArgumentOutOfRangeException(nameof(meter), meter, null)
+        _ => throw new ArgumentOutOfRangeException(nameof(meter), meter, "Meter not supported.")
+    };
+
+    /// <summary>
+    ///    Gets the default <see cref="MusicalTimeSpan"/> for the given <see cref="Meter"/>.
+    /// </summary>
+    /// <param name="meter">The <see cref="Meter"/> to get the default <see cref="MusicalTimeSpan"/> for.</param>
+    /// <returns>The default <see cref="MusicalTimeSpan"/> for the given <see cref="Meter"/>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"> Thrown if the given <see cref="Meter"/> is not supported. </exception>
+    public static MusicalTimeSpan DefaultMusicalTimeSpan(this Meter meter) => meter switch
+    {
+        Meter.FourFour => MusicalTimeSpan.Half,
+        Meter.ThreeFour => MusicalTimeSpan.Half.Dotted(1),
+        _ => throw new ArgumentOutOfRangeException(nameof(meter), meter, "Meter not supported.")
     };
 }

--- a/src/BaroquenMelody.Library/Compositions/Enums/Meter.cs
+++ b/src/BaroquenMelody.Library/Compositions/Enums/Meter.cs
@@ -1,6 +1,6 @@
 ﻿namespace BaroquenMelody.Library.Compositions.Enums;
 
-internal enum Meter
+public enum Meter
 {
     /// <summary>
     ///     4/4 time.

--- a/src/BaroquenMelody.Library/Compositions/Enums/Voice.cs
+++ b/src/BaroquenMelody.Library/Compositions/Enums/Voice.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///    Indicates the voice being used to play a note.
 /// </summary>
-internal enum Voice : byte
+public enum Voice : byte
 {
     /// <summary>
     ///     The highest voice.

--- a/src/BaroquenMelody.Library/Compositions/Midi/Extensions/PatternBuilderExtensions.cs
+++ b/src/BaroquenMelody.Library/Compositions/Midi/Extensions/PatternBuilderExtensions.cs
@@ -2,7 +2,7 @@
 using Melanchall.DryWetMidi.Composing;
 using Melanchall.DryWetMidi.Interaction;
 
-namespace BaroquenMelody.Library.Midi.Extensions;
+namespace BaroquenMelody.Library.Compositions.Midi.Extensions;
 
 /// <summary>
 ///     A home for extension methods for <see cref="PatternBuilder"/>.

--- a/src/BaroquenMelody.Library/Compositions/Midi/IMidiGenerator.cs
+++ b/src/BaroquenMelody.Library/Compositions/Midi/IMidiGenerator.cs
@@ -1,7 +1,7 @@
 ﻿using BaroquenMelody.Library.Compositions.Domain;
 using Melanchall.DryWetMidi.Core;
 
-namespace BaroquenMelody.Library.Midi;
+namespace BaroquenMelody.Library.Compositions.Midi;
 
 /// <summary>
 ///     Generates a <see cref="MidiFile"/> from a <see cref="Composition"/>.

--- a/src/BaroquenMelody.Library/Compositions/Midi/MidiGenerator.cs
+++ b/src/BaroquenMelody.Library/Compositions/Midi/MidiGenerator.cs
@@ -1,14 +1,14 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Midi.Extensions;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
-using BaroquenMelody.Library.Midi.Extensions;
 using Melanchall.DryWetMidi.Common;
 using Melanchall.DryWetMidi.Composing;
 using Melanchall.DryWetMidi.Core;
 using Melanchall.DryWetMidi.Interaction;
 
-namespace BaroquenMelody.Library.Midi;
+namespace BaroquenMelody.Library.Compositions.Midi;
 
 /// <inheritdoc cref="IMidiGenerator"/>
 internal sealed class MidiGenerator(CompositionConfiguration compositionConfiguration) : IMidiGenerator

--- a/src/BaroquenMelody.Library/Compositions/Ornamentation/Enums/OrnamentationType.cs
+++ b/src/BaroquenMelody.Library/Compositions/Ornamentation/Enums/OrnamentationType.cs
@@ -1,6 +1,6 @@
 ﻿namespace BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 
-internal enum OrnamentationType : byte
+public enum OrnamentationType : byte
 {
     /// <summary>
     ///     No ornamentation.

--- a/src/BaroquenMelody.Library/Compositions/Rules/Enums/CompositionRule.cs
+++ b/src/BaroquenMelody.Library/Compositions/Rules/Enums/CompositionRule.cs
@@ -3,7 +3,7 @@
 /// <summary>
 ///     Represents the different configurable composition rules available for use.
 /// </summary>
-internal enum CompositionRule : byte
+public enum CompositionRule : byte
 {
     /// <summary>
     ///     Avoid dissonant intervals.

--- a/src/BaroquenMelody.Library/IBaroquenMelodyComposerConfigurator.cs
+++ b/src/BaroquenMelody.Library/IBaroquenMelodyComposerConfigurator.cs
@@ -1,0 +1,17 @@
+﻿using BaroquenMelody.Library.Compositions.Composers;
+using BaroquenMelody.Library.Compositions.Configurations;
+
+namespace BaroquenMelody.Library;
+
+/// <summary>
+///     Configures a new <see cref="IBaroquenMelodyComposer"/> which can compose a <see cref="BaroquenMelody"/> for the given <see cref="CompositionConfiguration"/>.
+/// </summary>
+public interface IBaroquenMelodyComposerConfigurator
+{
+    /// <summary>
+    ///     Configure a new <see cref="IBaroquenMelodyComposer"/> with the given <see cref="CompositionConfiguration"/>.
+    /// </summary>
+    /// <param name="compositionConfiguration">The <see cref="CompositionConfiguration"/> to configure the <see cref="IBaroquenMelodyComposer"/> with.</param>
+    /// <returns>The configured <see cref="IBaroquenMelodyComposer"/>.</returns>
+    IBaroquenMelodyComposer Configure(CompositionConfiguration compositionConfiguration);
+}

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -1,26 +1,12 @@
-﻿using BaroquenMelody.Library.Compositions.Choices;
-using BaroquenMelody.Library.Compositions.Composers;
+﻿using BaroquenMelody.Library;
 using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
-using BaroquenMelody.Library.Compositions.MusicTheory;
-using BaroquenMelody.Library.Compositions.Ornamentation;
-using BaroquenMelody.Library.Compositions.Ornamentation.Engine;
-using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
-using BaroquenMelody.Library.Compositions.Ornamentation.Utilities;
-using BaroquenMelody.Library.Compositions.Phrasing;
-using BaroquenMelody.Library.Compositions.Rules;
-using BaroquenMelody.Library.Compositions.Strategies;
-using BaroquenMelody.Library.Infrastructure.Random;
-using BaroquenMelody.Library.Midi;
+using BaroquenMelody.Library.Compositions.Enums.Extensions;
 using Melanchall.DryWetMidi.MusicTheory;
 using Melanchall.DryWetMidi.Standards;
 using Microsoft.Extensions.Logging;
 using System.Globalization;
-
-Console.WriteLine("Hit 'enter' to start composing...");
-Console.ReadLine();
-Console.WriteLine();
 
 var phrasingConfiguration = new PhrasingConfiguration(
     PhraseLengths: [1, 2, 3, 4, 5, 6, 7, 8],
@@ -28,8 +14,6 @@ var phrasingConfiguration = new PhrasingConfiguration(
     MinPhraseRepetitionPoolSize: 2,
     PhraseRepetitionProbability: 100
 );
-
-var musicalTimeSpanCalculator = new MusicalTimeSpanCalculator();
 
 const Meter meter = Meter.ThreeFour;
 
@@ -43,85 +27,19 @@ var compositionConfiguration = new CompositionConfiguration(
     },
     phrasingConfiguration,
     AggregateCompositionRuleConfiguration.Default,
-    BaroquenScale.Parse("E Phrygian"),
+    BaroquenScale.Parse("C Major"),
     meter,
-    musicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(OrnamentationType.None, meter),
+    meter.DefaultMusicalTimeSpan(),
     30
 );
 
 using var factory = LoggerFactory.Create(builder => builder.AddConsole());
-var logger = factory.CreateLogger<Composer>();
+var logger = factory.CreateLogger<BaroquenMelody.Library.BaroquenMelody>();
 
-var compositionRuleFactory = new CompositionRuleFactory(compositionConfiguration, new WeightedRandomBooleanGenerator());
-var compositionRule = compositionRuleFactory.CreateAggregate(compositionConfiguration.AggregateCompositionRuleConfiguration);
+var baroquenMelody = new BaroquenMelodyComposerConfigurator(logger)
+    .Configure(compositionConfiguration)
+    .Compose();
 
-var compositionStrategyFactory = new CompositionStrategyFactory(
-    new ChordChoiceRepositoryFactory(
-        new NoteChoiceGenerator()
-    ),
-    compositionRule,
-    logger
-);
-
-var compositionStrategy = compositionStrategyFactory.Create(compositionConfiguration);
-var ornamentationEngineBuilder = new OrnamentationEngineBuilder(compositionConfiguration, musicalTimeSpanCalculator, logger);
-
-var compositionDecorator = new CompositionDecorator(
-    ornamentationEngineBuilder.BuildOrnamentationEngine(),
-    ornamentationEngineBuilder.BuildSustainedNoteEngine(),
-    compositionConfiguration
-);
-
-var weightedRandomBooleanGenerator = new WeightedRandomBooleanGenerator();
-var themeSplitter = new ThemeSplitter();
-var compositionPhraser = new CompositionPhraser(compositionRule, themeSplitter, weightedRandomBooleanGenerator, logger, compositionConfiguration);
-var noteTransposer = new NoteTransposer(compositionConfiguration);
-var chordComposer = new ChordComposer(compositionStrategy, compositionConfiguration, logger);
-var chordNumberIdentifier = new ChordNumberIdentifier(compositionConfiguration);
-
-var themeComposer = new ThemeComposer(
-    compositionStrategy,
-    compositionDecorator,
-    chordComposer,
-    noteTransposer,
-    logger,
-    compositionConfiguration
-);
-
-var endingComposer = new EndingComposer(
-    compositionStrategy,
-    compositionDecorator,
-    chordNumberIdentifier,
-    logger,
-    compositionConfiguration
-);
-
-var composer = new Composer(
-    compositionDecorator,
-    compositionPhraser,
-    chordComposer,
-    themeComposer,
-    endingComposer,
-    logger,
-    compositionConfiguration
-);
-
-var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-
-var composition = composer.Compose();
-
-stopwatch.Stop();
-
-Console.WriteLine();
-Console.WriteLine($"Done composing! Elapsed time: {stopwatch.Elapsed}.");
-Console.WriteLine("Creating MIDI file...");
-
-var midiGenerator = new MidiGenerator(compositionConfiguration);
-var midiFile = midiGenerator.Generate(composition);
 var timestamp = DateTime.Now.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture);
 
-midiFile.Write($"test-{timestamp}.mid");
-
-Console.WriteLine("Done creating MIDI file!");
-Console.WriteLine("Press any key to exit...");
-Console.ReadLine();
+baroquenMelody.MidiFile.Write($"test-{timestamp}.mid");

--- a/tests/BaroquenMelody.Library.Tests/BaroquenMelodyComposerConfiguratorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/BaroquenMelodyComposerConfiguratorTests.cs
@@ -1,0 +1,42 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Tests.TestData;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests;
+
+[TestFixture]
+internal sealed class BaroquenMelodyComposerConfiguratorTests
+{
+    private BaroquenMelodyComposerConfigurator _baroquenMelodyComposerConfigurator = null!;
+
+    [SetUp]
+    public void SetUp() => _baroquenMelodyComposerConfigurator = new BaroquenMelodyComposerConfigurator(Substitute.For<ILogger>());
+
+    [Test]
+    [TestCaseSource(nameof(TestCases))]
+    public void Configure_returns_configured_BaroquenMelodyComposer_which_can_compose_a_BaroquenMelody(CompositionConfiguration compositionConfiguration)
+    {
+        // arrange
+        var baroquenMelodyComposer = _baroquenMelodyComposerConfigurator.Configure(compositionConfiguration);
+
+        // act
+        var baroquenMelody = baroquenMelodyComposer.Compose();
+
+        // assert
+        baroquenMelody.Should().NotBeNull();
+        baroquenMelody.MidiFile.Should().NotBeNull();
+    }
+
+    private static IEnumerable<TestCaseData> TestCases
+    {
+        get
+        {
+            yield return new TestCaseData(Configurations.GetCompositionConfiguration(2, 10));
+
+            yield return new TestCaseData(Configurations.GetCompositionConfiguration(3, 10));
+        }
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Composers/BaroquenMelodyComposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Composers/BaroquenMelodyComposerTests.cs
@@ -1,0 +1,49 @@
+﻿using BaroquenMelody.Library.Compositions.Composers;
+using BaroquenMelody.Library.Compositions.Domain;
+using BaroquenMelody.Library.Compositions.Midi;
+using FluentAssertions;
+using Melanchall.DryWetMidi.Core;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Composers;
+
+[TestFixture]
+internal sealed class BaroquenMelodyComposerTests
+{
+    private IComposer _mockComposer = null!;
+
+    private IMidiGenerator _mockMidiGenerator = null!;
+
+    private BaroquenMelodyComposer _baroquenMelodyComposer = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockComposer = Substitute.For<IComposer>();
+        _mockMidiGenerator = Substitute.For<IMidiGenerator>();
+
+        _baroquenMelodyComposer = new BaroquenMelodyComposer(_mockComposer, _mockMidiGenerator);
+    }
+
+    [Test]
+    public void Compose_invokes_expected_components_and_returns_BaroquenMelody()
+    {
+        // arrange
+        var testComposition = new Composition([]);
+        var midiFile = new MidiFile();
+
+        _mockComposer.Compose().Returns(testComposition);
+        _mockMidiGenerator.Generate(testComposition).Returns(midiFile);
+
+        // act
+        var result = _baroquenMelodyComposer.Compose();
+
+        // assert
+        _mockComposer.Received(1).Compose();
+        _mockMidiGenerator.Received(1).Generate(testComposition);
+
+        result.Should().NotBeNull();
+        result.MidiFile.Should().Be(midiFile);
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Enums/Extensions/MeterExtensionsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Enums/Extensions/MeterExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Enums.Extensions;
 using FluentAssertions;
+using Melanchall.DryWetMidi.Interaction;
 using NUnit.Framework;
 
 namespace BaroquenMelody.Library.Tests.Compositions.Enums.Extensions;
@@ -15,6 +16,32 @@ internal sealed class MeterExtensionsTests
         meter.BeatsPerMeasure().Should().Be(expectedBeatsPerMeasure);
 
     [Test]
-    public void BeatsPerMeasure_throws_on_unsupported_meter() =>
-        Assert.Throws<ArgumentOutOfRangeException>(() => ((Meter)int.MaxValue).BeatsPerMeasure());
+    public void BeatsPerMeasure_throws_on_unsupported_meter()
+    {
+        var act = () => ((Meter)int.MaxValue).BeatsPerMeasure();
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    [TestCaseSource(nameof(DefaultMusicalTimeSpanTestCases))]
+    public void DefaultMusicalTimeSpan_returns_expected_value(Meter meter, MusicalTimeSpan expectedDefaultMusicalTimeSpan) =>
+        meter.DefaultMusicalTimeSpan().Should().Be(expectedDefaultMusicalTimeSpan);
+
+    [Test]
+    public void DefaultMusicalTimeSpan_throws_on_unsupported_meter()
+    {
+        var act = () => ((Meter)int.MaxValue).DefaultMusicalTimeSpan();
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    private static IEnumerable<TestCaseData> DefaultMusicalTimeSpanTestCases
+    {
+        get
+        {
+            yield return new TestCaseData(Meter.FourFour, MusicalTimeSpan.Half);
+            yield return new TestCaseData(Meter.ThreeFour, MusicalTimeSpan.Half.Dotted(1));
+        }
+    }
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Midi/MidiGeneratorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Midi/MidiGeneratorTests.cs
@@ -1,14 +1,14 @@
 ﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Midi;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
-using BaroquenMelody.Library.Midi;
 using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
 using NUnit.Framework;
 
-namespace BaroquenMelody.Library.Tests.Midi;
+namespace BaroquenMelody.Library.Tests.Compositions.Midi;
 
 [TestFixture]
 internal sealed class MidiGeneratorTests

--- a/tests/BaroquenMelody.Library.Tests/TestData/Configurations.cs
+++ b/tests/BaroquenMelody.Library.Tests/TestData/Configurations.cs
@@ -8,14 +8,17 @@ namespace BaroquenMelody.Library.Tests.TestData;
 
 internal static class Configurations
 {
-    public static CompositionConfiguration GetCompositionConfiguration(int numberOfVoices = 4) => new(
+    public static CompositionConfiguration GetCompositionConfiguration(
+        int numberOfVoices = 4,
+        int compositionLength = 100
+    ) => new(
         GenerateVoiceConfigurations(numberOfVoices),
         PhrasingConfiguration.Default,
         AggregateCompositionRuleConfiguration.Default,
         BaroquenScale.Parse("C Major"),
         Meter.FourFour,
         MusicalTimeSpan.Half,
-        CompositionLength: 100
+        CompositionLength: compositionLength
     );
 
     private static HashSet<VoiceConfiguration> GenerateVoiceConfigurations(int numberOfVoices) => numberOfVoices switch


### PR DESCRIPTION
## Description

- Abstract out dependency management and composer configuration into a new configurator class
- Disallow library internals to be visible to CLI app now that configuration is abstracted out
- Add new `Meter` extension for selecting a default musical timespan for the given `Meter`. This was done to ensure that `MusicalTimeSpanCalculator` can remain `internal`.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
