### PR TITLE
Rename Voice Enum Values

### DIFF
--- a/benchmarks/BaroquenMelody.Benchmarks/Compositions/BenchmarkData.cs
+++ b/benchmarks/BaroquenMelody.Benchmarks/Compositions/BenchmarkData.cs
@@ -11,10 +11,10 @@ internal static class BenchmarkData
     public static readonly CompositionConfiguration CompositionConfiguration = new(
         new HashSet<VoiceConfiguration>
         {
-            new(Voice.Soprano, Notes.C0, Notes.C6),
-            new(Voice.Alto, Notes.C0, Notes.C6),
-            new(Voice.Tenor, Notes.C0, Notes.C6),
-            new(Voice.Bass, Notes.C0, Notes.C6)
+            new(Voice.One, Notes.C0, Notes.C6),
+            new(Voice.Two, Notes.C0, Notes.C6),
+            new(Voice.Three, Notes.C0, Notes.C6),
+            new(Voice.Four, Notes.C0, Notes.C6)
         },
         new PhrasingConfiguration(
             PhraseLengths: [1, 2, 4, 8],
@@ -31,37 +31,37 @@ internal static class BenchmarkData
     );
 
     public static readonly BaroquenChord CMajor = new([
-        new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Quarter),
-        new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Quarter),
-        new BaroquenNote(Voice.Tenor, Notes.G2, MusicalTimeSpan.Quarter),
-        new BaroquenNote(Voice.Bass, Notes.C1, MusicalTimeSpan.Quarter)
+        new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Quarter),
+        new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Quarter),
+        new BaroquenNote(Voice.Three, Notes.G2, MusicalTimeSpan.Quarter),
+        new BaroquenNote(Voice.Four, Notes.C1, MusicalTimeSpan.Quarter)
     ]);
 
     public static readonly BaroquenChord EMinor = new([
-        new BaroquenNote(Voice.Soprano, Notes.B4, MusicalTimeSpan.Quarter),
-        new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Quarter),
-        new BaroquenNote(Voice.Tenor, Notes.G2, MusicalTimeSpan.Quarter),
-        new BaroquenNote(Voice.Bass, Notes.B1, MusicalTimeSpan.Quarter)
+        new BaroquenNote(Voice.One, Notes.B4, MusicalTimeSpan.Quarter),
+        new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Quarter),
+        new BaroquenNote(Voice.Three, Notes.G2, MusicalTimeSpan.Quarter),
+        new BaroquenNote(Voice.Four, Notes.B1, MusicalTimeSpan.Quarter)
     ]);
 
     public static readonly BaroquenChord FMajor = new([
-        new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Quarter),
-        new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Quarter),
-        new BaroquenNote(Voice.Tenor, Notes.A2, MusicalTimeSpan.Quarter),
-        new BaroquenNote(Voice.Bass, Notes.F1, MusicalTimeSpan.Quarter)
+        new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Quarter),
+        new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Quarter),
+        new BaroquenNote(Voice.Three, Notes.A2, MusicalTimeSpan.Quarter),
+        new BaroquenNote(Voice.Four, Notes.F1, MusicalTimeSpan.Quarter)
     ]);
 
     public static readonly BaroquenChord GMajor = new([
-        new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Quarter),
-        new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Quarter),
-        new BaroquenNote(Voice.Tenor, Notes.B2, MusicalTimeSpan.Quarter),
-        new BaroquenNote(Voice.Bass, Notes.G1, MusicalTimeSpan.Quarter)
+        new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Quarter),
+        new BaroquenNote(Voice.Two, Notes.G3, MusicalTimeSpan.Quarter),
+        new BaroquenNote(Voice.Three, Notes.B2, MusicalTimeSpan.Quarter),
+        new BaroquenNote(Voice.Four, Notes.G1, MusicalTimeSpan.Quarter)
     ]);
 
     public static readonly BaroquenChord DMinor = new([
-        new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Quarter),
-        new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Quarter),
-        new BaroquenNote(Voice.Tenor, Notes.A2, MusicalTimeSpan.Quarter),
-        new BaroquenNote(Voice.Bass, Notes.D1, MusicalTimeSpan.Quarter)
+        new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Quarter),
+        new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Quarter),
+        new BaroquenNote(Voice.Three, Notes.A2, MusicalTimeSpan.Quarter),
+        new BaroquenNote(Voice.Four, Notes.D1, MusicalTimeSpan.Quarter)
     ]);
 }

--- a/src/BaroquenMelody.Library/Compositions/Enums/Voice.cs
+++ b/src/BaroquenMelody.Library/Compositions/Enums/Voice.cs
@@ -8,20 +8,20 @@ public enum Voice : byte
     /// <summary>
     ///     The first voice.
     /// </summary>
-    Soprano,
+    One,
 
     /// <summary>
     ///    The second voice.
     /// </summary>
-    Alto,
+    Two,
 
     /// <summary>
     ///   The third voice.
     /// </summary>
-    Tenor,
+    Three,
 
     /// <summary>
     ///  The fourth voice.
     /// </summary>
-    Bass
+    Four
 }

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -43,9 +43,9 @@ void DispatchInitialState(IDispatcher dispatcher)
 {
     dispatcher.Dispatch(new UpdateCompositionConfiguration(BaroquenScale.Parse("C Major"), Meter.ThreeFour, 25));
 
-    dispatcher.Dispatch(new UpdateVoiceConfiguration(Voice.Soprano, Notes.C5, Notes.E6, GeneralMidi2Program.AcousticGuitarNylon, true));
-    dispatcher.Dispatch(new UpdateVoiceConfiguration(Voice.Alto, Notes.G3, Notes.B4, GeneralMidi2Program.AcousticGuitarNylon, true));
-    dispatcher.Dispatch(new UpdateVoiceConfiguration(Voice.Tenor, Notes.F3, Notes.A4, GeneralMidi2Program.AcousticGuitarNylon, true));
+    dispatcher.Dispatch(new UpdateVoiceConfiguration(Voice.One, Notes.C5, Notes.E6, GeneralMidi2Program.AcousticGuitarNylon, true));
+    dispatcher.Dispatch(new UpdateVoiceConfiguration(Voice.Two, Notes.G3, Notes.B4, GeneralMidi2Program.AcousticGuitarNylon, true));
+    dispatcher.Dispatch(new UpdateVoiceConfiguration(Voice.Three, Notes.F3, Notes.A4, GeneralMidi2Program.AcousticGuitarNylon, true));
 
     // dispatcher.Dispatch(new UpdateVoiceConfiguration(Voice.Four, Notes.C2, Notes.E3, GeneralMidi2Program.AcousticGuitarNylon, true));
     foreach (var configuration in AggregateCompositionRuleConfiguration.Default.Configurations)

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/ChordChoiceTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/ChordChoiceTests.cs
@@ -11,10 +11,10 @@ internal sealed class ChordChoiceTests
     [Test]
     public void WhenChordChoicesAreSameReference_TheyAreEqual()
     {
-        var note1 = new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0);
-        var note2 = new NoteChoice(Voice.Alto, NoteMotion.Ascending, 2);
-        var note3 = new NoteChoice(Voice.Tenor, NoteMotion.Descending, 3);
-        var note4 = new NoteChoice(Voice.Bass, NoteMotion.Ascending, 5);
+        var note1 = new NoteChoice(Voice.One, NoteMotion.Oblique, 0);
+        var note2 = new NoteChoice(Voice.Two, NoteMotion.Ascending, 2);
+        var note3 = new NoteChoice(Voice.Three, NoteMotion.Descending, 3);
+        var note4 = new NoteChoice(Voice.Four, NoteMotion.Ascending, 5);
 
         var chordChoiceA = new ChordChoice([note1, note2, note3, note4]);
         var chordChoiceB = chordChoiceA;
@@ -38,10 +38,10 @@ internal sealed class ChordChoiceTests
     [Test]
     public void WhenChordChoicesHaveSameNoteChoices_TheyAreEqual()
     {
-        var note1 = new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0);
-        var note2 = new NoteChoice(Voice.Alto, NoteMotion.Ascending, 2);
-        var note3 = new NoteChoice(Voice.Tenor, NoteMotion.Descending, 3);
-        var note4 = new NoteChoice(Voice.Bass, NoteMotion.Ascending, 5);
+        var note1 = new NoteChoice(Voice.One, NoteMotion.Oblique, 0);
+        var note2 = new NoteChoice(Voice.Two, NoteMotion.Ascending, 2);
+        var note3 = new NoteChoice(Voice.Three, NoteMotion.Descending, 3);
+        var note4 = new NoteChoice(Voice.Four, NoteMotion.Ascending, 5);
 
         var chordChoiceA = new ChordChoice([note1, note2, note3, note4]);
         var chordChoiceB = new ChordChoice([note1, note2, note3, note4]);
@@ -65,10 +65,10 @@ internal sealed class ChordChoiceTests
     [Test]
     public void WhenOneChordChoiceIsNull_TheyAreNotEqual()
     {
-        var note1 = new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0);
-        var note2 = new NoteChoice(Voice.Alto, NoteMotion.Ascending, 2);
-        var note3 = new NoteChoice(Voice.Tenor, NoteMotion.Descending, 3);
-        var note4 = new NoteChoice(Voice.Bass, NoteMotion.Ascending, 5);
+        var note1 = new NoteChoice(Voice.One, NoteMotion.Oblique, 0);
+        var note2 = new NoteChoice(Voice.Two, NoteMotion.Ascending, 2);
+        var note3 = new NoteChoice(Voice.Three, NoteMotion.Descending, 3);
+        var note4 = new NoteChoice(Voice.Four, NoteMotion.Ascending, 5);
 
         var chordChoiceA = new ChordChoice([note1, note2, note3, note4]);
         ChordChoice? chordChoiceB = null;
@@ -82,10 +82,10 @@ internal sealed class ChordChoiceTests
     [Test]
     public void WhenNonDestructiveMutationUsed_InitializerInvoked()
     {
-        var note1 = new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0);
-        var note2 = new NoteChoice(Voice.Alto, NoteMotion.Ascending, 2);
-        var note3 = new NoteChoice(Voice.Tenor, NoteMotion.Descending, 3);
-        var note4 = new NoteChoice(Voice.Bass, NoteMotion.Ascending, 5);
+        var note1 = new NoteChoice(Voice.One, NoteMotion.Oblique, 0);
+        var note2 = new NoteChoice(Voice.Two, NoteMotion.Ascending, 2);
+        var note3 = new NoteChoice(Voice.Three, NoteMotion.Descending, 3);
+        var note4 = new NoteChoice(Voice.Four, NoteMotion.Ascending, 5);
 
         var chordChoice = new ChordChoice([note1, note2, note3, note4]);
         var otherChordChoice = chordChoice with { NoteChoices = [note3, note4, note1, note2] };

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/DuetChordChoiceRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/DuetChordChoiceRepositoryTests.cs
@@ -18,24 +18,24 @@ internal sealed class DuetChordChoiceRepositoryTests
         _mockNoteChoiceGenerator = Substitute.For<INoteChoiceGenerator>();
 
         _mockNoteChoiceGenerator
-            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Soprano))
+            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.One))
             .Returns(
                 new HashSet<NoteChoice>
                 {
-                    new(Voice.Soprano, NoteMotion.Oblique, 0),
-                    new(Voice.Soprano, NoteMotion.Ascending, 2),
-                    new(Voice.Soprano, NoteMotion.Descending, 3)
+                    new(Voice.One, NoteMotion.Oblique, 0),
+                    new(Voice.One, NoteMotion.Ascending, 2),
+                    new(Voice.One, NoteMotion.Descending, 3)
                 }
             );
 
         _mockNoteChoiceGenerator
-            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Alto))
+            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Two))
             .Returns(
                 new HashSet<NoteChoice>
                 {
-                    new(Voice.Alto, NoteMotion.Oblique, 0),
-                    new(Voice.Alto, NoteMotion.Ascending, 2),
-                    new(Voice.Alto, NoteMotion.Descending, 3)
+                    new(Voice.Two, NoteMotion.Oblique, 0),
+                    new(Voice.Two, NoteMotion.Ascending, 2),
+                    new(Voice.Two, NoteMotion.Descending, 3)
                 }
             );
     }
@@ -61,8 +61,8 @@ internal sealed class DuetChordChoiceRepositoryTests
         noteChoice.Should().BeEquivalentTo(
             new ChordChoice(
                 [
-                    new NoteChoice(Voice.Soprano, NoteMotion.Ascending, 2),
-                    new NoteChoice(Voice.Alto, NoteMotion.Descending, 3)
+                    new NoteChoice(Voice.One, NoteMotion.Ascending, 2),
+                    new NoteChoice(Voice.Two, NoteMotion.Descending, 3)
                 ]
             )
         );
@@ -101,8 +101,8 @@ internal sealed class DuetChordChoiceRepositoryTests
         var id = duetChordChoiceRepository.GetChordChoiceId(
             new ChordChoice(
                 [
-                    new NoteChoice(Voice.Soprano, NoteMotion.Ascending, 2),
-                    new NoteChoice(Voice.Alto, NoteMotion.Descending, 3)
+                    new NoteChoice(Voice.One, NoteMotion.Ascending, 2),
+                    new NoteChoice(Voice.Two, NoteMotion.Descending, 3)
                 ]
             )
         );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/Extensions/NoteChoiceExtensionsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/Extensions/NoteChoiceExtensionsTests.cs
@@ -13,8 +13,8 @@ internal sealed class NoteChoiceExtensionsTests
     public void ToChordChoice_TwoNotes_CreatesExpectedChordChoice()
     {
         // arrange
-        var note1 = new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0);
-        var note2 = new NoteChoice(Voice.Alto, NoteMotion.Ascending, 2);
+        var note1 = new NoteChoice(Voice.One, NoteMotion.Oblique, 0);
+        var note2 = new NoteChoice(Voice.Two, NoteMotion.Ascending, 2);
 
         var source = (note1, note2);
 
@@ -29,9 +29,9 @@ internal sealed class NoteChoiceExtensionsTests
     public void ToChordChoice_ThreeNotes_CreatesExpectedChordChoice()
     {
         // arrange
-        var note1 = new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0);
-        var note2 = new NoteChoice(Voice.Alto, NoteMotion.Ascending, 2);
-        var note3 = new NoteChoice(Voice.Tenor, NoteMotion.Descending, 3);
+        var note1 = new NoteChoice(Voice.One, NoteMotion.Oblique, 0);
+        var note2 = new NoteChoice(Voice.Two, NoteMotion.Ascending, 2);
+        var note3 = new NoteChoice(Voice.Three, NoteMotion.Descending, 3);
 
         var source = (note1, note2, note3);
 
@@ -46,10 +46,10 @@ internal sealed class NoteChoiceExtensionsTests
     public void ToChordChoice_FourNotes_CreatesExpectedChordChoice()
     {
         // arrange
-        var note1 = new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0);
-        var note2 = new NoteChoice(Voice.Alto, NoteMotion.Ascending, 2);
-        var note3 = new NoteChoice(Voice.Tenor, NoteMotion.Descending, 3);
-        var note4 = new NoteChoice(Voice.Bass, NoteMotion.Ascending, 5);
+        var note1 = new NoteChoice(Voice.One, NoteMotion.Oblique, 0);
+        var note2 = new NoteChoice(Voice.Two, NoteMotion.Ascending, 2);
+        var note3 = new NoteChoice(Voice.Three, NoteMotion.Descending, 3);
+        var note4 = new NoteChoice(Voice.Four, NoteMotion.Ascending, 5);
 
         var source = (note1, note2, note3, note4);
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/NoteChoiceGeneratorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/NoteChoiceGeneratorTests.cs
@@ -16,7 +16,7 @@ internal sealed class NoteChoiceGeneratorTests
     [Test]
     public void GenerateNoteChoices_GivenVoice_ReturnsNoteChoices()
     {
-        var noteChoices = _noteChoiceGenerator.GenerateNoteChoices(Voice.Soprano);
+        var noteChoices = _noteChoiceGenerator.GenerateNoteChoices(Voice.One);
 
         noteChoices.Should().NotBeNull();
         noteChoices.Should().NotBeEmpty();

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/QuartetChordChoiceRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/QuartetChordChoiceRepositoryTests.cs
@@ -18,46 +18,46 @@ internal sealed class QuartetChordChoiceRepositoryTests
         _mockNoteChoiceGenerator = Substitute.For<INoteChoiceGenerator>();
 
         _mockNoteChoiceGenerator
-            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Soprano))
+            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.One))
             .Returns(
                 new HashSet<NoteChoice>
                 {
-                    new(Voice.Soprano, NoteMotion.Oblique, 0),
-                    new(Voice.Soprano, NoteMotion.Ascending, 2),
-                    new(Voice.Soprano, NoteMotion.Descending, 3)
+                    new(Voice.One, NoteMotion.Oblique, 0),
+                    new(Voice.One, NoteMotion.Ascending, 2),
+                    new(Voice.One, NoteMotion.Descending, 3)
                 }
             );
 
         _mockNoteChoiceGenerator
-            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Alto))
+            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Two))
             .Returns(
                 new HashSet<NoteChoice>
                 {
-                    new(Voice.Alto, NoteMotion.Oblique, 0),
-                    new(Voice.Alto, NoteMotion.Ascending, 2),
-                    new(Voice.Alto, NoteMotion.Descending, 3)
+                    new(Voice.Two, NoteMotion.Oblique, 0),
+                    new(Voice.Two, NoteMotion.Ascending, 2),
+                    new(Voice.Two, NoteMotion.Descending, 3)
                 }
             );
 
         _mockNoteChoiceGenerator
-            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Tenor))
+            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Three))
             .Returns(
                 new HashSet<NoteChoice>
                 {
-                    new(Voice.Tenor, NoteMotion.Oblique, 0),
-                    new(Voice.Tenor, NoteMotion.Ascending, 2),
-                    new(Voice.Tenor, NoteMotion.Descending, 3)
+                    new(Voice.Three, NoteMotion.Oblique, 0),
+                    new(Voice.Three, NoteMotion.Ascending, 2),
+                    new(Voice.Three, NoteMotion.Descending, 3)
                 }
             );
 
         _mockNoteChoiceGenerator
-            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Bass))
+            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Four))
             .Returns(
                 new HashSet<NoteChoice>
                 {
-                    new(Voice.Bass, NoteMotion.Oblique, 0),
-                    new(Voice.Bass, NoteMotion.Ascending, 2),
-                    new(Voice.Bass, NoteMotion.Descending, 3)
+                    new(Voice.Four, NoteMotion.Oblique, 0),
+                    new(Voice.Four, NoteMotion.Ascending, 2),
+                    new(Voice.Four, NoteMotion.Descending, 3)
                 }
             );
     }
@@ -83,10 +83,10 @@ internal sealed class QuartetChordChoiceRepositoryTests
         noteChoice.Should().BeEquivalentTo(
             new ChordChoice(
                 [
-                    new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0),
-                    new NoteChoice(Voice.Alto, NoteMotion.Oblique, 0),
-                    new NoteChoice(Voice.Tenor, NoteMotion.Oblique, 0),
-                    new NoteChoice(Voice.Bass, NoteMotion.Ascending, 2)
+                    new NoteChoice(Voice.One, NoteMotion.Oblique, 0),
+                    new NoteChoice(Voice.Two, NoteMotion.Oblique, 0),
+                    new NoteChoice(Voice.Three, NoteMotion.Oblique, 0),
+                    new NoteChoice(Voice.Four, NoteMotion.Ascending, 2)
                 ]
             )
         );
