### PR TITLE
Integrate Reactive Extensions

### DIFF
--- a/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
+++ b/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
@@ -28,6 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Reactive" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BaroquenMelody.Library/Infrastructure/State/StateExtensions.cs
+++ b/src/BaroquenMelody.Library/Infrastructure/State/StateExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Fluxor;
+using System.Reactive.Linq;
+
+namespace BaroquenMelody.Library.Infrastructure.State;
+
+/// <summary>
+///     A home for <see cref="IState{TState}"/> extension methods.
+/// </summary>
+public static class StateExtensions
+{
+    /// <summary>
+    ///     Create an observable that emits the current state whenever it has changed.
+    /// </summary>
+    /// <typeparam name="TState">The type of the state to observe.</typeparam>
+    /// <param name="state">The state to observe.</param>
+    /// <returns>An observable that emits the current state whenever it has changed.</returns>
+    public static IObservable<IState<TState>> ObserveChanges<TState>(this IState<TState> state) => Observable.FromEventPattern<EventHandler, EventArgs>(
+            unused => state.StateChanged += unused,
+            unused => state.StateChanged -= unused
+        )
+        .Select(_ => state);
+}

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -18,7 +18,7 @@ var phrasingConfiguration = new PhrasingConfiguration(
     PhraseRepetitionProbability: 100
 );
 
-const Meter meter = Meter.ThreeFour;
+const Meter meter = Meter.FourFour;
 
 var compositionConfiguration = new CompositionConfiguration(
     new HashSet<VoiceConfiguration>
@@ -49,14 +49,13 @@ var serviceProvider = new ServiceCollection()
         fluxorOptions.ScanAssemblies(typeof(BaroquenMelodyComposerConfigurator).Assembly);
     })
     .AddSingleton<IBaroquenMelodyComposerConfigurator, BaroquenMelodyComposerConfigurator>()
-    .AddSingleton<App>()
+    .AddScoped<App>()
     .BuildServiceProvider();
 
-var baroquenMelody = await serviceProvider
-    .GetRequiredService<App>()
-    .RunAsync(compositionConfiguration)
-    .ConfigureAwait(false);
+using var scope = serviceProvider.CreateScope();
 
+var app = scope.ServiceProvider.GetRequiredService<App>();
+var baroquenMelody = app.Run(compositionConfiguration);
 var timestamp = DateTime.Now.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture);
 
 baroquenMelody.MidiFile.Write($"test-{timestamp}.mid");

--- a/tests/BaroquenMelody.Library.Tests/Infrastructure/State/StateExtensionsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Infrastructure/State/StateExtensionsTests.cs
@@ -1,0 +1,32 @@
+﻿using BaroquenMelody.Library.Infrastructure.State;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Infrastructure.State;
+
+[TestFixture]
+internal sealed class StateExtensionsTests
+{
+    private TestState _testState = null!;
+
+    [SetUp]
+    public void SetUp() => _testState = new TestState();
+
+    [Test]
+    public void ObserveChanges_returns_IObservable_of_state_changes_which_can_be_subscribed_to()
+    {
+        var stateChanges = new List<int> { 1, 2, 3, 4, 5 };
+        var expectedStateChanges = new List<int>();
+
+        // arrange
+        using var stateSubscription = _testState
+            .ObserveChanges()
+            .Subscribe(state => expectedStateChanges.Add(state.Value));
+
+        // act
+        stateChanges.ForEach(stateChange => _testState.SetValue(stateChange));
+
+        // assert
+        expectedStateChanges.Should().BeEquivalentTo(stateChanges);
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Infrastructure/State/TestState.cs
+++ b/tests/BaroquenMelody.Library.Tests/Infrastructure/State/TestState.cs
@@ -1,0 +1,17 @@
+﻿using Fluxor;
+
+namespace BaroquenMelody.Library.Tests.Infrastructure.State;
+
+internal sealed class TestState : IState<int>
+{
+    public event EventHandler? StateChanged;
+
+    public int Value { get; private set; }
+
+    public void SetValue(int value)
+    {
+        Value = value;
+
+        StateChanged?.Invoke(this, EventArgs.Empty);
+    }
+}


### PR DESCRIPTION
## Description

Integrate System.Reactive and implement `ObserveChanges` as an extension method on `IState<T>` to make observing Fluxor state changes more ergonomic.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