@@ -125,10 +125,10 @@ internal sealed class QuartetChordChoiceRepositoryTests
         var id = quartetChordChoiceRepository.GetChordChoiceId(
             new ChordChoice(
                 [
-                    new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0),
-                    new NoteChoice(Voice.Alto, NoteMotion.Oblique, 0),
-                    new NoteChoice(Voice.Tenor, NoteMotion.Oblique, 0),
-                    new NoteChoice(Voice.Bass, NoteMotion.Ascending, 2)
+                    new NoteChoice(Voice.One, NoteMotion.Oblique, 0),
+                    new NoteChoice(Voice.Two, NoteMotion.Oblique, 0),
+                    new NoteChoice(Voice.Three, NoteMotion.Oblique, 0),
+                    new NoteChoice(Voice.Four, NoteMotion.Ascending, 2)
                 ]
             )
         );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/TrioChordChoiceRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/TrioChordChoiceRepositoryTests.cs
@@ -18,35 +18,35 @@ internal sealed class TrioChordChoiceRepositoryTests
         _mockNoteChoiceGenerator = Substitute.For<INoteChoiceGenerator>();
 
         _mockNoteChoiceGenerator
-            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Soprano))
+            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.One))
             .Returns(
                 new HashSet<NoteChoice>
                 {
-                    new(Voice.Soprano, NoteMotion.Oblique, 0),
-                    new(Voice.Soprano, NoteMotion.Ascending, 2),
-                    new(Voice.Soprano, NoteMotion.Descending, 3)
+                    new(Voice.One, NoteMotion.Oblique, 0),
+                    new(Voice.One, NoteMotion.Ascending, 2),
+                    new(Voice.One, NoteMotion.Descending, 3)
                 }
             );
 
         _mockNoteChoiceGenerator
-            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Alto))
+            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Two))
             .Returns(
                 new HashSet<NoteChoice>
                 {
-                    new(Voice.Alto, NoteMotion.Oblique, 0),
-                    new(Voice.Alto, NoteMotion.Ascending, 2),
-                    new(Voice.Alto, NoteMotion.Descending, 3)
+                    new(Voice.Two, NoteMotion.Oblique, 0),
+                    new(Voice.Two, NoteMotion.Ascending, 2),
+                    new(Voice.Two, NoteMotion.Descending, 3)
                 }
             );
 
         _mockNoteChoiceGenerator
-            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Tenor))
+            .GenerateNoteChoices(Arg.Is<Voice>(voice => voice == Voice.Three))
             .Returns(
                 new HashSet<NoteChoice>
                 {
-                    new(Voice.Tenor, NoteMotion.Oblique, 0),
-                    new(Voice.Tenor, NoteMotion.Ascending, 2),
-                    new(Voice.Tenor, NoteMotion.Descending, 3)
+                    new(Voice.Three, NoteMotion.Oblique, 0),
+                    new(Voice.Three, NoteMotion.Ascending, 2),
+                    new(Voice.Three, NoteMotion.Descending, 3)
                 }
             );
     }
@@ -72,9 +72,9 @@ internal sealed class TrioChordChoiceRepositoryTests
         noteChoice.Should().BeEquivalentTo(
             new ChordChoice(
                 [
-                    new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0),
-                    new NoteChoice(Voice.Alto, NoteMotion.Oblique, 0),
-                    new NoteChoice(Voice.Tenor, NoteMotion.Ascending, 2)
+                    new NoteChoice(Voice.One, NoteMotion.Oblique, 0),
+                    new NoteChoice(Voice.Two, NoteMotion.Oblique, 0),
+                    new NoteChoice(Voice.Three, NoteMotion.Ascending, 2)
                 ]
             )
         );
@@ -113,9 +113,9 @@ internal sealed class TrioChordChoiceRepositoryTests
         var id = trioChordChoiceRepository.GetChordChoiceId(
             new ChordChoice(
                 [
-                    new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0),
-                    new NoteChoice(Voice.Alto, NoteMotion.Oblique, 0),
-                    new NoteChoice(Voice.Tenor, NoteMotion.Ascending, 2)
+                    new NoteChoice(Voice.One, NoteMotion.Oblique, 0),
+                    new NoteChoice(Voice.Two, NoteMotion.Oblique, 0),
+                    new NoteChoice(Voice.Three, NoteMotion.Ascending, 2)
                 ]
             )
         );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ChordComposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ChordComposerTests.cs
@@ -45,13 +45,13 @@ internal sealed class ChordComposerTests
         [
             new ChordChoice(
             [
-                new NoteChoice(Voice.Soprano, NoteMotion.Ascending, 3),
-                new NoteChoice(Voice.Alto, NoteMotion.Descending, 3)
+                new NoteChoice(Voice.One, NoteMotion.Ascending, 3),
+                new NoteChoice(Voice.Two, NoteMotion.Descending, 3)
             ]),
             new ChordChoice(
             [
-                new NoteChoice(Voice.Soprano, NoteMotion.Descending, 3),
-                new NoteChoice(Voice.Alto, NoteMotion.Ascending, 3)
+                new NoteChoice(Voice.One, NoteMotion.Descending, 3),
+                new NoteChoice(Voice.Two, NoteMotion.Ascending, 3)
             ])
         ]);
 
@@ -59,21 +59,21 @@ internal sealed class ChordComposerTests
         {
             new(
             [
-                new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half)
+                new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half)
             ])
         };
 
         var expectedChordA = new BaroquenChord(
         [
-            new BaroquenNote(Voice.Soprano, Notes.D5, MusicalTimeSpan.Half),
-            new BaroquenNote(Voice.Alto, Notes.G2, MusicalTimeSpan.Half)
+            new BaroquenNote(Voice.One, Notes.D5, MusicalTimeSpan.Half),
+            new BaroquenNote(Voice.Two, Notes.G2, MusicalTimeSpan.Half)
         ]);
 
         var expectedChordB = new BaroquenChord(
         [
-            new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half),
-            new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half)
+            new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half),
+            new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half)
         ]);
 
         // act
@@ -94,8 +94,8 @@ internal sealed class ChordComposerTests
         {
             new(
             [
-                new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half)
+                new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half)
             ])
         };
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ComposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ComposerTests.cs
@@ -78,8 +78,8 @@ internal sealed class ComposerTests
         // arrange
         _mockCompositionStrategy.GenerateInitialChord().Returns(
             new BaroquenChord([
-                new BaroquenNote(Voice.Soprano, MinSopranoNote, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Alto, MinAltoNote, MusicalTimeSpan.Half)
+                new BaroquenNote(Voice.One, MinSopranoNote, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Two, MinAltoNote, MusicalTimeSpan.Half)
             ])
         );
 
@@ -87,8 +87,8 @@ internal sealed class ComposerTests
             .GetPossibleChordChoices(Arg.Any<IReadOnlyList<BaroquenChord>>())
             .Returns([
                 new ChordChoice([
-                    new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0),
-                    new NoteChoice(Voice.Alto, NoteMotion.Oblique, 0)
+                    new NoteChoice(Voice.One, NoteMotion.Oblique, 0),
+                    new NoteChoice(Voice.Two, NoteMotion.Oblique, 0)
                 ])
             ]);
 
@@ -96,8 +96,8 @@ internal sealed class ComposerTests
             .GetPossibleChordsForPartiallyVoicedChords(Arg.Any<IReadOnlyList<BaroquenChord>>(), Arg.Any<BaroquenChord>())
             .Returns([
                 new BaroquenChord([
-                    new BaroquenNote(Voice.Soprano, MinSopranoNote, MusicalTimeSpan.Half),
-                    new BaroquenNote(Voice.Alto, MinAltoNote, MusicalTimeSpan.Half)
+                    new BaroquenNote(Voice.One, MinSopranoNote, MusicalTimeSpan.Half),
+                    new BaroquenNote(Voice.Two, MinAltoNote, MusicalTimeSpan.Half)
                 ])
             ]);
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Composers/EndingComposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Composers/EndingComposerTests.cs
@@ -53,13 +53,13 @@ internal sealed class EndingComposerTests
         // arrange
         var composition = CreateTestComposition();
         var theme = CreateTestTheme();
-        var bridgingChords = new List<BaroquenChord> { new([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)]) };
+        var bridgingChords = new List<BaroquenChord> { new([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)]) };
 
         _mockCompositionStrategy.GetPossibleChordsForPartiallyVoicedChords(Arg.Any<IReadOnlyList<BaroquenChord>>(), Arg.Any<BaroquenChord>())
             .Returns(bridgingChords);
 
         _mockCompositionStrategy.GetPossibleChordChoices(Arg.Any<IReadOnlyList<BaroquenChord>>())
-            .Returns([new ChordChoice([new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 1)])]);
+            .Returns([new ChordChoice([new NoteChoice(Voice.One, NoteMotion.Oblique, 1)])]);
 
         _mockChordNumberIdentifier.IdentifyChordNumber(Arg.Any<BaroquenChord>())
             .Returns(ChordNumber.V, ChordNumber.V, ChordNumber.V, ChordNumber.I);
@@ -79,7 +79,7 @@ internal sealed class EndingComposerTests
         // arrange
         var composition = CreateTestComposition();
         var theme = CreateTestTheme();
-        var bridgingChords = new List<BaroquenChord> { new([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)]) };
+        var bridgingChords = new List<BaroquenChord> { new([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)]) };
 
         _mockCompositionStrategy.GetPossibleChordsForPartiallyVoicedChords(Arg.Any<IReadOnlyList<BaroquenChord>>(), Arg.Any<BaroquenChord>())
             .Returns([], bridgingChords);
@@ -95,10 +95,10 @@ internal sealed class EndingComposerTests
 
         var fallbackChordChoice = new ChordChoice(
         [
-            new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 1),
-            new NoteChoice(Voice.Alto, NoteMotion.Oblique, 1),
-            new NoteChoice(Voice.Tenor, NoteMotion.Oblique, 1),
-            new NoteChoice(Voice.Bass, NoteMotion.Oblique, 1)
+            new NoteChoice(Voice.One, NoteMotion.Oblique, 1),
+            new NoteChoice(Voice.Two, NoteMotion.Oblique, 1),
+            new NoteChoice(Voice.Three, NoteMotion.Oblique, 1),
+            new NoteChoice(Voice.Four, NoteMotion.Oblique, 1)
         ]);
 
         _mockCompositionStrategy.GetPossibleChordChoices(Arg.Any<IReadOnlyList<BaroquenChord>>())
@@ -124,7 +124,7 @@ internal sealed class EndingComposerTests
             .Returns([]);
 
         _mockCompositionStrategy.GetPossibleChordChoices(Arg.Any<IReadOnlyList<BaroquenChord>>())
-            .Returns([new ChordChoice([new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0)])]);
+            .Returns([new ChordChoice([new NoteChoice(Voice.One, NoteMotion.Oblique, 0)])]);
 
         _mockChordNumberIdentifier.IdentifyChordNumber(Arg.Any<BaroquenChord>())
             .Returns(ChordNumber.V, ChordNumber.V);
@@ -138,14 +138,14 @@ internal sealed class EndingComposerTests
 
     private static Composition CreateTestComposition()
     {
-        var measure = new Measure([new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)]))], Meter.FourFour);
+        var measure = new Measure([new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)]))], Meter.FourFour);
 
         return new Composition([measure]);
     }
 
     private static BaroquenTheme CreateTestTheme()
     {
-        var measure = new Measure([new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)]))], Meter.FourFour);
+        var measure = new Measure([new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)]))], Meter.FourFour);
 
         return new BaroquenTheme([measure], [measure]);
     }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ThemeComposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ThemeComposerTests.cs
@@ -51,10 +51,10 @@ internal sealed class ThemeComposerTests
     {
         // arrange
         var mockBaroquenChord = new BaroquenChord([
-            new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-            new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half),
-            new BaroquenNote(Voice.Tenor, Notes.G2, MusicalTimeSpan.Half),
-            new BaroquenNote(Voice.Bass, Notes.C1, MusicalTimeSpan.Half)
+            new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+            new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half),
+            new BaroquenNote(Voice.Three, Notes.G2, MusicalTimeSpan.Half),
+            new BaroquenNote(Voice.Four, Notes.C1, MusicalTimeSpan.Half)
         ]);
 
         _mockCompositionStrategy.GenerateInitialChord().Returns(mockBaroquenChord);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/CompositionConfigurationTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/CompositionConfigurationTests.cs
@@ -23,10 +23,10 @@ internal sealed class CompositionConfigurationTests
         _compositionConfiguration = new CompositionConfiguration(
             new HashSet<VoiceConfiguration>
             {
-                new(Voice.Soprano, MinSopranoPitch.ToNote(), MaxSopranoPitch.ToNote()),
-                new(Voice.Alto, 48.ToNote(), 60.ToNote()),
-                new(Voice.Tenor, 36.ToNote(), 48.ToNote()),
-                new(Voice.Bass, 24.ToNote(), 36.ToNote())
+                new(Voice.One, MinSopranoPitch.ToNote(), MaxSopranoPitch.ToNote()),
+                new(Voice.Two, 48.ToNote(), 60.ToNote()),
+                new(Voice.Three, 36.ToNote(), 48.ToNote()),
+                new(Voice.Four, 24.ToNote(), 36.ToNote())
             },
             PhrasingConfiguration.Default,
             AggregateCompositionRuleConfiguration.Default,
@@ -39,12 +39,12 @@ internal sealed class CompositionConfigurationTests
     }
 
     [Test]
-    [TestCase(Voice.Soprano, MaxSopranoPitch + 1, false)]
-    [TestCase(Voice.Soprano, MinSopranoPitch - 1, false)]
-    [TestCase(Voice.Soprano, MaxSopranoPitch, true)]
-    [TestCase(Voice.Soprano, MinSopranoPitch, true)]
-    [TestCase(Voice.Soprano, MaxSopranoPitch - 1, true)]
-    [TestCase(Voice.Soprano, MinSopranoPitch + 1, true)]
+    [TestCase(Voice.One, MaxSopranoPitch + 1, false)]
+    [TestCase(Voice.One, MinSopranoPitch - 1, false)]
+    [TestCase(Voice.One, MaxSopranoPitch, true)]
+    [TestCase(Voice.One, MinSopranoPitch, true)]
+    [TestCase(Voice.One, MaxSopranoPitch - 1, true)]
+    [TestCase(Voice.One, MinSopranoPitch + 1, true)]
     public void IsPitchInVoiceRange_returns_expected_result(
         Voice voice,
         byte pitch,

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BaroquenChordTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BaroquenChordTests.cs
@@ -26,7 +26,7 @@ internal sealed class BaroquenChordTests
     public void GetHashCode_throws_InvalidOperationException()
     {
         // arrange
-        var chord = new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C1, MusicalTimeSpan.Half)]);
+        var chord = new BaroquenChord([new BaroquenNote(Voice.One, Notes.C1, MusicalTimeSpan.Half)]);
 
         // act
         var act = () => chord.GetHashCode();
@@ -50,13 +50,13 @@ internal sealed class BaroquenChordTests
     public void ResetOrnamentation_resets_ornamentation()
     {
         // arrange
-        var sopranoC1 = new BaroquenNote(Voice.Soprano, Notes.C1, MusicalTimeSpan.Half)
+        var sopranoC1 = new BaroquenNote(Voice.One, Notes.C1, MusicalTimeSpan.Half)
         {
             OrnamentationType = OrnamentationType.PassingTone,
-            Ornamentations = { new BaroquenNote(Voice.Soprano, Notes.C2, MusicalTimeSpan.Half) }
+            Ornamentations = { new BaroquenNote(Voice.One, Notes.C2, MusicalTimeSpan.Half) }
         };
 
-        var altoE1 = new BaroquenNote(Voice.Alto, Notes.E1, MusicalTimeSpan.Half);
+        var altoE1 = new BaroquenNote(Voice.Two, Notes.E1, MusicalTimeSpan.Half);
         var cMajor = new BaroquenChord([sopranoC1, altoE1]);
 
         // act
@@ -65,8 +65,8 @@ internal sealed class BaroquenChordTests
         // assert
         cMajor.Notes.Should().BeEquivalentTo(new[]
         {
-            new BaroquenNote(Voice.Soprano, Notes.C1, MusicalTimeSpan.Half),
-            new BaroquenNote(Voice.Alto, Notes.E1, MusicalTimeSpan.Half)
+            new BaroquenNote(Voice.One, Notes.C1, MusicalTimeSpan.Half),
+            new BaroquenNote(Voice.Two, Notes.E1, MusicalTimeSpan.Half)
         });
     }
 
@@ -74,16 +74,16 @@ internal sealed class BaroquenChordTests
     {
         get
         {
-            var sopranoC1 = new BaroquenNote(Voice.Soprano, Notes.C1, MusicalTimeSpan.Half);
-            var altoE1 = new BaroquenNote(Voice.Alto, Notes.E1, MusicalTimeSpan.Half);
+            var sopranoC1 = new BaroquenNote(Voice.One, Notes.C1, MusicalTimeSpan.Half);
+            var altoE1 = new BaroquenNote(Voice.Two, Notes.E1, MusicalTimeSpan.Half);
 
             var cMajor = new BaroquenChord([sopranoC1, altoE1]);
 
-            yield return new TestCaseData(cMajor, Voice.Soprano, true).SetName("Chord contains soprano voice");
+            yield return new TestCaseData(cMajor, Voice.One, true).SetName("Chord contains soprano voice");
 
-            yield return new TestCaseData(cMajor, Voice.Alto, true).SetName("Chord contains alto voice");
+            yield return new TestCaseData(cMajor, Voice.Two, true).SetName("Chord contains alto voice");
 
-            yield return new TestCaseData(cMajor, Voice.Tenor, false).SetName("Chord does not contain tenor voice");
+            yield return new TestCaseData(cMajor, Voice.Three, false).SetName("Chord does not contain tenor voice");
         }
     }
 
@@ -91,20 +91,20 @@ internal sealed class BaroquenChordTests
     {
         get
         {
-            var sopranoC1 = new BaroquenNote(Voice.Soprano, Notes.C1, MusicalTimeSpan.Half);
-            var altoE1 = new BaroquenNote(Voice.Alto, Notes.E1, MusicalTimeSpan.Half);
+            var sopranoC1 = new BaroquenNote(Voice.One, Notes.C1, MusicalTimeSpan.Half);
+            var altoE1 = new BaroquenNote(Voice.Two, Notes.E1, MusicalTimeSpan.Half);
 
             var cMajor = new BaroquenChord([sopranoC1, altoE1]);
             var identicalCMajor = new BaroquenChord([sopranoC1, altoE1]);
 
-            var sopranoD1 = new BaroquenNote(Voice.Soprano, Notes.D1, MusicalTimeSpan.Half);
-            var altoF1 = new BaroquenNote(Voice.Alto, Notes.F1, MusicalTimeSpan.Half);
+            var sopranoD1 = new BaroquenNote(Voice.One, Notes.D1, MusicalTimeSpan.Half);
+            var altoF1 = new BaroquenNote(Voice.Two, Notes.F1, MusicalTimeSpan.Half);
 
             var dMinor = new BaroquenChord([sopranoD1, altoF1]);
 
-            var sopranoC1WithOrnamentation = new BaroquenNote(Voice.Soprano, Notes.C1, MusicalTimeSpan.Half)
+            var sopranoC1WithOrnamentation = new BaroquenNote(Voice.One, Notes.C1, MusicalTimeSpan.Half)
             {
-                Ornamentations = { new BaroquenNote(Voice.Soprano, Notes.C2, MusicalTimeSpan.Half) }
+                Ornamentations = { new BaroquenNote(Voice.One, Notes.C2, MusicalTimeSpan.Half) }
             };
 
             var cMajorWithOrnamentation = new BaroquenChord([sopranoC1WithOrnamentation, altoE1]);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BaroquenNoteTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BaroquenNoteTests.cs
@@ -25,7 +25,7 @@ internal sealed class BaroquenNoteTests
     public void GetHashCode_throws_InvalidOperationException()
     {
         // arrange
-        var note = new BaroquenNote(Voice.Soprano, Notes.C1, MusicalTimeSpan.Half);
+        var note = new BaroquenNote(Voice.One, Notes.C1, MusicalTimeSpan.Half);
 
         // act
         var act = () => note.GetHashCode();
@@ -47,9 +47,9 @@ internal sealed class BaroquenNoteTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var sopranoC3 = new BaroquenNote(Voice.Soprano, Notes.C3, MusicalTimeSpan.Half);
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var sopranoC3 = new BaroquenNote(Voice.One, Notes.C3, MusicalTimeSpan.Half);
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half);
 
             yield return new TestCaseData(sopranoC4, sopranoD4, false).SetName("C4 is less than D4");
 
@@ -63,19 +63,19 @@ internal sealed class BaroquenNoteTests
     {
         get
         {
-            var note = new BaroquenNote(Voice.Soprano, Notes.C1, MusicalTimeSpan.Half);
-            var identicalNote = new BaroquenNote(Voice.Soprano, Notes.C1, MusicalTimeSpan.Half);
-            var noteWithDifferentPitch = new BaroquenNote(Voice.Soprano, Notes.D1, MusicalTimeSpan.Half);
-            var noteWithDifferentVoice = new BaroquenNote(Voice.Alto, Notes.C1, MusicalTimeSpan.Half);
+            var note = new BaroquenNote(Voice.One, Notes.C1, MusicalTimeSpan.Half);
+            var identicalNote = new BaroquenNote(Voice.One, Notes.C1, MusicalTimeSpan.Half);
+            var noteWithDifferentPitch = new BaroquenNote(Voice.One, Notes.D1, MusicalTimeSpan.Half);
+            var noteWithDifferentVoice = new BaroquenNote(Voice.Two, Notes.C1, MusicalTimeSpan.Half);
 
-            var noteWithDifferentMusicalTimeSpan = new BaroquenNote(Voice.Soprano, Notes.C1, MusicalTimeSpan.Half)
+            var noteWithDifferentMusicalTimeSpan = new BaroquenNote(Voice.One, Notes.C1, MusicalTimeSpan.Half)
             {
                 MusicalTimeSpan = note.MusicalTimeSpan.Triplet()
             };
 
-            var noteWithOrnamentation = new BaroquenNote(Voice.Soprano, Notes.C1, MusicalTimeSpan.Half)
+            var noteWithOrnamentation = new BaroquenNote(Voice.One, Notes.C1, MusicalTimeSpan.Half)
             {
-                Ornamentations = { new BaroquenNote(Voice.Soprano, Notes.C2, MusicalTimeSpan.Half) }
+                Ornamentations = { new BaroquenNote(Voice.One, Notes.C2, MusicalTimeSpan.Half) }
             };
 
             BaroquenNote? nullNote = null;

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BeatTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BeatTests.cs
@@ -26,14 +26,14 @@ internal sealed class BeatTests
         get
         {
             yield return new TestCaseData(
-                new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C1, MusicalTimeSpan.Half)])),
-                Voice.Soprano,
+                new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C1, MusicalTimeSpan.Half)])),
+                Voice.One,
                 true
             );
 
             yield return new TestCaseData(
-                new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C1, MusicalTimeSpan.Half)])),
-                Voice.Alto,
+                new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C1, MusicalTimeSpan.Half)])),
+                Voice.Two,
                 false
             );
         }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Enums/Extensions/NoteMotionExtensionsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Enums/Extensions/NoteMotionExtensionsTests.cs
@@ -24,32 +24,32 @@ internal sealed class NoteMotionExtensionsTests
         get
         {
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.B3, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.B3, MusicalTimeSpan.Half),
                 NoteMotion.Descending
             );
 
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
                 NoteMotion.Oblique
             );
 
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.CSharp4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.CSharp4, MusicalTimeSpan.Half),
                 NoteMotion.Ascending
             );
 
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.C5, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C5, MusicalTimeSpan.Half),
                 NoteMotion.Ascending
             );
 
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.C3, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C3, MusicalTimeSpan.Half),
                 NoteMotion.Descending
             );
         }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Extensions/BaroquenNoteExtensionsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Extensions/BaroquenNoteExtensionsTests.cs
@@ -16,9 +16,9 @@ internal sealed class BaroquenNoteExtensionsTests
     public void ApplyNoteChoice_WhenMotionIsAscending_ThenNextNoteIsReturned()
     {
         // arrange
-        var note = new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half);
+        var note = new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half);
         var scale = BaroquenScale.Parse("C Major");
-        var noteChoice = new NoteChoice(Voice.Soprano, NoteMotion.Ascending, 2);
+        var noteChoice = new NoteChoice(Voice.One, NoteMotion.Ascending, 2);
 
         // act
         var result = note.ApplyNoteChoice(scale, noteChoice, MusicalTimeSpan.Half);
@@ -31,9 +31,9 @@ internal sealed class BaroquenNoteExtensionsTests
     public void ApplyNoteChoice_WhenMotionIsDescending_ThenNextNoteIsReturned()
     {
         // arrange
-        var note = new BaroquenNote(Voice.Soprano, Notes.C5, MusicalTimeSpan.Half);
+        var note = new BaroquenNote(Voice.One, Notes.C5, MusicalTimeSpan.Half);
         var scale = BaroquenScale.Parse("C Major");
-        var noteChoice = new NoteChoice(Voice.Soprano, NoteMotion.Descending, 2);
+        var noteChoice = new NoteChoice(Voice.One, NoteMotion.Descending, 2);
 
         // act
         var result = note.ApplyNoteChoice(scale, noteChoice, MusicalTimeSpan.Half);
@@ -46,9 +46,9 @@ internal sealed class BaroquenNoteExtensionsTests
     public void ApplyNoteChoice_WhenMotionIsOblique_ThenNextNoteIsReturned()
     {
         // arrange
-        var note = new BaroquenNote(Voice.Soprano, Notes.C5, MusicalTimeSpan.Half);
+        var note = new BaroquenNote(Voice.One, Notes.C5, MusicalTimeSpan.Half);
         var scale = BaroquenScale.Parse("C Major");
-        var noteChoice = new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0);
+        var noteChoice = new NoteChoice(Voice.One, NoteMotion.Oblique, 0);
 
         // act
         var result = note.ApplyNoteChoice(scale, noteChoice, MusicalTimeSpan.Half);
@@ -61,9 +61,9 @@ internal sealed class BaroquenNoteExtensionsTests
     public void ApplyNoteChoice_WhenMotionIsInvalid_ThenExceptionIsThrown()
     {
         // arrange
-        var note = new BaroquenNote(Voice.Soprano, Notes.C5, MusicalTimeSpan.Half);
+        var note = new BaroquenNote(Voice.One, Notes.C5, MusicalTimeSpan.Half);
         var scale = BaroquenScale.Parse("C Major");
-        var noteChoice = new NoteChoice(Voice.Soprano, (NoteMotion)99, 0);
+        var noteChoice = new NoteChoice(Voice.One, (NoteMotion)99, 0);
 
         // act
         var act = () => note.ApplyNoteChoice(scale, noteChoice, MusicalTimeSpan.Half);
@@ -76,8 +76,8 @@ internal sealed class BaroquenNoteExtensionsTests
     public void IsDissonantWith_WhenNotDissonant_IsFalse()
     {
         // arrange
-        var note = new BaroquenNote(Voice.Soprano, Notes.C5, MusicalTimeSpan.Half);
-        var otherNote = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half);
+        var note = new BaroquenNote(Voice.One, Notes.C5, MusicalTimeSpan.Half);
+        var otherNote = new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half);
 
         // act
         var result = note.IsDissonantWith(otherNote);
@@ -90,8 +90,8 @@ internal sealed class BaroquenNoteExtensionsTests
     public void IsDissonantWith_WhenDissonant_IsTrue()
     {
         // arrange
-        var note = new BaroquenNote(Voice.Soprano, Notes.C5, MusicalTimeSpan.Half);
-        var otherNote = new BaroquenNote(Voice.Soprano, Notes.B4, MusicalTimeSpan.Half);
+        var note = new BaroquenNote(Voice.One, Notes.C5, MusicalTimeSpan.Half);
+        var otherNote = new BaroquenNote(Voice.One, Notes.B4, MusicalTimeSpan.Half);
 
         // act
         var result = note.IsDissonantWith(otherNote);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Midi/MidiGeneratorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Midi/MidiGeneratorTests.cs
@@ -27,26 +27,26 @@ internal sealed class MidiGeneratorTests
     public void Generate_returns_midi_file_as_expected()
     {
         // arrange
-        var sopranoWithMidSustain = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)
+        var sopranoWithMidSustain = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)
         {
             OrnamentationType = OrnamentationType.MidSustain
         };
 
-        var altoWithRest = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half)
+        var altoWithRest = new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half)
         {
             OrnamentationType = OrnamentationType.Rest
         };
 
-        var sopranoWithPassingTone = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half)
+        var sopranoWithPassingTone = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half)
         {
             OrnamentationType = OrnamentationType.PassingTone,
-            Ornamentations = { new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half) }
+            Ornamentations = { new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half) }
         };
 
-        var altoWithDoubleTurn = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half)
+        var altoWithDoubleTurn = new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half)
         {
             OrnamentationType = OrnamentationType.DoubleTurn,
-            Ornamentations = { new BaroquenNote(Voice.Alto, Notes.B3, MusicalTimeSpan.Half), new BaroquenNote(Voice.Alto, Notes.D4, MusicalTimeSpan.Half) }
+            Ornamentations = { new BaroquenNote(Voice.Two, Notes.B3, MusicalTimeSpan.Half), new BaroquenNote(Voice.Two, Notes.D4, MusicalTimeSpan.Half) }
         };
 
         var composition = new Composition(

--- a/tests/BaroquenMelody.Library.Tests/Compositions/MusicTheory/ChordNumberIdentifierTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/MusicTheory/ChordNumberIdentifierTests.cs
@@ -32,45 +32,45 @@ internal sealed class ChordNumberIdentifierTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
-            var tenorG2 = new BaroquenNote(Voice.Tenor, Notes.G2, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half);
+            var tenorG2 = new BaroquenNote(Voice.Three, Notes.G2, MusicalTimeSpan.Half);
 
             var i = new BaroquenChord([sopranoC4, altoE3, tenorG2]);
 
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half);
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half);
-            var tenorA2 = new BaroquenNote(Voice.Tenor, Notes.A2, MusicalTimeSpan.Half);
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half);
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half);
+            var tenorA2 = new BaroquenNote(Voice.Three, Notes.A2, MusicalTimeSpan.Half);
 
             var ii = new BaroquenChord([sopranoD4, altoF3, tenorA2]);
 
-            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half);
-            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half);
-            var tenorB2 = new BaroquenNote(Voice.Tenor, Notes.B2, MusicalTimeSpan.Half);
+            var sopranoE4 = new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half);
+            var altoG3 = new BaroquenNote(Voice.Two, Notes.G3, MusicalTimeSpan.Half);
+            var tenorB2 = new BaroquenNote(Voice.Three, Notes.B2, MusicalTimeSpan.Half);
 
             var iii = new BaroquenChord([sopranoE4, altoG3, tenorB2]);
 
-            var sopranoF4 = new BaroquenNote(Voice.Soprano, Notes.F4, MusicalTimeSpan.Half);
-            var altoA3 = new BaroquenNote(Voice.Alto, Notes.A3, MusicalTimeSpan.Half);
-            var tenorC3 = new BaroquenNote(Voice.Tenor, Notes.C3, MusicalTimeSpan.Half);
+            var sopranoF4 = new BaroquenNote(Voice.One, Notes.F4, MusicalTimeSpan.Half);
+            var altoA3 = new BaroquenNote(Voice.Two, Notes.A3, MusicalTimeSpan.Half);
+            var tenorC3 = new BaroquenNote(Voice.Three, Notes.C3, MusicalTimeSpan.Half);
 
             var iv = new BaroquenChord([sopranoF4, altoA3, tenorC3]);
 
-            var sopranoG4 = new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half);
-            var altoB3 = new BaroquenNote(Voice.Alto, Notes.B3, MusicalTimeSpan.Half);
-            var tenorD3 = new BaroquenNote(Voice.Tenor, Notes.D3, MusicalTimeSpan.Half);
+            var sopranoG4 = new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half);
+            var altoB3 = new BaroquenNote(Voice.Two, Notes.B3, MusicalTimeSpan.Half);
+            var tenorD3 = new BaroquenNote(Voice.Three, Notes.D3, MusicalTimeSpan.Half);
 
             var v = new BaroquenChord([sopranoG4, altoB3, tenorD3]);
 
-            var sopranoA4 = new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half);
-            var altoC4 = new BaroquenNote(Voice.Alto, Notes.C4, MusicalTimeSpan.Half);
-            var tenorE3 = new BaroquenNote(Voice.Tenor, Notes.E3, MusicalTimeSpan.Half);
+            var sopranoA4 = new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half);
+            var altoC4 = new BaroquenNote(Voice.Two, Notes.C4, MusicalTimeSpan.Half);
+            var tenorE3 = new BaroquenNote(Voice.Three, Notes.E3, MusicalTimeSpan.Half);
 
             var vi = new BaroquenChord([sopranoA4, altoC4, tenorE3]);
 
-            var sopranoB4 = new BaroquenNote(Voice.Soprano, Notes.B4, MusicalTimeSpan.Half);
-            var altoD4 = new BaroquenNote(Voice.Alto, Notes.D4, MusicalTimeSpan.Half);
-            var tenorF3 = new BaroquenNote(Voice.Tenor, Notes.F3, MusicalTimeSpan.Half);
+            var sopranoB4 = new BaroquenNote(Voice.One, Notes.B4, MusicalTimeSpan.Half);
+            var altoD4 = new BaroquenNote(Voice.Two, Notes.D4, MusicalTimeSpan.Half);
+            var tenorF3 = new BaroquenNote(Voice.Three, Notes.F3, MusicalTimeSpan.Half);
 
             var vii = new BaroquenChord([sopranoB4, altoD4, tenorF3]);
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/MusicTheory/Enums/Extensions/IntervalExtensionsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/MusicTheory/Enums/Extensions/IntervalExtensionsTests.cs
@@ -22,92 +22,92 @@ internal sealed class IntervalExtensionsTests
         get
         {
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.B3, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.B3, MusicalTimeSpan.Half),
                 Interval.MajorSeventh
             );
 
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
                 Interval.Unison
             );
 
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.CSharp4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.CSharp4, MusicalTimeSpan.Half),
                 Interval.MinorSecond
             );
 
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half),
                 Interval.MajorSecond
             );
 
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.DSharp4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.DSharp4, MusicalTimeSpan.Half),
                 Interval.MinorThird
             );
 
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half),
                 Interval.MajorThird
             );
 
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.F4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.F4, MusicalTimeSpan.Half),
                 Interval.PerfectFourth
             );
 
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.FSharp4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.FSharp4, MusicalTimeSpan.Half),
                 Interval.Tritone
             );
 
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half),
                 Interval.PerfectFifth
             );
 
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.GSharp4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.GSharp4, MusicalTimeSpan.Half),
                 Interval.MinorSixth
             );
 
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half),
                 Interval.MajorSixth
             );
 
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.ASharp4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.ASharp4, MusicalTimeSpan.Half),
                 Interval.MinorSeventh
             );
 
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.B4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.B4, MusicalTimeSpan.Half),
                 Interval.MajorSeventh
             );
 
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.C5, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C5, MusicalTimeSpan.Half),
                 Interval.Unison
             );
 
             yield return new TestCaseData(
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Soprano, Notes.CSharp5, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.One, Notes.CSharp5, MusicalTimeSpan.Half),
                 Interval.MinorSecond
             );
         }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/MusicTheory/NoteTransposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/MusicTheory/NoteTransposerTests.cs
@@ -29,33 +29,33 @@ internal sealed class NoteTransposerTests
         // arrange
         var notesToTranspose = new List<BaroquenNote>
         {
-            new(Voice.Soprano, Notes.C4, MusicalTimeSpan.Eighth)
+            new(Voice.One, Notes.C4, MusicalTimeSpan.Eighth)
             {
                 OrnamentationType = OrnamentationType.PassingTone,
                 Ornamentations =
                 {
-                    new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Eighth)
+                    new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Eighth)
                     {
                         OrnamentationType = OrnamentationType.PassingTone
                     }
                 }
             },
-            new(Voice.Soprano, Notes.E4, MusicalTimeSpan.Eighth)
+            new(Voice.One, Notes.E4, MusicalTimeSpan.Eighth)
             {
                 OrnamentationType = OrnamentationType.PassingTone,
                 Ornamentations =
                 {
-                    new BaroquenNote(Voice.Soprano, Notes.F4, MusicalTimeSpan.Eighth)
+                    new BaroquenNote(Voice.One, Notes.F4, MusicalTimeSpan.Eighth)
                     {
                         OrnamentationType = OrnamentationType.PassingTone
                     }
                 }
             },
-            new(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half)
+            new(Voice.One, Notes.G4, MusicalTimeSpan.Half)
             {
                 OrnamentationType = OrnamentationType.None
             },
-            new(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)
+            new(Voice.One, Notes.C4, MusicalTimeSpan.Half)
             {
                 OrnamentationType = OrnamentationType.None
             }
@@ -63,40 +63,40 @@ internal sealed class NoteTransposerTests
 
         var expectedNotes = new List<BaroquenNote>
         {
-            new(Voice.Alto, Notes.G2, MusicalTimeSpan.Eighth)
+            new(Voice.Two, Notes.G2, MusicalTimeSpan.Eighth)
             {
                 OrnamentationType = OrnamentationType.PassingTone,
                 Ornamentations =
                 {
-                    new BaroquenNote(Voice.Alto, Notes.A2, MusicalTimeSpan.Eighth)
+                    new BaroquenNote(Voice.Two, Notes.A2, MusicalTimeSpan.Eighth)
                     {
                         OrnamentationType = OrnamentationType.PassingTone
                     }
                 }
             },
-            new(Voice.Alto, Notes.B2, MusicalTimeSpan.Eighth)
+            new(Voice.Two, Notes.B2, MusicalTimeSpan.Eighth)
             {
                 OrnamentationType = OrnamentationType.PassingTone,
                 Ornamentations =
                 {
-                    new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Eighth)
+                    new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Eighth)
                     {
                         OrnamentationType = OrnamentationType.PassingTone
                     }
                 }
             },
-            new(Voice.Alto, Notes.D3, MusicalTimeSpan.Half)
+            new(Voice.Two, Notes.D3, MusicalTimeSpan.Half)
             {
                 OrnamentationType = OrnamentationType.None
             },
-            new(Voice.Alto, Notes.G2, MusicalTimeSpan.Half)
+            new(Voice.Two, Notes.G2, MusicalTimeSpan.Half)
             {
                 OrnamentationType = OrnamentationType.None
             }
         };
 
         // act
-        var transposedNotes = _noteTransposer.TransposeToVoice(notesToTranspose, Voice.Soprano, Voice.Alto).ToList();
+        var transposedNotes = _noteTransposer.TransposeToVoice(notesToTranspose, Voice.One, Voice.Two).ToList();
 
         // assert
         transposedNotes.Should().HaveCount(expectedNotes.Count);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/FourFourOrnamentationCleaningEngineBuilderTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/FourFourOrnamentationCleaningEngineBuilderTests.cs
@@ -209,8 +209,8 @@ internal sealed class FourFourOrnamentationCleaningEngineBuilderTests
     {
         // arrange
         var ornamentationCleaningItem = new OrnamentationCleaningItem(
-            new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half) { OrnamentationType = ornamentationTypeA },
-            new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half) { OrnamentationType = ornamentationTypeB }
+            new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half) { OrnamentationType = ornamentationTypeA },
+            new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half) { OrnamentationType = ornamentationTypeB }
         );
 
         var ornamentationCleaningEngine = _fourFourOrnamentationCleaningEngineBuilder.Build();

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Policies/Input/HasTargetOrnamentationsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Policies/Input/HasTargetOrnamentationsTests.cs
@@ -29,8 +29,8 @@ internal sealed class HasTargetOrnamentationsTests
     {
         // arrange
         var item = new OrnamentationCleaningItem(
-            new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half) { OrnamentationType = noteOrnamentationType },
-            new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half) { OrnamentationType = otherNoteOrnamentationType }
+            new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half) { OrnamentationType = noteOrnamentationType },
+            new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half) { OrnamentationType = otherNoteOrnamentationType }
         );
 
         var policy = new HasTargetOrnamentations(targetOrnamentationType, otherTargetOrnamentationType);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/MordentEighthNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/MordentEighthNoteOrnamentationCleanerTests.cs
@@ -38,13 +38,13 @@ internal sealed class MordentEighthNoteOrnamentationCleanerTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half);
 
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half);
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
-            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half);
-            var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half);
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half);
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half);
+            var altoD3 = new BaroquenNote(Voice.Two, Notes.D3, MusicalTimeSpan.Half);
+            var altoC3 = new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half);
 
             var sopranoC4WithMordent = new BaroquenNote(sopranoC4)
             {

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/QuarterEighthNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/QuarterEighthNoteOrnamentationCleanerTests.cs
@@ -38,15 +38,15 @@ internal sealed class QuarterEighthNoteOrnamentationCleanerTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half);
-            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half);
+            var sopranoE4 = new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half);
 
-            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half);
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half);
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
-            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half);
-            var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half);
+            var altoG3 = new BaroquenNote(Voice.Two, Notes.G3, MusicalTimeSpan.Half);
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half);
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half);
+            var altoD3 = new BaroquenNote(Voice.Two, Notes.D3, MusicalTimeSpan.Half);
+            var altoC3 = new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half);
 
             var sopranoC4WithAscendingPassingTone = new BaroquenNote(sopranoC4)
             {

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/QuarterNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/QuarterNoteOrnamentationCleanerTests.cs
@@ -38,14 +38,14 @@ internal sealed class QuarterNoteOrnamentationCleanerTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half);
-            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half);
+            var sopranoE4 = new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half);
 
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half);
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
-            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half);
-            var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half);
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half);
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half);
+            var altoD3 = new BaroquenNote(Voice.Two, Notes.D3, MusicalTimeSpan.Half);
+            var altoC3 = new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half);
 
             var sopranoC4WithAscendingPassingTone = new BaroquenNote(sopranoC4)
             {

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/SixteenthEighthNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/SixteenthEighthNoteOrnamentationCleanerTests.cs
@@ -38,16 +38,16 @@ internal sealed class SixteenthEighthNoteOrnamentationCleanerTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half);
-            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half);
-            var sopranoF4 = new BaroquenNote(Voice.Soprano, Notes.F4, MusicalTimeSpan.Half);
-            var sopranoG4 = new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half);
+            var sopranoE4 = new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half);
+            var sopranoF4 = new BaroquenNote(Voice.One, Notes.F4, MusicalTimeSpan.Half);
+            var sopranoG4 = new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half);
 
-            var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half);
-            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half);
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half);
+            var altoC3 = new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half);
+            var altoD3 = new BaroquenNote(Voice.Two, Notes.D3, MusicalTimeSpan.Half);
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half);
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half);
 
             var sopranoWithAscendingDoubleRun = new BaroquenNote(sopranoC4)
             {

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/TurnAlternateTurnOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/FourFour/TurnAlternateTurnOrnamentationCleanerTests.cs
@@ -38,16 +38,16 @@ internal sealed class TurnAlternateTurnOrnamentationCleanerTests
     {
         get
         {
-            var sopranoB3 = new BaroquenNote(Voice.Soprano, Notes.B3, MusicalTimeSpan.Half);
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half);
+            var sopranoB3 = new BaroquenNote(Voice.One, Notes.B3, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half);
 
-            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half);
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half);
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
-            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half);
-            var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half);
-            var altoB3 = new BaroquenNote(Voice.Alto, Notes.B3, MusicalTimeSpan.Half);
+            var altoG3 = new BaroquenNote(Voice.Two, Notes.G3, MusicalTimeSpan.Half);
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half);
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half);
+            var altoD3 = new BaroquenNote(Voice.Two, Notes.D3, MusicalTimeSpan.Half);
+            var altoC3 = new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half);
+            var altoB3 = new BaroquenNote(Voice.Two, Notes.B3, MusicalTimeSpan.Half);
 
             var sopranoC4WithDescendingTurn = new BaroquenNote(sopranoC4)
             {

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/MeterAgnostic/EighthNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/MeterAgnostic/EighthNoteOrnamentationCleanerTests.cs
@@ -41,19 +41,19 @@ internal sealed class EighthNoteOrnamentationCleanerTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half);
-            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half);
-            var sopranoF4 = new BaroquenNote(Voice.Soprano, Notes.F4, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half);
+            var sopranoE4 = new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half);
+            var sopranoF4 = new BaroquenNote(Voice.One, Notes.F4, MusicalTimeSpan.Half);
 
-            var altoD4 = new BaroquenNote(Voice.Alto, Notes.D4, MusicalTimeSpan.Half);
-            var altoC4 = new BaroquenNote(Voice.Alto, Notes.C4, MusicalTimeSpan.Half);
-            var altoB3 = new BaroquenNote(Voice.Alto, Notes.B3, MusicalTimeSpan.Half);
-            var altoA3 = new BaroquenNote(Voice.Alto, Notes.A3, MusicalTimeSpan.Half);
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half);
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
-            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half);
-            var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half);
+            var altoD4 = new BaroquenNote(Voice.Two, Notes.D4, MusicalTimeSpan.Half);
+            var altoC4 = new BaroquenNote(Voice.Two, Notes.C4, MusicalTimeSpan.Half);
+            var altoB3 = new BaroquenNote(Voice.Two, Notes.B3, MusicalTimeSpan.Half);
+            var altoA3 = new BaroquenNote(Voice.Two, Notes.A3, MusicalTimeSpan.Half);
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half);
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half);
+            var altoD3 = new BaroquenNote(Voice.Two, Notes.D3, MusicalTimeSpan.Half);
+            var altoC3 = new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half);
 
             var sopranoC4WithAscendingRun = new BaroquenNote(sopranoC4)
             {

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/MeterAgnostic/SixteenthNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/MeterAgnostic/SixteenthNoteOrnamentationCleanerTests.cs
@@ -38,17 +38,17 @@ internal sealed class SixteenthNoteOrnamentationCleanerTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half);
-            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half);
-            var sopranoF4 = new BaroquenNote(Voice.Soprano, Notes.F4, MusicalTimeSpan.Half);
-            var sopranoG4 = new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half);
+            var sopranoE4 = new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half);
+            var sopranoF4 = new BaroquenNote(Voice.One, Notes.F4, MusicalTimeSpan.Half);
+            var sopranoG4 = new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half);
 
-            var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half);
-            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half);
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half);
-            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half);
+            var altoC3 = new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half);
+            var altoD3 = new BaroquenNote(Voice.Two, Notes.D3, MusicalTimeSpan.Half);
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half);
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half);
+            var altoG3 = new BaroquenNote(Voice.Two, Notes.G3, MusicalTimeSpan.Half);
 
             var sopranoWithAscendingDoubleRun = new BaroquenNote(sopranoC4)
             {

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DelayedRunEighthOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DelayedRunEighthOrnamentationCleanerTests.cs
@@ -43,17 +43,17 @@ internal sealed class DelayedRunEighthOrnamentationCleanerTests
     {
         get
         {
-            var sopranoG4 = new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half.Dotted(1));
-            var sopranoF4 = new BaroquenNote(Voice.Soprano, Notes.F4, MusicalTimeSpan.Half.Dotted(1));
-            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half.Dotted(1));
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoG4 = new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoF4 = new BaroquenNote(Voice.One, Notes.F4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoE4 = new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
 
-            var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half.Dotted(1));
-            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half.Dotted(1));
-            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half.Dotted(1));
+            var altoC3 = new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half.Dotted(1));
+            var altoD3 = new BaroquenNote(Voice.Two, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half.Dotted(1));
+            var altoG3 = new BaroquenNote(Voice.Two, Notes.G3, MusicalTimeSpan.Half.Dotted(1));
 
             var sopranoC4WithAscendingDelayedRun = new BaroquenNote(sopranoC4)
             {

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DoublePassingToneDelayedRunOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DoublePassingToneDelayedRunOrnamentationCleanerTests.cs
@@ -43,17 +43,17 @@ internal sealed class DoublePassingToneDelayedRunOrnamentationCleanerTests
     {
         get
         {
-            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half.Dotted(1));
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoE4 = new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
 
-            var altoB2 = new BaroquenNote(Voice.Alto, Notes.B2, MusicalTimeSpan.Half.Dotted(1));
-            var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half.Dotted(1));
-            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half.Dotted(1));
-            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half.Dotted(1));
-            var altoA3 = new BaroquenNote(Voice.Alto, Notes.A3, MusicalTimeSpan.Half.Dotted(1));
+            var altoB2 = new BaroquenNote(Voice.Two, Notes.B2, MusicalTimeSpan.Half.Dotted(1));
+            var altoC3 = new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half.Dotted(1));
+            var altoD3 = new BaroquenNote(Voice.Two, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half.Dotted(1));
+            var altoG3 = new BaroquenNote(Voice.Two, Notes.G3, MusicalTimeSpan.Half.Dotted(1));
+            var altoA3 = new BaroquenNote(Voice.Two, Notes.A3, MusicalTimeSpan.Half.Dotted(1));
 
             var sopranoC4WithAscendingDoublePassingTone = new BaroquenNote(sopranoC4)
             {

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DoublePassingToneOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DoublePassingToneOrnamentationCleanerTests.cs
@@ -43,14 +43,14 @@ internal sealed class DoublePassingToneOrnamentationCleanerTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
-            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoE4 = new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half.Dotted(1));
 
-            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half.Dotted(1));
-            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half.Dotted(1));
+            var altoD3 = new BaroquenNote(Voice.Two, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half.Dotted(1));
+            var altoG3 = new BaroquenNote(Voice.Two, Notes.G3, MusicalTimeSpan.Half.Dotted(1));
 
             var sopranoC4WithAscendingDoublePassingTone = new BaroquenNote(sopranoC4)
             {

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DoublePassingToneQuarterOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/DoublePassingToneQuarterOrnamentationCleanerTests.cs
@@ -43,13 +43,13 @@ internal sealed class DoublePassingToneQuarterOrnamentationCleanerTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
-            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoE4 = new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half.Dotted(1));
 
-            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half.Dotted(1));
+            var altoD3 = new BaroquenNote(Voice.Two, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half.Dotted(1));
 
             var sopranoC4WithAscendingDoublePassingTone = new BaroquenNote(sopranoC4)
             {

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/HalfEighthNoteOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/HalfEighthNoteOrnamentationCleanerTests.cs
@@ -43,11 +43,11 @@ internal sealed class HalfEighthNoteOrnamentationCleanerTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
-            var sopranoB3 = new BaroquenNote(Voice.Soprano, Notes.B3, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoB3 = new BaroquenNote(Voice.One, Notes.B3, MusicalTimeSpan.Half.Dotted(1));
 
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
-            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
+            var altoD3 = new BaroquenNote(Voice.Two, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
 
             var sopranoC4WithDelayedRepeatedNote = new BaroquenNote(sopranoC4)
             {

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/HalfQuarterEighthOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/HalfQuarterEighthOrnamentationCleanerTests.cs
@@ -43,15 +43,15 @@ internal sealed class HalfQuarterEighthOrnamentationCleanerTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
-            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoE4 = new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half.Dotted(1));
 
-            var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half.Dotted(1));
-            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half.Dotted(1));
-            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half.Dotted(1));
+            var altoC3 = new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half.Dotted(1));
+            var altoD3 = new BaroquenNote(Voice.Two, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half.Dotted(1));
+            var altoG3 = new BaroquenNote(Voice.Two, Notes.G3, MusicalTimeSpan.Half.Dotted(1));
 
             var sopranoC4WithAscendingPassingTone = new BaroquenNote(sopranoC4)
             {

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/HalfQuarterOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/HalfQuarterOrnamentationCleanerTests.cs
@@ -43,13 +43,13 @@ internal sealed class HalfQuarterOrnamentationCleanerTests
     {
         get
         {
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
-            var sopranoB3 = new BaroquenNote(Voice.Soprano, Notes.B3, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoB3 = new BaroquenNote(Voice.One, Notes.B3, MusicalTimeSpan.Half.Dotted(1));
 
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
-            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
-            var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half.Dotted(1));
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
+            var altoD3 = new BaroquenNote(Voice.Two, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
+            var altoC3 = new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half.Dotted(1));
 
             var sopranoC4WithRepeatedNote = new BaroquenNote(sopranoC4)
             {

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/QuarterQuarterEighthOrnamentationCleanerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/Processors/ThreeFour/QuarterQuarterEighthOrnamentationCleanerTests.cs
@@ -43,15 +43,15 @@ internal sealed class QuarterQuarterEighthOrnamentationCleanerTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
-            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half.Dotted(1));
+            var sopranoE4 = new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half.Dotted(1));
 
-            var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half.Dotted(1));
-            var altoD3 = new BaroquenNote(Voice.Alto, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half.Dotted(1));
-            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half.Dotted(1));
+            var altoC3 = new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half.Dotted(1));
+            var altoD3 = new BaroquenNote(Voice.Two, Notes.D3, MusicalTimeSpan.Half.Dotted(1));
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half.Dotted(1));
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half.Dotted(1));
+            var altoG3 = new BaroquenNote(Voice.Two, Notes.G3, MusicalTimeSpan.Half.Dotted(1));
 
             var sopranoC4WithAscendingDoublePassingTone = new BaroquenNote(sopranoC4)
             {

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/ThreeFourOrnamentationCleaningEngineBuilderTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Cleaning/Engine/ThreeFourOrnamentationCleaningEngineBuilderTests.cs
@@ -172,8 +172,8 @@ internal sealed class ThreeFourOrnamentationCleaningEngineBuilderTests
     {
         // arrange
         var ornamentationCleaningItem = new OrnamentationCleaningItem(
-            new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half) { OrnamentationType = ornamentationTypeA },
-            new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half) { OrnamentationType = ornamentationTypeB }
+            new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half) { OrnamentationType = ornamentationTypeA },
+            new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half) { OrnamentationType = ornamentationTypeB }
         );
 
         var ornamentationCleaningEngine = _threeFourOrnamentationCleaningEngineBuilder.Build();

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/CompositionDecoratorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/CompositionDecoratorTests.cs
@@ -36,29 +36,29 @@ internal sealed class CompositionDecoratorTests
         // arrange
         var chordA = new BaroquenChord(
             [
-                new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half)
+                new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half)
             ]
         );
 
         var chordB = new BaroquenChord(
             [
-                new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half)
+                new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half)
             ]
         );
 
         var chordC = new BaroquenChord(
             [
-                new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half)
+                new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half)
             ]
         );
 
         var chordD = new BaroquenChord(
             [
-                new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half)
+                new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half)
             ]
         );
 
@@ -90,29 +90,29 @@ internal sealed class CompositionDecoratorTests
         // arrange
         var chordA = new BaroquenChord(
             [
-                new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half)
+                new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half)
             ]
         );
 
         var chordB = new BaroquenChord(
             [
-                new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half)
+                new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half)
             ]
         );
 
         var chordC = new BaroquenChord(
             [
-                new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half)
+                new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half)
             ]
         );
 
         var chordD = new BaroquenChord(
             [
-                new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half)
+                new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half)
             ]
         );
 
@@ -131,7 +131,7 @@ internal sealed class CompositionDecoratorTests
         );
 
         // act
-        _compositionDecorator.Decorate(composition, Voice.Soprano);
+        _compositionDecorator.Decorate(composition, Voice.One);
 
         // assert
         _mockOrnamentationEngine.ReceivedWithAnyArgs(4).Process(Arg.Any<OrnamentationItem>());
@@ -144,29 +144,29 @@ internal sealed class CompositionDecoratorTests
         // arrange
         var chordA = new BaroquenChord(
             [
-                new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half)
+                new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half)
             ]
         );
 
         var chordB = new BaroquenChord(
             [
-                new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half)
+                new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half)
             ]
         );
 
         var chordC = new BaroquenChord(
             [
-                new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half)
+                new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half)
             ]
         );
 
         var chordD = new BaroquenChord(
             [
-                new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half)
+                new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half)
             ]
         );
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/HasNextBeatTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/HasNextBeatTests.cs
@@ -38,9 +38,9 @@ internal sealed class HasNextBeatTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half)])),
                     null
                 ),
                 InputPolicyResult.Reject
@@ -48,10 +48,10 @@ internal sealed class HasNextBeatTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half)])),
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half)]))
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half)]))
                 ),
                 InputPolicyResult.Continue
             ).SetName($"When next beat is not null, then {nameof(InputPolicyResult.Continue)} is returned.");

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/HasOrnamentationTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/HasOrnamentationTests.cs
@@ -38,9 +38,9 @@ internal sealed class HasOrnamentationTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half)])),
                     null
                 ),
                 InputPolicyResult.Reject
@@ -48,9 +48,9 @@ internal sealed class HasOrnamentationTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half) { Ornamentations = { new BaroquenNote(Voice.Soprano, Notes.G2, MusicalTimeSpan.Half) } }])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half) { Ornamentations = { new BaroquenNote(Voice.One, Notes.G2, MusicalTimeSpan.Half) } }])),
                     null
                 ),
                 InputPolicyResult.Continue

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/HasTargetNotesTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/HasTargetNotesTests.cs
@@ -38,9 +38,9 @@ internal sealed class HasTargetNotesTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Alto, Notes.B4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Bass, Notes.D4, MusicalTimeSpan.Half)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Two, Notes.B4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Four, Notes.D4, MusicalTimeSpan.Half)])),
                     null
                 ),
                 InputPolicyResult.Continue
@@ -48,9 +48,9 @@ internal sealed class HasTargetNotesTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Alto, Notes.B4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Tenor, Notes.E4, MusicalTimeSpan.Half)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Two, Notes.B4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Three, Notes.E4, MusicalTimeSpan.Half)])),
                     null
                 ),
                 InputPolicyResult.Reject

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/HasTargetOrnamentationTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/HasTargetOrnamentationTests.cs
@@ -37,27 +37,27 @@ internal sealed class HasTargetOrnamentationTests
         {
             var testCompositionContext = new FixedSizeList<Beat>(1);
 
-            var noteWithPassingTone = new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half)
+            var noteWithPassingTone = new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half)
             {
                 OrnamentationType = OrnamentationType.PassingTone,
-                Ornamentations = { new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half) }
+                Ornamentations = { new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half) }
             };
 
-            var noteWithDelayedPassingTone = new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half)
+            var noteWithDelayedPassingTone = new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half)
             {
                 OrnamentationType = OrnamentationType.DelayedPassingTone,
-                Ornamentations = { new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half) }
+                Ornamentations = { new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half) }
             };
 
             var noteWithoutOrnamentation = new BaroquenNote(
-                Voice.Soprano,
+                Voice.One,
                 Notes.A4,
                 MusicalTimeSpan.Half
             );
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
                     new Beat(new BaroquenChord([noteWithPassingTone])),
                     null
@@ -67,7 +67,7 @@ internal sealed class HasTargetOrnamentationTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
                     new Beat(new BaroquenChord([noteWithDelayedPassingTone])),
                     null
@@ -77,7 +77,7 @@ internal sealed class HasTargetOrnamentationTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
                     new Beat(new BaroquenChord([noteWithoutOrnamentation])),
                     null

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsApplicableIntervalTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsApplicableIntervalTests.cs
@@ -44,29 +44,29 @@ internal sealed class IsApplicableIntervalTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half)])),
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.F4, MusicalTimeSpan.Half)]))
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.F4, MusicalTimeSpan.Half)]))
                 ),
                 InputPolicyResult.Continue
             ).SetName($"When notes are a third apart, then {nameof(InputPolicyResult.Continue)} is returned.");
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half)])),
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half)]))
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half)]))
                 ),
                 InputPolicyResult.Reject
             ).SetName($"When notes are not a third apart, then {nameof(InputPolicyResult.Reject)} is returned.");
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half)])),
                     null
                 ),
                 InputPolicyResult.Reject

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsFifthOfChordTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsFifthOfChordTests.cs
@@ -43,45 +43,45 @@ internal sealed class IsFifthOfChordTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
-            var tenorG2 = new BaroquenNote(Voice.Tenor, Notes.G2, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half);
+            var tenorG2 = new BaroquenNote(Voice.Three, Notes.G2, MusicalTimeSpan.Half);
 
             var i = new BaroquenChord([sopranoC4, altoE3, tenorG2]);
 
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half);
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half);
-            var tenorA2 = new BaroquenNote(Voice.Tenor, Notes.A2, MusicalTimeSpan.Half);
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half);
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half);
+            var tenorA2 = new BaroquenNote(Voice.Three, Notes.A2, MusicalTimeSpan.Half);
 
             var ii = new BaroquenChord([sopranoD4, altoF3, tenorA2]);
 
-            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half);
-            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half);
-            var tenorB2 = new BaroquenNote(Voice.Tenor, Notes.B2, MusicalTimeSpan.Half);
+            var sopranoE4 = new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half);
+            var altoG3 = new BaroquenNote(Voice.Two, Notes.G3, MusicalTimeSpan.Half);
+            var tenorB2 = new BaroquenNote(Voice.Three, Notes.B2, MusicalTimeSpan.Half);
 
             var iii = new BaroquenChord([sopranoE4, altoG3, tenorB2]);
 
-            var sopranoF4 = new BaroquenNote(Voice.Soprano, Notes.F4, MusicalTimeSpan.Half);
-            var altoA3 = new BaroquenNote(Voice.Alto, Notes.A3, MusicalTimeSpan.Half);
-            var tenorC3 = new BaroquenNote(Voice.Tenor, Notes.C3, MusicalTimeSpan.Half);
+            var sopranoF4 = new BaroquenNote(Voice.One, Notes.F4, MusicalTimeSpan.Half);
+            var altoA3 = new BaroquenNote(Voice.Two, Notes.A3, MusicalTimeSpan.Half);
+            var tenorC3 = new BaroquenNote(Voice.Three, Notes.C3, MusicalTimeSpan.Half);
 
             var iv = new BaroquenChord([sopranoF4, altoA3, tenorC3]);
 
-            var sopranoG4 = new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half);
-            var altoB3 = new BaroquenNote(Voice.Alto, Notes.B3, MusicalTimeSpan.Half);
-            var tenorD3 = new BaroquenNote(Voice.Tenor, Notes.D3, MusicalTimeSpan.Half);
+            var sopranoG4 = new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half);
+            var altoB3 = new BaroquenNote(Voice.Two, Notes.B3, MusicalTimeSpan.Half);
+            var tenorD3 = new BaroquenNote(Voice.Three, Notes.D3, MusicalTimeSpan.Half);
 
             var v = new BaroquenChord([sopranoG4, altoB3, tenorD3]);
 
-            var sopranoA4 = new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half);
-            var altoC4 = new BaroquenNote(Voice.Alto, Notes.C4, MusicalTimeSpan.Half);
-            var tenorE3 = new BaroquenNote(Voice.Tenor, Notes.E3, MusicalTimeSpan.Half);
+            var sopranoA4 = new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half);
+            var altoC4 = new BaroquenNote(Voice.Two, Notes.C4, MusicalTimeSpan.Half);
+            var tenorE3 = new BaroquenNote(Voice.Three, Notes.E3, MusicalTimeSpan.Half);
 
             var vi = new BaroquenChord([sopranoA4, altoC4, tenorE3]);
 
-            var sopranoB4 = new BaroquenNote(Voice.Soprano, Notes.B4, MusicalTimeSpan.Half);
-            var altoD4 = new BaroquenNote(Voice.Alto, Notes.D4, MusicalTimeSpan.Half);
-            var tenorF3 = new BaroquenNote(Voice.Tenor, Notes.F3, MusicalTimeSpan.Half);
+            var sopranoB4 = new BaroquenNote(Voice.One, Notes.B4, MusicalTimeSpan.Half);
+            var altoD4 = new BaroquenNote(Voice.Two, Notes.D4, MusicalTimeSpan.Half);
+            var tenorF3 = new BaroquenNote(Voice.Three, Notes.F3, MusicalTimeSpan.Half);
 
             var vii = new BaroquenChord([sopranoB4, altoD4, tenorF3]);
 
@@ -89,7 +89,7 @@ internal sealed class IsFifthOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(i),
                     null
@@ -99,7 +99,7 @@ internal sealed class IsFifthOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(ii),
                     null
@@ -109,7 +109,7 @@ internal sealed class IsFifthOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(iii),
                     null
@@ -119,7 +119,7 @@ internal sealed class IsFifthOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(iv),
                     null
@@ -129,7 +129,7 @@ internal sealed class IsFifthOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(v),
                     null
@@ -139,7 +139,7 @@ internal sealed class IsFifthOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(vi),
                     null
@@ -149,7 +149,7 @@ internal sealed class IsFifthOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(vii),
                     null
@@ -159,7 +159,7 @@ internal sealed class IsFifthOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Tenor,
+                    Voice.Three,
                     new FixedSizeList<Beat>(1),
                     new Beat(unknown),
                     null
@@ -169,7 +169,7 @@ internal sealed class IsFifthOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Tenor,
+                    Voice.Three,
                     new FixedSizeList<Beat>(1),
                     new Beat(i),
                     null
@@ -179,7 +179,7 @@ internal sealed class IsFifthOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Tenor,
+                    Voice.Three,
                     new FixedSizeList<Beat>(1),
                     new Beat(ii),
                     null
@@ -189,7 +189,7 @@ internal sealed class IsFifthOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Tenor,
+                    Voice.Three,
                     new FixedSizeList<Beat>(1),
                     new Beat(iii),
                     null
@@ -199,7 +199,7 @@ internal sealed class IsFifthOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Tenor,
+                    Voice.Three,
                     new FixedSizeList<Beat>(1),
                     new Beat(iv),
                     null
@@ -209,7 +209,7 @@ internal sealed class IsFifthOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Tenor,
+                    Voice.Three,
                     new FixedSizeList<Beat>(1),
                     new Beat(v),
                     null
@@ -219,7 +219,7 @@ internal sealed class IsFifthOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Tenor,
+                    Voice.Three,
                     new FixedSizeList<Beat>(1),
                     new Beat(vi),
                     null
@@ -229,7 +229,7 @@ internal sealed class IsFifthOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Tenor,
+                    Voice.Three,
                     new FixedSizeList<Beat>(1),
                     new Beat(vii),
                     null

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsIntervalWithinVoiceRangeTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsIntervalWithinVoiceRangeTests.cs
@@ -44,9 +44,9 @@ internal sealed class IsIntervalWithinVoiceRangeTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C5, MusicalTimeSpan.Half), new BaroquenNote(Voice.Alto, Notes.G4, MusicalTimeSpan.Half)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C5, MusicalTimeSpan.Half), new BaroquenNote(Voice.Two, Notes.G4, MusicalTimeSpan.Half)])),
                     null
                 ),
                 InputPolicyResult.Continue
@@ -54,9 +54,9 @@ internal sealed class IsIntervalWithinVoiceRangeTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C6, MusicalTimeSpan.Half), new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C6, MusicalTimeSpan.Half), new BaroquenNote(Voice.Two, Notes.G3, MusicalTimeSpan.Half)])),
                     null
                 ),
                 InputPolicyResult.Reject

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsNextNoteIntervalWithinVoiceRangeTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsNextNoteIntervalWithinVoiceRangeTests.cs
@@ -44,20 +44,20 @@ internal sealed class IsNextNoteIntervalWithinVoiceRangeTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C5, MusicalTimeSpan.Half), new BaroquenNote(Voice.Alto, Notes.G4, MusicalTimeSpan.Half)])),
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C5, MusicalTimeSpan.Half), new BaroquenNote(Voice.Alto, Notes.G4, MusicalTimeSpan.Half)]))
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C5, MusicalTimeSpan.Half), new BaroquenNote(Voice.Two, Notes.G4, MusicalTimeSpan.Half)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C5, MusicalTimeSpan.Half), new BaroquenNote(Voice.Two, Notes.G4, MusicalTimeSpan.Half)]))
                 ),
                 InputPolicyResult.Continue
             ).SetName($"When added interval is within voice range, then {nameof(InputPolicyResult.Continue)} is returned.");
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C6, MusicalTimeSpan.Half), new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half)])),
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C6, MusicalTimeSpan.Half), new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half)]))
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C6, MusicalTimeSpan.Half), new BaroquenNote(Voice.Two, Notes.G3, MusicalTimeSpan.Half)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C6, MusicalTimeSpan.Half), new BaroquenNote(Voice.Two, Notes.G3, MusicalTimeSpan.Half)]))
                 ),
                 InputPolicyResult.Reject
             ).SetName($"When added interval is not within voice range, then {nameof(InputPolicyResult.Reject)} is returned.");

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsRepeatedNoteTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsRepeatedNoteTests.cs
@@ -36,39 +36,39 @@ internal sealed class IsRepeatedNoteTests
         {
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)]))
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)]))
                 ),
                 InputPolicyResult.Continue
             ).SetName("When notes are repeated, policy continues.");
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half)]))
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half)]))
                 ),
                 InputPolicyResult.Reject
             ).SetName("When notes are not repeated, policy rejects.");
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Tenor,
+                    Voice.Three,
                     new FixedSizeList<Beat>(1),
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half)]))
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half)]))
                 ),
                 InputPolicyResult.Reject
             ).SetName("When voice is not present, policy rejects.");
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
                     null
                 ),
                 InputPolicyResult.Reject

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsRootOfChordTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsRootOfChordTests.cs
@@ -43,45 +43,45 @@ internal sealed class IsRootOfChordTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
-            var tenorG2 = new BaroquenNote(Voice.Tenor, Notes.G2, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half);
+            var tenorG2 = new BaroquenNote(Voice.Three, Notes.G2, MusicalTimeSpan.Half);
 
             var i = new BaroquenChord([sopranoC4, altoE3, tenorG2]);
 
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half);
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half);
-            var tenorA2 = new BaroquenNote(Voice.Tenor, Notes.A2, MusicalTimeSpan.Half);
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half);
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half);
+            var tenorA2 = new BaroquenNote(Voice.Three, Notes.A2, MusicalTimeSpan.Half);
 
             var ii = new BaroquenChord([sopranoD4, altoF3, tenorA2]);
 
-            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half);
-            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half);
-            var tenorB2 = new BaroquenNote(Voice.Tenor, Notes.B2, MusicalTimeSpan.Half);
+            var sopranoE4 = new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half);
+            var altoG3 = new BaroquenNote(Voice.Two, Notes.G3, MusicalTimeSpan.Half);
+            var tenorB2 = new BaroquenNote(Voice.Three, Notes.B2, MusicalTimeSpan.Half);
 
             var iii = new BaroquenChord([sopranoE4, altoG3, tenorB2]);
 
-            var sopranoF4 = new BaroquenNote(Voice.Soprano, Notes.F4, MusicalTimeSpan.Half);
-            var altoA3 = new BaroquenNote(Voice.Alto, Notes.A3, MusicalTimeSpan.Half);
-            var tenorC3 = new BaroquenNote(Voice.Tenor, Notes.C3, MusicalTimeSpan.Half);
+            var sopranoF4 = new BaroquenNote(Voice.One, Notes.F4, MusicalTimeSpan.Half);
+            var altoA3 = new BaroquenNote(Voice.Two, Notes.A3, MusicalTimeSpan.Half);
+            var tenorC3 = new BaroquenNote(Voice.Three, Notes.C3, MusicalTimeSpan.Half);
 
             var iv = new BaroquenChord([sopranoF4, altoA3, tenorC3]);
 
-            var sopranoG4 = new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half);
-            var altoB3 = new BaroquenNote(Voice.Alto, Notes.B3, MusicalTimeSpan.Half);
-            var tenorD3 = new BaroquenNote(Voice.Tenor, Notes.D3, MusicalTimeSpan.Half);
+            var sopranoG4 = new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half);
+            var altoB3 = new BaroquenNote(Voice.Two, Notes.B3, MusicalTimeSpan.Half);
+            var tenorD3 = new BaroquenNote(Voice.Three, Notes.D3, MusicalTimeSpan.Half);
 
             var v = new BaroquenChord([sopranoG4, altoB3, tenorD3]);
 
-            var sopranoA4 = new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half);
-            var altoC4 = new BaroquenNote(Voice.Alto, Notes.C4, MusicalTimeSpan.Half);
-            var tenorE3 = new BaroquenNote(Voice.Tenor, Notes.E3, MusicalTimeSpan.Half);
+            var sopranoA4 = new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half);
+            var altoC4 = new BaroquenNote(Voice.Two, Notes.C4, MusicalTimeSpan.Half);
+            var tenorE3 = new BaroquenNote(Voice.Three, Notes.E3, MusicalTimeSpan.Half);
 
             var vi = new BaroquenChord([sopranoA4, altoC4, tenorE3]);
 
-            var sopranoB4 = new BaroquenNote(Voice.Soprano, Notes.B4, MusicalTimeSpan.Half);
-            var altoD4 = new BaroquenNote(Voice.Alto, Notes.D4, MusicalTimeSpan.Half);
-            var tenorF3 = new BaroquenNote(Voice.Tenor, Notes.F3, MusicalTimeSpan.Half);
+            var sopranoB4 = new BaroquenNote(Voice.One, Notes.B4, MusicalTimeSpan.Half);
+            var altoD4 = new BaroquenNote(Voice.Two, Notes.D4, MusicalTimeSpan.Half);
+            var tenorF3 = new BaroquenNote(Voice.Three, Notes.F3, MusicalTimeSpan.Half);
 
             var vii = new BaroquenChord([sopranoB4, altoD4, tenorF3]);
 
@@ -89,7 +89,7 @@ internal sealed class IsRootOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(i),
                     null
@@ -99,7 +99,7 @@ internal sealed class IsRootOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(ii),
                     null
@@ -109,7 +109,7 @@ internal sealed class IsRootOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(iii),
                     null
@@ -119,7 +119,7 @@ internal sealed class IsRootOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(iv),
                     null
@@ -129,7 +129,7 @@ internal sealed class IsRootOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(v),
                     null
@@ -139,7 +139,7 @@ internal sealed class IsRootOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(vi),
                     null
@@ -149,7 +149,7 @@ internal sealed class IsRootOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(vii),
                     null
@@ -159,7 +159,7 @@ internal sealed class IsRootOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(unknown),
                     null
@@ -169,7 +169,7 @@ internal sealed class IsRootOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Alto,
+                    Voice.Two,
                     new FixedSizeList<Beat>(1),
                     new Beat(i),
                     null
@@ -179,7 +179,7 @@ internal sealed class IsRootOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Alto,
+                    Voice.Two,
                     new FixedSizeList<Beat>(1),
                     new Beat(ii),
                     null
@@ -189,7 +189,7 @@ internal sealed class IsRootOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Alto,
+                    Voice.Two,
                     new FixedSizeList<Beat>(1),
                     new Beat(iii),
                     null
@@ -199,7 +199,7 @@ internal sealed class IsRootOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Alto,
+                    Voice.Two,
                     new FixedSizeList<Beat>(1),
                     new Beat(iv),
                     null
@@ -209,7 +209,7 @@ internal sealed class IsRootOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Alto,
+                    Voice.Two,
                     new FixedSizeList<Beat>(1),
                     new Beat(v),
                     null
@@ -219,7 +219,7 @@ internal sealed class IsRootOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Alto,
+                    Voice.Two,
                     new FixedSizeList<Beat>(1),
                     new Beat(vi),
                     null
@@ -229,7 +229,7 @@ internal sealed class IsRootOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Alto,
+                    Voice.Two,
                     new FixedSizeList<Beat>(1),
                     new Beat(vii),
                     null

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsTargetNoteTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsTargetNoteTests.cs
@@ -36,14 +36,14 @@ internal sealed class IsTargetNoteTests
         {
             var testCompositionContext = new FixedSizeList<Beat>(1);
 
-            var sopranoNoteWithTargetNoteName = new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half);
-            var altoNoteWithTargetNoteName = new BaroquenNote(Voice.Alto, Notes.A4, MusicalTimeSpan.Half);
-            var sopranoNoteWithoutNoteName = new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half);
-            var altoNoteWithoutNoteName = new BaroquenNote(Voice.Alto, Notes.G4, MusicalTimeSpan.Half);
+            var sopranoNoteWithTargetNoteName = new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half);
+            var altoNoteWithTargetNoteName = new BaroquenNote(Voice.Two, Notes.A4, MusicalTimeSpan.Half);
+            var sopranoNoteWithoutNoteName = new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half);
+            var altoNoteWithoutNoteName = new BaroquenNote(Voice.Two, Notes.G4, MusicalTimeSpan.Half);
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
                     new Beat(new BaroquenChord([sopranoNoteWithTargetNoteName, altoNoteWithoutNoteName])),
                     null
@@ -53,7 +53,7 @@ internal sealed class IsTargetNoteTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
                     new Beat(new BaroquenChord([sopranoNoteWithoutNoteName, altoNoteWithTargetNoteName])),
                     null

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsThirdOfChordTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/IsThirdOfChordTests.cs
@@ -43,45 +43,45 @@ internal sealed class IsThirdOfChordTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
-            var tenorG2 = new BaroquenNote(Voice.Tenor, Notes.G2, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half);
+            var tenorG2 = new BaroquenNote(Voice.Three, Notes.G2, MusicalTimeSpan.Half);
 
             var i = new BaroquenChord([sopranoC4, altoE3, tenorG2]);
 
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half);
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half);
-            var tenorA2 = new BaroquenNote(Voice.Tenor, Notes.A2, MusicalTimeSpan.Half);
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half);
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half);
+            var tenorA2 = new BaroquenNote(Voice.Three, Notes.A2, MusicalTimeSpan.Half);
 
             var ii = new BaroquenChord([sopranoD4, altoF3, tenorA2]);
 
-            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half);
-            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half);
-            var tenorB2 = new BaroquenNote(Voice.Tenor, Notes.B2, MusicalTimeSpan.Half);
+            var sopranoE4 = new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half);
+            var altoG3 = new BaroquenNote(Voice.Two, Notes.G3, MusicalTimeSpan.Half);
+            var tenorB2 = new BaroquenNote(Voice.Three, Notes.B2, MusicalTimeSpan.Half);
 
             var iii = new BaroquenChord([sopranoE4, altoG3, tenorB2]);
 
-            var sopranoF4 = new BaroquenNote(Voice.Soprano, Notes.F4, MusicalTimeSpan.Half);
-            var altoA3 = new BaroquenNote(Voice.Alto, Notes.A3, MusicalTimeSpan.Half);
-            var tenorC3 = new BaroquenNote(Voice.Tenor, Notes.C3, MusicalTimeSpan.Half);
+            var sopranoF4 = new BaroquenNote(Voice.One, Notes.F4, MusicalTimeSpan.Half);
+            var altoA3 = new BaroquenNote(Voice.Two, Notes.A3, MusicalTimeSpan.Half);
+            var tenorC3 = new BaroquenNote(Voice.Three, Notes.C3, MusicalTimeSpan.Half);
 
             var iv = new BaroquenChord([sopranoF4, altoA3, tenorC3]);
 
-            var sopranoG4 = new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half);
-            var altoB3 = new BaroquenNote(Voice.Alto, Notes.B3, MusicalTimeSpan.Half);
-            var tenorD3 = new BaroquenNote(Voice.Tenor, Notes.D3, MusicalTimeSpan.Half);
+            var sopranoG4 = new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half);
+            var altoB3 = new BaroquenNote(Voice.Two, Notes.B3, MusicalTimeSpan.Half);
+            var tenorD3 = new BaroquenNote(Voice.Three, Notes.D3, MusicalTimeSpan.Half);
 
             var v = new BaroquenChord([sopranoG4, altoB3, tenorD3]);
 
-            var sopranoA4 = new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half);
-            var altoC4 = new BaroquenNote(Voice.Alto, Notes.C4, MusicalTimeSpan.Half);
-            var tenorE3 = new BaroquenNote(Voice.Tenor, Notes.E3, MusicalTimeSpan.Half);
+            var sopranoA4 = new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half);
+            var altoC4 = new BaroquenNote(Voice.Two, Notes.C4, MusicalTimeSpan.Half);
+            var tenorE3 = new BaroquenNote(Voice.Three, Notes.E3, MusicalTimeSpan.Half);
 
             var vi = new BaroquenChord([sopranoA4, altoC4, tenorE3]);
 
-            var sopranoB4 = new BaroquenNote(Voice.Soprano, Notes.B4, MusicalTimeSpan.Half);
-            var altoD4 = new BaroquenNote(Voice.Alto, Notes.D4, MusicalTimeSpan.Half);
-            var tenorF3 = new BaroquenNote(Voice.Tenor, Notes.F3, MusicalTimeSpan.Half);
+            var sopranoB4 = new BaroquenNote(Voice.One, Notes.B4, MusicalTimeSpan.Half);
+            var altoD4 = new BaroquenNote(Voice.Two, Notes.D4, MusicalTimeSpan.Half);
+            var tenorF3 = new BaroquenNote(Voice.Three, Notes.F3, MusicalTimeSpan.Half);
 
             var vii = new BaroquenChord([sopranoB4, altoD4, tenorF3]);
 
@@ -89,7 +89,7 @@ internal sealed class IsThirdOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(i),
                     null
@@ -99,7 +99,7 @@ internal sealed class IsThirdOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(ii),
                     null
@@ -109,7 +109,7 @@ internal sealed class IsThirdOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(iii),
                     null
@@ -119,7 +119,7 @@ internal sealed class IsThirdOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(iv),
                     null
@@ -129,7 +129,7 @@ internal sealed class IsThirdOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(v),
                     null
@@ -139,7 +139,7 @@ internal sealed class IsThirdOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(vi),
                     null
@@ -149,7 +149,7 @@ internal sealed class IsThirdOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     new FixedSizeList<Beat>(1),
                     new Beat(vii),
                     null
@@ -159,7 +159,7 @@ internal sealed class IsThirdOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Alto,
+                    Voice.Two,
                     new FixedSizeList<Beat>(1),
                     new Beat(unknown),
                     null
@@ -169,7 +169,7 @@ internal sealed class IsThirdOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Alto,
+                    Voice.Two,
                     new FixedSizeList<Beat>(1),
                     new Beat(i),
                     null
@@ -179,7 +179,7 @@ internal sealed class IsThirdOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Alto,
+                    Voice.Two,
                     new FixedSizeList<Beat>(1),
                     new Beat(ii),
                     null
@@ -189,7 +189,7 @@ internal sealed class IsThirdOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Alto,
+                    Voice.Two,
                     new FixedSizeList<Beat>(1),
                     new Beat(iii),
                     null
@@ -199,7 +199,7 @@ internal sealed class IsThirdOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Alto,
+                    Voice.Two,
                     new FixedSizeList<Beat>(1),
                     new Beat(iv),
                     null
@@ -209,7 +209,7 @@ internal sealed class IsThirdOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Alto,
+                    Voice.Two,
                     new FixedSizeList<Beat>(1),
                     new Beat(v),
                     null
@@ -219,7 +219,7 @@ internal sealed class IsThirdOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Alto,
+                    Voice.Two,
                     new FixedSizeList<Beat>(1),
                     new Beat(vi),
                     null
@@ -229,7 +229,7 @@ internal sealed class IsThirdOfChordTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Alto,
+                    Voice.Two,
                     new FixedSizeList<Beat>(1),
                     new Beat(vii),
                     null

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/NextBeatHasTargetNotesTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/NextBeatHasTargetNotesTests.cs
@@ -38,20 +38,20 @@ internal sealed class NextBeatHasTargetNotesTests
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Alto, Notes.B4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Bass, Notes.D4, MusicalTimeSpan.Half)])),
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Alto, Notes.B4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Bass, Notes.D4, MusicalTimeSpan.Half)]))
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Two, Notes.B4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Four, Notes.D4, MusicalTimeSpan.Half)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Two, Notes.B4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Four, Notes.D4, MusicalTimeSpan.Half)]))
                 ),
                 InputPolicyResult.Continue
             ).SetName($"When notes are G, B, and D, then {nameof(InputPolicyResult.Continue)} is returned.");
 
             yield return new TestCaseData(
                 new OrnamentationItem(
-                    Voice.Soprano,
+                    Voice.One,
                     testCompositionContext,
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Alto, Notes.B4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Tenor, Notes.E4, MusicalTimeSpan.Half)])),
-                    new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Alto, Notes.B4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Tenor, Notes.E4, MusicalTimeSpan.Half)]))
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Two, Notes.B4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Three, Notes.E4, MusicalTimeSpan.Half)])),
+                    new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Two, Notes.B4, MusicalTimeSpan.Half), new BaroquenNote(Voice.Three, Notes.E4, MusicalTimeSpan.Half)]))
                 ),
                 InputPolicyResult.Reject
             ).SetName($"When notes are G, B, and E, then {nameof(InputPolicyResult.Reject)} is returned.");

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/WantsToOrnamentTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Input/WantsToOrnamentTests.cs
@@ -23,7 +23,7 @@ internal sealed class WantsToOrnamentTests
         // arrange
         var policy = new WantsToOrnament(_weightedRandomBooleanGenerator, 101);
 
-        var ornamentationItem = new OrnamentationItem(Voice.Soprano, [], new Beat(new BaroquenChord([])), null);
+        var ornamentationItem = new OrnamentationItem(Voice.One, [], new Beat(new BaroquenChord([])), null);
 
         // act
         var result = policy.ShouldProcess(ornamentationItem);
@@ -38,7 +38,7 @@ internal sealed class WantsToOrnamentTests
         // arrange
         var policy = new WantsToOrnament(_weightedRandomBooleanGenerator, -1);
 
-        var ornamentationItem = new OrnamentationItem(Voice.Soprano, [], new Beat(new BaroquenChord([])), null);
+        var ornamentationItem = new OrnamentationItem(Voice.One, [], new Beat(new BaroquenChord([])), null);
 
         // act
         var result = policy.ShouldProcess(ornamentationItem);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Output/CleanConflictingOrnamentationsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Policies/Output/CleanConflictingOrnamentationsTests.cs
@@ -31,20 +31,20 @@ internal sealed class CleanConflictingOrnamentationsTests
     public void Apply_Invokes_Expected_Components_Expected_Number_Of_Times()
     {
         // arrange
-        var sopranoC4WithPassingTone = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)
+        var sopranoC4WithPassingTone = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)
         {
             OrnamentationType = OrnamentationType.PassingTone,
-            Ornamentations = { new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half) }
+            Ornamentations = { new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half) }
         };
 
-        var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half);
+        var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half);
 
-        var tenorA2 = new BaroquenNote(Voice.Tenor, Notes.A2, MusicalTimeSpan.Half);
+        var tenorA2 = new BaroquenNote(Voice.Three, Notes.A2, MusicalTimeSpan.Half);
 
-        var bassF1 = new BaroquenNote(Voice.Bass, Notes.F1, MusicalTimeSpan.Half);
+        var bassF1 = new BaroquenNote(Voice.Four, Notes.F1, MusicalTimeSpan.Half);
 
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
             new Beat(new BaroquenChord([sopranoC4WithPassingTone, altoF3, tenorA2, bassF1])),
             null

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/AlternateTurnProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/AlternateTurnProcessorTests.cs
@@ -31,17 +31,17 @@ internal sealed class AlternateTurnProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half)]))
         );
 
         // act
         _processor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.AlternateTurn);
         noteToAssert.Ornamentations.Should().HaveCount(3);
@@ -63,17 +63,17 @@ internal sealed class AlternateTurnProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.B3, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.B3, MusicalTimeSpan.Half)]))
         );
 
         // act
         _processor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.AlternateTurn);
         noteToAssert.Ornamentations.Should().HaveCount(3);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DecorateIntervalProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DecorateIntervalProcessorTests.cs
@@ -31,9 +31,9 @@ internal sealed class DecorateIntervalProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half)])),
             null
         );
 
@@ -41,7 +41,7 @@ internal sealed class DecorateIntervalProcessorTests
         _processor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.DecorateInterval);
         noteToAssert.Ornamentations.Should().HaveCount(3);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DelayedRunProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DelayedRunProcessorTests.cs
@@ -31,17 +31,17 @@ internal sealed class DelayedRunProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half)]))
         );
 
         // act
         _processor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.DelayedRun);
         noteToAssert.Ornamentations.Should().HaveCount(4);
@@ -64,17 +64,17 @@ internal sealed class DelayedRunProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)]))
         );
 
         // act
         _processor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.DelayedRun);
         noteToAssert.Ornamentations.Should().HaveCount(4);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DoublePassingToneProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DoublePassingToneProcessorTests.cs
@@ -31,17 +31,17 @@ internal sealed class DoublePassingToneProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half)]))
         );
 
         // act
         _processor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.DoublePassingTone);
         noteToAssert.Ornamentations.Should().HaveCount(2);
@@ -57,17 +57,17 @@ internal sealed class DoublePassingToneProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.D5, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.D5, MusicalTimeSpan.Half)]))
         );
 
         // act
         _processor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.DoublePassingTone);
         noteToAssert.Ornamentations.Should().HaveCount(2);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DoubleRunProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DoubleRunProcessorTests.cs
@@ -31,17 +31,17 @@ internal sealed class DoubleRunProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.E3, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.E3, MusicalTimeSpan.Half)]))
         );
 
         // act
         _processor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.DoubleRun);
         noteToAssert.Ornamentations.Should().HaveCount(7);
@@ -67,17 +67,17 @@ internal sealed class DoubleRunProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half)]))
         );
 
         // act
         _processor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.DoubleRun);
         noteToAssert.Ornamentations.Should().HaveCount(7);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DoubleTurnProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/DoubleTurnProcessorTests.cs
@@ -31,17 +31,17 @@ internal sealed class DoubleTurnProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A3, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A3, MusicalTimeSpan.Half)]))
         );
 
         // act
         _processor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.DoubleTurn);
         noteToAssert.Ornamentations.Should().HaveCount(7);
@@ -67,17 +67,17 @@ internal sealed class DoubleTurnProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A3, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A3, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)]))
         );
 
         // act
         _processor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.DoubleTurn);
         noteToAssert.Ornamentations.Should().HaveCount(7);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/MordentProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/MordentProcessorTests.cs
@@ -37,10 +37,10 @@ internal sealed class MordentProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.F4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.F4, MusicalTimeSpan.Half)]))
         );
 
         _mockWeightedRandomBooleanGenerator.IsTrue().Returns(true);
@@ -49,7 +49,7 @@ internal sealed class MordentProcessorTests
         _mordentProcessor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.Mordent);
         noteToAssert.MusicalTimeSpan.Should().Be(MusicalTimeSpan.Sixteenth);
@@ -67,10 +67,10 @@ internal sealed class MordentProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.F4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.F4, MusicalTimeSpan.Half)]))
         );
 
         _mockWeightedRandomBooleanGenerator.IsTrue().Returns(false);
@@ -79,7 +79,7 @@ internal sealed class MordentProcessorTests
         _mordentProcessor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.Mordent);
         noteToAssert.MusicalTimeSpan.Should().Be(MusicalTimeSpan.Sixteenth);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/NeighborToneProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/NeighborToneProcessorTests.cs
@@ -40,10 +40,10 @@ internal sealed class NeighborToneProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)]))
         );
 
         _mockMusicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(Arg.Any<OrnamentationType>(), Arg.Any<Meter>()).Returns(MusicalTimeSpan.Eighth.Dotted(1));
@@ -54,7 +54,7 @@ internal sealed class NeighborToneProcessorTests
         _neighborToneProcessor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.DelayedNeighborTone);
         noteToAssert.MusicalTimeSpan.Should().Be(MusicalTimeSpan.Eighth.Dotted(1));
@@ -68,10 +68,10 @@ internal sealed class NeighborToneProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)]))
         );
 
         _mockMusicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(Arg.Any<OrnamentationType>(), Arg.Any<Meter>()).Returns(MusicalTimeSpan.Eighth.Dotted(1));
@@ -82,7 +82,7 @@ internal sealed class NeighborToneProcessorTests
         _neighborToneProcessor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.DelayedNeighborTone);
         noteToAssert.MusicalTimeSpan.Should().Be(MusicalTimeSpan.Eighth.Dotted(1));

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/PassingToneProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/PassingToneProcessorTests.cs
@@ -31,17 +31,17 @@ internal sealed class PassingToneProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.F4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.F4, MusicalTimeSpan.Half)]))
         );
 
         // act
         _processor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.PassingTone);
         noteToAssert.Ornamentations.Should().ContainSingle();
@@ -55,17 +55,17 @@ internal sealed class PassingToneProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C5, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C5, MusicalTimeSpan.Half)]))
         );
 
         // act
         _processor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.PassingTone);
         noteToAssert.Ornamentations.Should().ContainSingle();

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/PedalProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/PedalProcessorTests.cs
@@ -53,17 +53,17 @@ internal sealed class PedalProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half)]))
         );
 
         // act
         _rootPedalProcessor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.Pedal);
         noteToAssert.Ornamentations.Should().HaveCount(3);
@@ -83,17 +83,17 @@ internal sealed class PedalProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A3, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A3, MusicalTimeSpan.Half)]))
         );
 
         // act
         _rootPedalProcessor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.Pedal);
         noteToAssert.Ornamentations.Should().HaveCount(3);
@@ -113,17 +113,17 @@ internal sealed class PedalProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half)]))
         );
 
         // act
         _thirdPedalProcessor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.Pedal);
         noteToAssert.Ornamentations.Should().HaveCount(3);
@@ -143,17 +143,17 @@ internal sealed class PedalProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)]))
         );
 
         // act
         _thirdPedalProcessor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.Pedal);
         noteToAssert.Ornamentations.Should().HaveCount(3);
@@ -173,17 +173,17 @@ internal sealed class PedalProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.B4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.B4, MusicalTimeSpan.Half)]))
         );
 
         // act
         _fifthPedalProcessor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.Pedal);
         noteToAssert.Ornamentations.Should().HaveCount(3);
@@ -203,17 +203,17 @@ internal sealed class PedalProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half)]))
         );
 
         // act
         _fifthPedalProcessor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.Pedal);
         noteToAssert.Ornamentations.Should().HaveCount(3);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/PickupProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/PickupProcessorTests.cs
@@ -36,10 +36,10 @@ internal sealed class PickupProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half)]))
         );
 
         _mockMusicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(Arg.Any<OrnamentationType>(), Arg.Any<Meter>()).Returns(MusicalTimeSpan.Quarter);
@@ -49,7 +49,7 @@ internal sealed class PickupProcessorTests
         _pickupProcessor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.Pickup);
         noteToAssert.MusicalTimeSpan.Should().Be(MusicalTimeSpan.Quarter);
@@ -62,10 +62,10 @@ internal sealed class PickupProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)]))
         );
 
         _mockMusicalTimeSpanCalculator.CalculatePrimaryNoteTimeSpan(Arg.Any<OrnamentationType>(), Arg.Any<Meter>()).Returns(MusicalTimeSpan.Quarter);
@@ -75,7 +75,7 @@ internal sealed class PickupProcessorTests
         _pickupProcessor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.Pickup);
         noteToAssert.MusicalTimeSpan.Should().Be(MusicalTimeSpan.Quarter);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/RepeatedNoteProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/RepeatedNoteProcessorTests.cs
@@ -35,10 +35,10 @@ internal sealed class RepeatedNoteProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half)]))
         );
 
         _mockMusicalTimeSpanCalculator.CalculateOrnamentationTimeSpan(Arg.Any<OrnamentationType>(), Arg.Any<Meter>()).Returns(MusicalTimeSpan.Eighth);
@@ -48,7 +48,7 @@ internal sealed class RepeatedNoteProcessorTests
         _repeatedNoteProcessor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.RepeatedNote);
         noteToAssert.Ornamentations.Should().ContainSingle();

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/RunProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/RunProcessorTests.cs
@@ -31,17 +31,17 @@ internal sealed class RunProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.F3, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.F3, MusicalTimeSpan.Half)]))
         );
 
         // act
         _processor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.Run);
         noteToAssert.Ornamentations.Should().HaveCount(3);
@@ -62,17 +62,17 @@ internal sealed class RunProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.F3, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.F3, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)]))
         );
 
         // act
         _processor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.Run);
         noteToAssert.Ornamentations.Should().HaveCount(3);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/SustainedNoteProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/SustainedNoteProcessorTests.cs
@@ -31,18 +31,18 @@ internal sealed class SustainedNoteProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)]))
         );
 
         // act
         _sustainedNoteProcessor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
-        var nextNoteToAssert = ornamentationItem.NextBeat![Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
+        var nextNoteToAssert = ornamentationItem.NextBeat![Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.Sustain);
         noteToAssert.Ornamentations.Should().BeEmpty();

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/TurnProcessorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Ornamentation/Engine/Processors/TurnProcessorTests.cs
@@ -31,17 +31,17 @@ internal sealed class TurnProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half)]))
         );
 
         // act
         _processor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.Turn);
         noteToAssert.Ornamentations.Should().HaveCount(3);
@@ -63,17 +63,17 @@ internal sealed class TurnProcessorTests
     {
         // arrange
         var ornamentationItem = new OrnamentationItem(
-            Voice.Soprano,
+            Voice.One,
             new FixedSizeList<Beat>(1),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)])),
-            new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.A3, MusicalTimeSpan.Half)]))
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)])),
+            new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.A3, MusicalTimeSpan.Half)]))
         );
 
         // act
         _processor.Process(ornamentationItem);
 
         // assert
-        var noteToAssert = ornamentationItem.CurrentBeat[Voice.Soprano];
+        var noteToAssert = ornamentationItem.CurrentBeat[Voice.One];
 
         noteToAssert.OrnamentationType.Should().Be(OrnamentationType.Turn);
         noteToAssert.Ornamentations.Should().HaveCount(3);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Phrasing/CompositionPhraserTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Phrasing/CompositionPhraserTests.cs
@@ -200,7 +200,7 @@ internal sealed class CompositionPhraserTests
 
         for (var i = 0; i < count; i++)
         {
-            var beats = Enumerable.Range(0, beatsPerMeasure).Select(_ => new Beat(new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)]))).ToList();
+            var beats = Enumerable.Range(0, beatsPerMeasure).Select(_ => new Beat(new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)]))).ToList();
             measures.Add(new Measure(beats, Meter.FourFour));
         }
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Phrasing/ThemeSplitterTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Phrasing/ThemeSplitterTests.cs
@@ -31,19 +31,19 @@ internal sealed class ThemeSplitterTests
     {
         get
         {
-            var chordA = new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half)]);
+            var chordA = new BaroquenChord([new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half)]);
             var beatA = new Beat(chordA);
             var measureA = new Measure([beatA], Meter.FourFour);
 
-            var chordB = new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half)]);
+            var chordB = new BaroquenChord([new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half)]);
             var beatB = new Beat(chordB);
             var measureB = new Measure([beatB], Meter.FourFour);
 
-            var chordC = new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half)]);
+            var chordC = new BaroquenChord([new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half)]);
             var beatC = new Beat(chordC);
             var measureC = new Measure([beatC], Meter.FourFour);
 
-            var chordD = new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.F4, MusicalTimeSpan.Half)]);
+            var chordD = new BaroquenChord([new BaroquenNote(Voice.One, Notes.F4, MusicalTimeSpan.Half)]);
             var beatD = new Beat(chordD);
             var measureD = new Measure([beatD], Meter.FourFour);
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidDirectIntervalsTest.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidDirectIntervalsTest.cs
@@ -32,12 +32,12 @@ internal sealed class AvoidDirectIntervalsTest
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half);
 
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half);
-            var altoA3 = new BaroquenNote(Voice.Alto, Notes.A3, MusicalTimeSpan.Half);
-            var altoA2 = new BaroquenNote(Voice.Alto, Notes.A2, MusicalTimeSpan.Half);
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half);
+            var altoA3 = new BaroquenNote(Voice.Two, Notes.A3, MusicalTimeSpan.Half);
+            var altoA2 = new BaroquenNote(Voice.Two, Notes.A2, MusicalTimeSpan.Half);
 
             yield return new TestCaseData(
                 new List<BaroquenChord>(),

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidDissonanceTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidDissonanceTests.cs
@@ -28,13 +28,13 @@ internal sealed class AvoidDissonanceTests
             // the current chord is unnecessary for this test, so it is set to empty
             var unusedChord = new BaroquenChord([]);
 
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
-            var tenorG2 = new BaroquenNote(Voice.Tenor, Notes.G2, MusicalTimeSpan.Half);
-            var bassC1 = new BaroquenNote(Voice.Bass, Notes.C1, MusicalTimeSpan.Half);
-            var sopranoB4 = new BaroquenNote(Voice.Soprano, Notes.B4, MusicalTimeSpan.Half);
-            var sopranoCSharp4 = new BaroquenNote(Voice.Soprano, Notes.CSharp4, MusicalTimeSpan.Half);
-            var bassASharp1 = new BaroquenNote(Voice.Bass, Notes.ASharp1, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half);
+            var tenorG2 = new BaroquenNote(Voice.Three, Notes.G2, MusicalTimeSpan.Half);
+            var bassC1 = new BaroquenNote(Voice.Four, Notes.C1, MusicalTimeSpan.Half);
+            var sopranoB4 = new BaroquenNote(Voice.One, Notes.B4, MusicalTimeSpan.Half);
+            var sopranoCSharp4 = new BaroquenNote(Voice.One, Notes.CSharp4, MusicalTimeSpan.Half);
+            var bassASharp1 = new BaroquenNote(Voice.Four, Notes.ASharp1, MusicalTimeSpan.Half);
 
             var cMajor = new BaroquenChord([sopranoC4, altoE3, tenorG2, bassC1]);
             var eMinor = new BaroquenChord([altoE3, tenorG2, sopranoB4]);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidDissonantLeapTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidDissonantLeapTests.cs
@@ -30,20 +30,20 @@ internal sealed class AvoidDissonantLeapsTests
     {
         get
         {
-            var sopranoB3 = new BaroquenNote(Voice.Soprano, Notes.B3, MusicalTimeSpan.Half);
-            var altoE4 = new BaroquenNote(Voice.Alto, Notes.E4, MusicalTimeSpan.Half);
-            var tenorG3 = new BaroquenNote(Voice.Tenor, Notes.G3, MusicalTimeSpan.Half);
-            var baseE2 = new BaroquenNote(Voice.Bass, Notes.E2, MusicalTimeSpan.Half);
+            var sopranoB3 = new BaroquenNote(Voice.One, Notes.B3, MusicalTimeSpan.Half);
+            var altoE4 = new BaroquenNote(Voice.Two, Notes.E4, MusicalTimeSpan.Half);
+            var tenorG3 = new BaroquenNote(Voice.Three, Notes.G3, MusicalTimeSpan.Half);
+            var baseE2 = new BaroquenNote(Voice.Four, Notes.E2, MusicalTimeSpan.Half);
 
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var altoF4 = new BaroquenNote(Voice.Alto, Notes.F4, MusicalTimeSpan.Half);
-            var tenorA3 = new BaroquenNote(Voice.Tenor, Notes.A3, MusicalTimeSpan.Half);
-            var bassF2 = new BaroquenNote(Voice.Bass, Notes.F2, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var altoF4 = new BaroquenNote(Voice.Two, Notes.F4, MusicalTimeSpan.Half);
+            var tenorA3 = new BaroquenNote(Voice.Three, Notes.A3, MusicalTimeSpan.Half);
+            var bassF2 = new BaroquenNote(Voice.Four, Notes.F2, MusicalTimeSpan.Half);
 
-            var sopranoF4 = new BaroquenNote(Voice.Soprano, Notes.F4, MusicalTimeSpan.Half);
-            var altoA4 = new BaroquenNote(Voice.Alto, Notes.A4, MusicalTimeSpan.Half);
-            var tenorC4 = new BaroquenNote(Voice.Tenor, Notes.C4, MusicalTimeSpan.Half);
-            var bassA2 = new BaroquenNote(Voice.Bass, Notes.A2, MusicalTimeSpan.Half);
+            var sopranoF4 = new BaroquenNote(Voice.One, Notes.F4, MusicalTimeSpan.Half);
+            var altoA4 = new BaroquenNote(Voice.Two, Notes.A4, MusicalTimeSpan.Half);
+            var tenorC4 = new BaroquenNote(Voice.Three, Notes.C4, MusicalTimeSpan.Half);
+            var bassA2 = new BaroquenNote(Voice.Four, Notes.A2, MusicalTimeSpan.Half);
 
             var eMinor = new BaroquenChord([sopranoB3, altoE4, tenorG3, baseE2]);
             var fMajor = new BaroquenChord([sopranoC4, altoF4, tenorA3, bassF2]);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidOverDoublingTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidOverDoublingTests.cs
@@ -27,16 +27,16 @@ internal sealed class AvoidOverDoublingTests
 
     private static IEnumerable<TestCaseData> TestCases()
     {
-        var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
+        var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
 
-        var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half);
-        var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
+        var altoC3 = new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half);
+        var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half);
 
-        var tenorC2 = new BaroquenNote(Voice.Tenor, Notes.C2, MusicalTimeSpan.Half);
-        var tenorD2 = new BaroquenNote(Voice.Tenor, Notes.D2, MusicalTimeSpan.Half);
+        var tenorC2 = new BaroquenNote(Voice.Three, Notes.C2, MusicalTimeSpan.Half);
+        var tenorD2 = new BaroquenNote(Voice.Three, Notes.D2, MusicalTimeSpan.Half);
 
-        var bassC1 = new BaroquenNote(Voice.Bass, Notes.C1, MusicalTimeSpan.Half);
-        var bassF1 = new BaroquenNote(Voice.Bass, Notes.F1, MusicalTimeSpan.Half);
+        var bassC1 = new BaroquenNote(Voice.Four, Notes.C1, MusicalTimeSpan.Half);
+        var bassF1 = new BaroquenNote(Voice.Four, Notes.F1, MusicalTimeSpan.Half);
 
         var duetChordWithDuplicateNotes = new BaroquenChord([sopranoC4, altoC3]);
         var duetChordWithDifferingNotes = new BaroquenChord([sopranoC4, altoE3]);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidParallelIntervalsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidParallelIntervalsTests.cs
@@ -35,26 +35,26 @@ internal sealed class AvoidParallelIntervalsTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
-            var tenorG2 = new BaroquenNote(Voice.Tenor, Notes.G2, MusicalTimeSpan.Half);
-            var bassC1 = new BaroquenNote(Voice.Bass, Notes.C1, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half);
+            var tenorG2 = new BaroquenNote(Voice.Three, Notes.G2, MusicalTimeSpan.Half);
+            var bassC1 = new BaroquenNote(Voice.Four, Notes.C1, MusicalTimeSpan.Half);
 
             var cMajor = new BaroquenChord([sopranoC4, altoE3, tenorG2, bassC1]);
 
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half);
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half);
-            var tenorA2 = new BaroquenNote(Voice.Tenor, Notes.A2, MusicalTimeSpan.Half);
-            var bassD1 = new BaroquenNote(Voice.Bass, Notes.D1, MusicalTimeSpan.Half);
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half);
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half);
+            var tenorA2 = new BaroquenNote(Voice.Three, Notes.A2, MusicalTimeSpan.Half);
+            var bassD1 = new BaroquenNote(Voice.Four, Notes.D1, MusicalTimeSpan.Half);
 
             var dMinor = new BaroquenChord([sopranoD4, altoF3, tenorA2, bassD1]);
 
-            var altoA3 = new BaroquenNote(Voice.Alto, Notes.A3, MusicalTimeSpan.Half);
-            var tenorF2 = new BaroquenNote(Voice.Tenor, Notes.F2, MusicalTimeSpan.Half);
+            var altoA3 = new BaroquenNote(Voice.Two, Notes.A3, MusicalTimeSpan.Half);
+            var tenorF2 = new BaroquenNote(Voice.Three, Notes.F2, MusicalTimeSpan.Half);
 
             var dMinorDifferentVoices = new BaroquenChord([sopranoD4, altoA3, tenorF2, bassD1]);
 
-            var tenorA1 = new BaroquenNote(Voice.Tenor, Notes.A1, MusicalTimeSpan.Half);
+            var tenorA1 = new BaroquenNote(Voice.Three, Notes.A1, MusicalTimeSpan.Half);
 
             var dMinorDifferentDirection = new BaroquenChord([sopranoD4, altoF3, tenorA1, bassD1]);
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidRepeatedChordsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidRepeatedChordsTests.cs
@@ -38,18 +38,18 @@ internal sealed class AvoidRepeatedChordsTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half);
-            var sopranoG4 = new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half);
-            var sopranoA4 = new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var sopranoE4 = new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half);
+            var sopranoG4 = new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half);
+            var sopranoA4 = new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half);
 
-            var altoC3 = new BaroquenNote(Voice.Alto, Notes.C3, MusicalTimeSpan.Half);
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
-            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half);
+            var altoC3 = new BaroquenNote(Voice.Two, Notes.C3, MusicalTimeSpan.Half);
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half);
+            var altoG3 = new BaroquenNote(Voice.Two, Notes.G3, MusicalTimeSpan.Half);
 
-            var tenorC2 = new BaroquenNote(Voice.Tenor, Notes.C2, MusicalTimeSpan.Half);
-            var tenorE2 = new BaroquenNote(Voice.Tenor, Notes.E2, MusicalTimeSpan.Half);
-            var tenorG2 = new BaroquenNote(Voice.Tenor, Notes.G2, MusicalTimeSpan.Half);
+            var tenorC2 = new BaroquenNote(Voice.Three, Notes.C2, MusicalTimeSpan.Half);
+            var tenorE2 = new BaroquenNote(Voice.Three, Notes.E2, MusicalTimeSpan.Half);
+            var tenorG2 = new BaroquenNote(Voice.Three, Notes.G2, MusicalTimeSpan.Half);
 
             var cMajor1 = new BaroquenChord([sopranoC4, altoE3, tenorG2]);
             var cMajor2 = new BaroquenChord([sopranoE4, altoG3, tenorC2]);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidRepetitionTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/AvoidRepetitionTests.cs
@@ -29,24 +29,24 @@ internal sealed class AvoidRepetitionTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
-            var tenorG2 = new BaroquenNote(Voice.Tenor, Notes.G2, MusicalTimeSpan.Half);
-            var bassC1 = new BaroquenNote(Voice.Bass, Notes.C1, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half);
+            var tenorG2 = new BaroquenNote(Voice.Three, Notes.G2, MusicalTimeSpan.Half);
+            var bassC1 = new BaroquenNote(Voice.Four, Notes.C1, MusicalTimeSpan.Half);
 
             var cMajor = new BaroquenChord([sopranoC4, altoE3, tenorG2, bassC1]);
 
-            var sopranoF4 = new BaroquenNote(Voice.Soprano, Notes.F4, MusicalTimeSpan.Half);
-            var altoA3 = new BaroquenNote(Voice.Alto, Notes.A3, MusicalTimeSpan.Half);
-            var tenorC3 = new BaroquenNote(Voice.Tenor, Notes.C3, MusicalTimeSpan.Half);
-            var bassF2 = new BaroquenNote(Voice.Bass, Notes.F2, MusicalTimeSpan.Half);
+            var sopranoF4 = new BaroquenNote(Voice.One, Notes.F4, MusicalTimeSpan.Half);
+            var altoA3 = new BaroquenNote(Voice.Two, Notes.A3, MusicalTimeSpan.Half);
+            var tenorC3 = new BaroquenNote(Voice.Three, Notes.C3, MusicalTimeSpan.Half);
+            var bassF2 = new BaroquenNote(Voice.Four, Notes.F2, MusicalTimeSpan.Half);
 
             var fMajor = new BaroquenChord([sopranoF4, altoA3, tenorC3, bassF2]);
 
-            var sopranoA4 = new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half);
-            var altoC4 = new BaroquenNote(Voice.Alto, Notes.C4, MusicalTimeSpan.Half);
-            var tenorE3 = new BaroquenNote(Voice.Tenor, Notes.E3, MusicalTimeSpan.Half);
-            var bassA2 = new BaroquenNote(Voice.Bass, Notes.A2, MusicalTimeSpan.Half);
+            var sopranoA4 = new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half);
+            var altoC4 = new BaroquenNote(Voice.Two, Notes.C4, MusicalTimeSpan.Half);
+            var tenorE3 = new BaroquenNote(Voice.Three, Notes.E3, MusicalTimeSpan.Half);
+            var bassA2 = new BaroquenNote(Voice.Four, Notes.A2, MusicalTimeSpan.Half);
 
             var aMinor = new BaroquenChord([sopranoA4, altoC4, tenorE3, bassA2]);
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/EnsureVoiceRangeTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/EnsureVoiceRangeTests.cs
@@ -32,12 +32,12 @@ internal sealed class EnsureVoiceRangeTests
         get
         {
             yield return new TestCaseData(
-                new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.C5, MusicalTimeSpan.Half)]),
+                new BaroquenChord([new BaroquenNote(Voice.One, Notes.C5, MusicalTimeSpan.Half)]),
                 true
             ).SetName("Soprano note is in range.");
 
             yield return new TestCaseData(
-                new BaroquenChord([new BaroquenNote(Voice.Soprano, Notes.B2, MusicalTimeSpan.Half)]),
+                new BaroquenChord([new BaroquenNote(Voice.One, Notes.B2, MusicalTimeSpan.Half)]),
                 false
             ).SetName("Soprano note is out of range.");
         }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/FollowsStandardProgressionTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/FollowsStandardProgressionTests.cs
@@ -31,45 +31,45 @@ internal sealed class FollowsStandardProgressionTests
     {
         get
         {
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
-            var tenorG2 = new BaroquenNote(Voice.Tenor, Notes.G2, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half);
+            var tenorG2 = new BaroquenNote(Voice.Three, Notes.G2, MusicalTimeSpan.Half);
 
             var i = new BaroquenChord([sopranoC4, altoE3, tenorG2]);
 
-            var sopranoD4 = new BaroquenNote(Voice.Soprano, Notes.D4, MusicalTimeSpan.Half);
-            var altoF3 = new BaroquenNote(Voice.Alto, Notes.F3, MusicalTimeSpan.Half);
-            var tenorA2 = new BaroquenNote(Voice.Tenor, Notes.A2, MusicalTimeSpan.Half);
+            var sopranoD4 = new BaroquenNote(Voice.One, Notes.D4, MusicalTimeSpan.Half);
+            var altoF3 = new BaroquenNote(Voice.Two, Notes.F3, MusicalTimeSpan.Half);
+            var tenorA2 = new BaroquenNote(Voice.Three, Notes.A2, MusicalTimeSpan.Half);
 
             var ii = new BaroquenChord([sopranoD4, altoF3, tenorA2]);
 
-            var sopranoE4 = new BaroquenNote(Voice.Soprano, Notes.E4, MusicalTimeSpan.Half);
-            var altoG3 = new BaroquenNote(Voice.Alto, Notes.G3, MusicalTimeSpan.Half);
-            var tenorB2 = new BaroquenNote(Voice.Tenor, Notes.B2, MusicalTimeSpan.Half);
+            var sopranoE4 = new BaroquenNote(Voice.One, Notes.E4, MusicalTimeSpan.Half);
+            var altoG3 = new BaroquenNote(Voice.Two, Notes.G3, MusicalTimeSpan.Half);
+            var tenorB2 = new BaroquenNote(Voice.Three, Notes.B2, MusicalTimeSpan.Half);
 
             var iii = new BaroquenChord([sopranoE4, altoG3, tenorB2]);
 
-            var sopranoF4 = new BaroquenNote(Voice.Soprano, Notes.F4, MusicalTimeSpan.Half);
-            var altoA3 = new BaroquenNote(Voice.Alto, Notes.A3, MusicalTimeSpan.Half);
-            var tenorC3 = new BaroquenNote(Voice.Tenor, Notes.C3, MusicalTimeSpan.Half);
+            var sopranoF4 = new BaroquenNote(Voice.One, Notes.F4, MusicalTimeSpan.Half);
+            var altoA3 = new BaroquenNote(Voice.Two, Notes.A3, MusicalTimeSpan.Half);
+            var tenorC3 = new BaroquenNote(Voice.Three, Notes.C3, MusicalTimeSpan.Half);
 
             var iv = new BaroquenChord([sopranoF4, altoA3, tenorC3]);
 
-            var sopranoG4 = new BaroquenNote(Voice.Soprano, Notes.G4, MusicalTimeSpan.Half);
-            var altoB3 = new BaroquenNote(Voice.Alto, Notes.B3, MusicalTimeSpan.Half);
-            var tenorD3 = new BaroquenNote(Voice.Tenor, Notes.D3, MusicalTimeSpan.Half);
+            var sopranoG4 = new BaroquenNote(Voice.One, Notes.G4, MusicalTimeSpan.Half);
+            var altoB3 = new BaroquenNote(Voice.Two, Notes.B3, MusicalTimeSpan.Half);
+            var tenorD3 = new BaroquenNote(Voice.Three, Notes.D3, MusicalTimeSpan.Half);
 
             var v = new BaroquenChord([sopranoG4, altoB3, tenorD3]);
 
-            var sopranoA4 = new BaroquenNote(Voice.Soprano, Notes.A4, MusicalTimeSpan.Half);
-            var altoC4 = new BaroquenNote(Voice.Alto, Notes.C4, MusicalTimeSpan.Half);
-            var tenorE3 = new BaroquenNote(Voice.Tenor, Notes.E3, MusicalTimeSpan.Half);
+            var sopranoA4 = new BaroquenNote(Voice.One, Notes.A4, MusicalTimeSpan.Half);
+            var altoC4 = new BaroquenNote(Voice.Two, Notes.C4, MusicalTimeSpan.Half);
+            var tenorE3 = new BaroquenNote(Voice.Three, Notes.E3, MusicalTimeSpan.Half);
 
             var vi = new BaroquenChord([sopranoA4, altoC4, tenorE3]);
 
-            var sopranoB4 = new BaroquenNote(Voice.Soprano, Notes.B4, MusicalTimeSpan.Half);
-            var altoD4 = new BaroquenNote(Voice.Alto, Notes.D4, MusicalTimeSpan.Half);
-            var tenorF3 = new BaroquenNote(Voice.Tenor, Notes.F3, MusicalTimeSpan.Half);
+            var sopranoB4 = new BaroquenNote(Voice.One, Notes.B4, MusicalTimeSpan.Half);
+            var altoD4 = new BaroquenNote(Voice.Two, Notes.D4, MusicalTimeSpan.Half);
+            var tenorF3 = new BaroquenNote(Voice.Three, Notes.F3, MusicalTimeSpan.Half);
 
             var vii = new BaroquenChord([sopranoB4, altoD4, tenorF3]);
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/HandleAscendingSeventhTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/HandleAscendingSeventhTests.cs
@@ -37,10 +37,10 @@ internal sealed class HandleAscendingSeventhTests
     {
         get
         {
-            var sopranoA3 = new BaroquenNote(Voice.Soprano, Notes.A3, MusicalTimeSpan.Half);
-            var sopranoB3 = new BaroquenNote(Voice.Soprano, Notes.B3, MusicalTimeSpan.Half);
-            var sopranoC4 = new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half);
-            var altoE3 = new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half);
+            var sopranoA3 = new BaroquenNote(Voice.One, Notes.A3, MusicalTimeSpan.Half);
+            var sopranoB3 = new BaroquenNote(Voice.One, Notes.B3, MusicalTimeSpan.Half);
+            var sopranoC4 = new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half);
+            var altoE3 = new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half);
 
             var cMajor = new BaroquenChord([sopranoC4, altoE3]);
             var eMinor = new BaroquenChord([sopranoB3, altoE3]);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Strategies/CompositionStrategyTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Strategies/CompositionStrategyTests.cs
@@ -82,32 +82,32 @@ internal sealed class CompositionStrategyTests
         var precedingChords = new List<BaroquenChord>
         {
             new([
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Tenor, Notes.G2, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Bass, Notes.C2, MusicalTimeSpan.Half)
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Three, Notes.G2, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Four, Notes.C2, MusicalTimeSpan.Half)
             ])
         };
 
         var goodChordChoice = new ChordChoice([
-            new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0),
-            new NoteChoice(Voice.Alto, NoteMotion.Oblique, 0),
-            new NoteChoice(Voice.Tenor, NoteMotion.Oblique, 0),
-            new NoteChoice(Voice.Bass, NoteMotion.Oblique, 0)
+            new NoteChoice(Voice.One, NoteMotion.Oblique, 0),
+            new NoteChoice(Voice.Two, NoteMotion.Oblique, 0),
+            new NoteChoice(Voice.Three, NoteMotion.Oblique, 0),
+            new NoteChoice(Voice.Four, NoteMotion.Oblique, 0)
         ]);
 
         var otherGoodChordChoice = new ChordChoice([
-            new NoteChoice(Voice.Soprano, NoteMotion.Ascending, 1),
-            new NoteChoice(Voice.Alto, NoteMotion.Descending, 1),
-            new NoteChoice(Voice.Tenor, NoteMotion.Ascending, 1),
-            new NoteChoice(Voice.Bass, NoteMotion.Descending, 1)
+            new NoteChoice(Voice.One, NoteMotion.Ascending, 1),
+            new NoteChoice(Voice.Two, NoteMotion.Descending, 1),
+            new NoteChoice(Voice.Three, NoteMotion.Ascending, 1),
+            new NoteChoice(Voice.Four, NoteMotion.Descending, 1)
         ]);
 
         var badChordChoice = new ChordChoice([
-            new NoteChoice(Voice.Soprano, NoteMotion.Ascending, 5),
-            new NoteChoice(Voice.Alto, NoteMotion.Descending, 5),
-            new NoteChoice(Voice.Tenor, NoteMotion.Ascending, 5),
-            new NoteChoice(Voice.Bass, NoteMotion.Descending, 5)
+            new NoteChoice(Voice.One, NoteMotion.Ascending, 5),
+            new NoteChoice(Voice.Two, NoteMotion.Descending, 5),
+            new NoteChoice(Voice.Three, NoteMotion.Ascending, 5),
+            new NoteChoice(Voice.Four, NoteMotion.Descending, 5)
         ]);
 
         var mockChordChoices = new List<ChordChoice>
@@ -188,40 +188,40 @@ internal sealed class CompositionStrategyTests
         var precedingChords = new List<BaroquenChord>
         {
             new([
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Tenor, Notes.G2, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Bass, Notes.C2, MusicalTimeSpan.Half)
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Three, Notes.G2, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Four, Notes.C2, MusicalTimeSpan.Half)
             ])
         };
 
         var nextChord = new BaroquenChord([
-                new BaroquenNote(Voice.Soprano, Notes.C4, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Alto, Notes.E3, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Tenor, Notes.G2, MusicalTimeSpan.Half),
-                new BaroquenNote(Voice.Bass, Notes.C2, MusicalTimeSpan.Half)
+                new BaroquenNote(Voice.One, Notes.C4, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Two, Notes.E3, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Three, Notes.G2, MusicalTimeSpan.Half),
+                new BaroquenNote(Voice.Four, Notes.C2, MusicalTimeSpan.Half)
             ]
         );
 
         var goodChordChoice = new ChordChoice([
-            new NoteChoice(Voice.Soprano, NoteMotion.Oblique, 0),
-            new NoteChoice(Voice.Alto, NoteMotion.Oblique, 0),
-            new NoteChoice(Voice.Tenor, NoteMotion.Oblique, 0),
-            new NoteChoice(Voice.Bass, NoteMotion.Oblique, 0)
+            new NoteChoice(Voice.One, NoteMotion.Oblique, 0),
+            new NoteChoice(Voice.Two, NoteMotion.Oblique, 0),
+            new NoteChoice(Voice.Three, NoteMotion.Oblique, 0),
+            new NoteChoice(Voice.Four, NoteMotion.Oblique, 0)
         ]);
 
         var otherGoodChordChoice = new ChordChoice([
-            new NoteChoice(Voice.Soprano, NoteMotion.Ascending, 1),
-            new NoteChoice(Voice.Alto, NoteMotion.Descending, 1),
-            new NoteChoice(Voice.Tenor, NoteMotion.Ascending, 1),
-            new NoteChoice(Voice.Bass, NoteMotion.Descending, 1)
+            new NoteChoice(Voice.One, NoteMotion.Ascending, 1),
+            new NoteChoice(Voice.Two, NoteMotion.Descending, 1),
+            new NoteChoice(Voice.Three, NoteMotion.Ascending, 1),
+            new NoteChoice(Voice.Four, NoteMotion.Descending, 1)
         ]);
 
         var badChordChoice = new ChordChoice([
-            new NoteChoice(Voice.Soprano, NoteMotion.Ascending, 5),
-            new NoteChoice(Voice.Alto, NoteMotion.Descending, 5),
-            new NoteChoice(Voice.Tenor, NoteMotion.Ascending, 5),
-            new NoteChoice(Voice.Bass, NoteMotion.Descending, 5)
+            new NoteChoice(Voice.One, NoteMotion.Ascending, 5),
+            new NoteChoice(Voice.Two, NoteMotion.Descending, 5),
+            new NoteChoice(Voice.Three, NoteMotion.Ascending, 5),
+            new NoteChoice(Voice.Four, NoteMotion.Descending, 5)
         ]);
 
         var mockChordChoices = new List<ChordChoice>

--- a/tests/BaroquenMelody.Library.Tests/Store/Reducers/VoiceConfigurationReducersTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Reducers/VoiceConfigurationReducersTests.cs
@@ -20,35 +20,35 @@ internal sealed class VoiceConfigurationReducersTests
         var state = new VoiceConfigurationState();
 
         // act
-        state = VoiceConfigurationReducers.ReduceUpdateVoiceConfiguration(state, new UpdateVoiceConfiguration(Voice.Soprano, Notes.C4, Notes.C5, GeneralMidi2Program.Accordion, true));
-        state = VoiceConfigurationReducers.ReduceUpdateVoiceConfiguration(state, new UpdateVoiceConfiguration(Voice.Alto, Notes.C5, Notes.C6, GeneralMidi2Program.Banjo, true));
-        state = VoiceConfigurationReducers.ReduceUpdateVoiceConfiguration(state, new UpdateVoiceConfiguration(Voice.Tenor, Notes.C6, Notes.C7, GeneralMidi2Program.Celesta, true));
-        state = VoiceConfigurationReducers.ReduceUpdateVoiceConfiguration(state, new UpdateVoiceConfiguration(Voice.Soprano, Notes.C7, Notes.C8, GeneralMidi2Program.Dulcimer, false));
+        state = VoiceConfigurationReducers.ReduceUpdateVoiceConfiguration(state, new UpdateVoiceConfiguration(Voice.One, Notes.C4, Notes.C5, GeneralMidi2Program.Accordion, true));
+        state = VoiceConfigurationReducers.ReduceUpdateVoiceConfiguration(state, new UpdateVoiceConfiguration(Voice.Two, Notes.C5, Notes.C6, GeneralMidi2Program.Banjo, true));
+        state = VoiceConfigurationReducers.ReduceUpdateVoiceConfiguration(state, new UpdateVoiceConfiguration(Voice.Three, Notes.C6, Notes.C7, GeneralMidi2Program.Celesta, true));
+        state = VoiceConfigurationReducers.ReduceUpdateVoiceConfiguration(state, new UpdateVoiceConfiguration(Voice.One, Notes.C7, Notes.C8, GeneralMidi2Program.Dulcimer, false));
 
         // assert
-        state.Configurations.Should().ContainKeys(Voice.Soprano, Voice.Alto, Voice.Tenor);
+        state.Configurations.Should().ContainKeys(Voice.One, Voice.Two, Voice.Three);
 
-        state.Configurations[Voice.Soprano].MinNote.Should().Be(Notes.C7);
-        state.Configurations[Voice.Soprano].MaxNote.Should().Be(Notes.C8);
-        state.Configurations[Voice.Soprano].Instrument.Should().Be(GeneralMidi2Program.Dulcimer);
-        state.Configurations[Voice.Soprano].IsEnabled.Should().BeFalse();
+        state.Configurations[Voice.One].MinNote.Should().Be(Notes.C7);
+        state.Configurations[Voice.One].MaxNote.Should().Be(Notes.C8);
+        state.Configurations[Voice.One].Instrument.Should().Be(GeneralMidi2Program.Dulcimer);
+        state.Configurations[Voice.One].IsEnabled.Should().BeFalse();
 
-        state.Configurations[Voice.Alto].MinNote.Should().Be(Notes.C5);
-        state.Configurations[Voice.Alto].MaxNote.Should().Be(Notes.C6);
-        state.Configurations[Voice.Alto].Instrument.Should().Be(GeneralMidi2Program.Banjo);
-        state.Configurations[Voice.Alto].IsEnabled.Should().BeTrue();
+        state.Configurations[Voice.Two].MinNote.Should().Be(Notes.C5);
+        state.Configurations[Voice.Two].MaxNote.Should().Be(Notes.C6);
+        state.Configurations[Voice.Two].Instrument.Should().Be(GeneralMidi2Program.Banjo);
+        state.Configurations[Voice.Two].IsEnabled.Should().BeTrue();
 
-        state.Configurations[Voice.Tenor].MinNote.Should().Be(Notes.C6);
-        state.Configurations[Voice.Tenor].MaxNote.Should().Be(Notes.C7);
-        state.Configurations[Voice.Tenor].Instrument.Should().Be(GeneralMidi2Program.Celesta);
-        state.Configurations[Voice.Tenor].IsEnabled.Should().BeTrue();
+        state.Configurations[Voice.Three].MinNote.Should().Be(Notes.C6);
+        state.Configurations[Voice.Three].MaxNote.Should().Be(Notes.C7);
+        state.Configurations[Voice.Three].Instrument.Should().Be(GeneralMidi2Program.Celesta);
+        state.Configurations[Voice.Three].IsEnabled.Should().BeTrue();
 
         state.Aggregate.Should().BeEquivalentTo(
             new HashSet<VoiceConfiguration>
             {
-                new(Voice.Soprano, Notes.C7, Notes.C8, GeneralMidi2Program.Dulcimer, false),
-                new(Voice.Alto, Notes.C5, Notes.C6, GeneralMidi2Program.Banjo),
-                new(Voice.Tenor, Notes.C6, Notes.C7, GeneralMidi2Program.Celesta)
+                new(Voice.One, Notes.C7, Notes.C8, GeneralMidi2Program.Dulcimer, false),
+                new(Voice.Two, Notes.C5, Notes.C6, GeneralMidi2Program.Banjo),
+                new(Voice.Three, Notes.C6, Notes.C7, GeneralMidi2Program.Celesta)
             }
         );
     }

--- a/tests/BaroquenMelody.Library.Tests/TestData/Configurations.cs
+++ b/tests/BaroquenMelody.Library.Tests/TestData/Configurations.cs
@@ -26,25 +26,25 @@ internal static class Configurations
     {
         1 =>
         [
-            new VoiceConfiguration(Voice.Soprano, Notes.C4, Notes.C6)
+            new VoiceConfiguration(Voice.One, Notes.C4, Notes.C6)
         ],
         2 =>
         [
-            new VoiceConfiguration(Voice.Soprano, Notes.C4, Notes.C6),
-            new VoiceConfiguration(Voice.Alto, Notes.G2, Notes.G4)
+            new VoiceConfiguration(Voice.One, Notes.C4, Notes.C6),
+            new VoiceConfiguration(Voice.Two, Notes.G2, Notes.G4)
         ],
         3 =>
         [
-            new VoiceConfiguration(Voice.Soprano, Notes.C4, Notes.C6),
-            new VoiceConfiguration(Voice.Alto, Notes.G2, Notes.G4),
-            new VoiceConfiguration(Voice.Tenor, Notes.C2, Notes.C3)
+            new VoiceConfiguration(Voice.One, Notes.C4, Notes.C6),
+            new VoiceConfiguration(Voice.Two, Notes.G2, Notes.G4),
+            new VoiceConfiguration(Voice.Three, Notes.C2, Notes.C3)
         ],
         4 =>
         [
-            new VoiceConfiguration(Voice.Soprano, Notes.C4, Notes.C6),
-            new VoiceConfiguration(Voice.Alto, Notes.G2, Notes.G4),
-            new VoiceConfiguration(Voice.Tenor, Notes.C2, Notes.C3),
-            new VoiceConfiguration(Voice.Bass, Notes.C1, Notes.C2)
+            new VoiceConfiguration(Voice.One, Notes.C4, Notes.C6),
+            new VoiceConfiguration(Voice.Two, Notes.G2, Notes.G4),
+            new VoiceConfiguration(Voice.Three, Notes.C2, Notes.C3),
+            new VoiceConfiguration(Voice.Four, Notes.C1, Notes.C2)
         ],
         _ => throw new ArgumentException("Invalid number of voices.")
     };


### PR DESCRIPTION
## Description

Rename the `Voice` enum values to avoid the semantics of "soprano", "alto", "tenor", etc. which are not actually relevant to this app.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
