### PR TITLE
Initial Fluxor State Adjustments

### DIFF
--- a/src/BaroquenMelody.App/App.xaml.cs
+++ b/src/BaroquenMelody.App/App.xaml.cs
@@ -1,17 +1,13 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations.Services;
-
-namespace BaroquenMelody.App;
+﻿namespace BaroquenMelody.App;
 
 /// <summary>
 ///     The entrypoint of the application.
 /// </summary>
 public partial class App : Application
 {
-    public App(ICompositionConfigurationService compositionConfigurationService)
+    public App()
     {
         InitializeComponent();
-
-        compositionConfigurationService.ConfigureDefaults();
 
         MainPage = new MainPage();
     }

--- a/src/BaroquenMelody.Library/Compositions/Configurations/InstrumentConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/InstrumentConfiguration.cs
@@ -20,4 +20,12 @@ public sealed record InstrumentConfiguration(
     bool IsEnabled = true)
 {
     public bool IsNoteWithinInstrumentRange(Note note) => MinNote.NoteNumber <= note.NoteNumber && note.NoteNumber <= MaxNote.NoteNumber;
+
+    public static readonly IDictionary<Instrument, InstrumentConfiguration> DefaultConfigurations = new Dictionary<Instrument, InstrumentConfiguration>
+    {
+        { Instrument.One, new(Instrument.One, Notes.C5, Notes.E6) },
+        { Instrument.Two, new(Instrument.Two, Notes.G3, Notes.B4) },
+        { Instrument.Three, new(Instrument.Three, Notes.D3, Notes.F4) },
+        { Instrument.Four, new(Instrument.Four, Notes.C2, Notes.E3) }
+    };
 }

--- a/src/BaroquenMelody.Library/Compositions/Configurations/Services/CompositionConfigurationService.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/Services/CompositionConfigurationService.cs
@@ -9,12 +9,7 @@ using System.Collections.Frozen;
 
 namespace BaroquenMelody.Library.Compositions.Configurations.Services;
 
-internal sealed class CompositionConfigurationService(
-    IOrnamentationConfigurationService compositionOrnamentationConfigurationService,
-    ICompositionRuleConfigurationService compositionRuleConfigurationService,
-    IInstrumentConfigurationService compositionInstrumentConfigurationService,
-    IDispatcher dispatcher
-) : ICompositionConfigurationService
+internal sealed class CompositionConfigurationService(IDispatcher dispatcher) : ICompositionConfigurationService
 {
     private const Meter _defaultMeter = Meter.FourFour;
 
@@ -33,15 +28,6 @@ internal sealed class CompositionConfigurationService(
     public IEnumerable<Mode> ConfigurableScaleModes => _configurableScaleModes;
 
     public IEnumerable<Meter> ConfigurableMeters => _configurableMeters;
-
-    public void ConfigureDefaults()
-    {
-        compositionOrnamentationConfigurationService.ConfigureDefaults();
-        compositionRuleConfigurationService.ConfigureDefaults();
-        compositionInstrumentConfigurationService.ConfigureDefaults();
-
-        Reset();
-    }
 
     public void Randomize()
     {

--- a/src/BaroquenMelody.Library/Compositions/Configurations/Services/ICompositionConfigurationService.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/Services/ICompositionConfigurationService.cs
@@ -25,11 +25,6 @@ public interface ICompositionConfigurationService
     IEnumerable<Meter> ConfigurableMeters { get; }
 
     /// <summary>
-    ///     Configure the default composition configuration.
-    /// </summary>
-    void ConfigureDefaults();
-
-    /// <summary>
     ///     Randomize the composition configuration.
     /// </summary>
     void Randomize();

--- a/src/BaroquenMelody.Library/Store/State/CompositionOrnamentationConfigurationState.cs
+++ b/src/BaroquenMelody.Library/Store/State/CompositionOrnamentationConfigurationState.cs
@@ -7,10 +7,15 @@ namespace BaroquenMelody.Library.Store.State;
 [FeatureState]
 public sealed record CompositionOrnamentationConfigurationState(IDictionary<OrnamentationType, OrnamentationConfiguration> Configurations)
 {
+    private static readonly IDictionary<OrnamentationType, OrnamentationConfiguration> Defaults = AggregateOrnamentationConfiguration.Default.Configurations.ToDictionary(
+        configuration => configuration.OrnamentationType,
+        configuration => configuration
+    );
+
     public AggregateOrnamentationConfiguration Aggregate => new(Configurations.Values.ToHashSet());
 
     public CompositionOrnamentationConfigurationState()
-        : this(new Dictionary<OrnamentationType, OrnamentationConfiguration>())
+        : this(Defaults)
     {
     }
 

--- a/src/BaroquenMelody.Library/Store/State/CompositionRuleConfigurationState.cs
+++ b/src/BaroquenMelody.Library/Store/State/CompositionRuleConfigurationState.cs
@@ -7,10 +7,15 @@ namespace BaroquenMelody.Library.Store.State;
 [FeatureState]
 public sealed record CompositionRuleConfigurationState(IDictionary<CompositionRule, CompositionRuleConfiguration> Configurations)
 {
+    private static readonly IDictionary<CompositionRule, CompositionRuleConfiguration> Defaults = AggregateCompositionRuleConfiguration.Default.Configurations.ToDictionary(
+        configuration => configuration.Rule,
+        configuration => configuration
+    );
+
     public AggregateCompositionRuleConfiguration Aggregate => new(Configurations.Values.ToHashSet());
 
     public CompositionRuleConfigurationState()
-        : this(new Dictionary<CompositionRule, CompositionRuleConfiguration>())
+        : this(Defaults)
     {
     }
 

--- a/src/BaroquenMelody.Library/Store/State/InstrumentConfigurationState.cs
+++ b/src/BaroquenMelody.Library/Store/State/InstrumentConfigurationState.cs
@@ -10,7 +10,7 @@ public sealed record InstrumentConfigurationState(IDictionary<Instrument, Instru
     public ISet<InstrumentConfiguration> EnabledConfigurations => Configurations.Values.Where(configuration => configuration.IsEnabled).ToHashSet();
 
     public InstrumentConfigurationState()
-        : this(new Dictionary<Instrument, InstrumentConfiguration>(), new Dictionary<Instrument, InstrumentConfiguration>())
+        : this(InstrumentConfiguration.DefaultConfigurations, InstrumentConfiguration.DefaultConfigurations)
     {
     }
 

--- a/src/BaroquenMelody/App.cs
+++ b/src/BaroquenMelody/App.cs
@@ -1,6 +1,5 @@
 ﻿using BaroquenMelody.Library;
 using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Configurations.Services;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums.Extensions;
 using BaroquenMelody.Library.Infrastructure.State;
@@ -26,7 +25,6 @@ internal sealed class App : IDisposable
     public App(
         IStore store,
         IBaroquenMelodyComposerConfigurator configurator,
-        ICompositionConfigurationService compositionConfigurationService,
         IState<CompositionProgressState> compositionProgressState,
         IState<CompositionConfigurationState> compositionConfigurationState,
         IState<InstrumentConfigurationState> instrumentConfigurationState,
@@ -34,7 +32,6 @@ internal sealed class App : IDisposable
         IState<CompositionOrnamentationConfigurationState> compositionOrnamentationConfigurationState)
     {
         store.InitializeAsync().Wait();
-        compositionConfigurationService.ConfigureDefaults();
 
         _configurator = configurator;
         _compositionConfigurationState = compositionConfigurationState;

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/Services/CompositionConfigurationServiceTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/Services/CompositionConfigurationServiceTests.cs
@@ -13,12 +13,6 @@ namespace BaroquenMelody.Library.Tests.Compositions.Configuration.Services;
 [TestFixture]
 internal sealed class CompositionConfigurationServiceTests
 {
-    private IOrnamentationConfigurationService _mockOrnamentationConfigurationService = null!;
-
-    private ICompositionRuleConfigurationService _mockCompositionRuleConfigurationService = null!;
-
-    private IInstrumentConfigurationService _mockInstrumentConfigurationService = null!;
-
     private IDispatcher _mockDispatcher = null!;
 
     private CompositionConfigurationService _compositionConfigurationService = null!;
@@ -26,17 +20,9 @@ internal sealed class CompositionConfigurationServiceTests
     [SetUp]
     public void SetUp()
     {
-        _mockOrnamentationConfigurationService = Substitute.For<IOrnamentationConfigurationService>();
-        _mockCompositionRuleConfigurationService = Substitute.For<ICompositionRuleConfigurationService>();
-        _mockInstrumentConfigurationService = Substitute.For<IInstrumentConfigurationService>();
         _mockDispatcher = Substitute.For<IDispatcher>();
 
-        _compositionConfigurationService = new CompositionConfigurationService(
-            _mockOrnamentationConfigurationService,
-            _mockCompositionRuleConfigurationService,
-            _mockInstrumentConfigurationService,
-            _mockDispatcher
-        );
+        _compositionConfigurationService = new CompositionConfigurationService(_mockDispatcher);
     }
 
     [Test]
@@ -103,19 +89,6 @@ internal sealed class CompositionConfigurationServiceTests
 
         // assert
         actualConfigurableMeters.Should().BeEquivalentTo(expectedConfigurableMeters);
-    }
-
-    [Test]
-    public void ConfigureDefaults_dispatches_expected_actions()
-    {
-        // act
-        _compositionConfigurationService.ConfigureDefaults();
-
-        // assert
-        _mockOrnamentationConfigurationService.Received(1).ConfigureDefaults();
-        _mockCompositionRuleConfigurationService.Received(1).ConfigureDefaults();
-        _mockInstrumentConfigurationService.Received(1).ConfigureDefaults();
-        _mockDispatcher.Received(1).Dispatch(Arg.Any<UpdateCompositionConfiguration>());
     }
 
     [Test]

--- a/tests/BaroquenMelody.Library.Tests/Store/Reducers/CompositionOrnamentationConfigurationReducersTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Reducers/CompositionOrnamentationConfigurationReducersTests.cs
@@ -47,15 +47,16 @@ internal sealed class CompositionOrnamentationConfigurationReducersTests
         state[OrnamentationType.Turn]!.Probability.Should().Be(3);
         state[OrnamentationType.Mordent]!.Probability.Should().Be(4);
 
-        state.Aggregate.Should().BeEquivalentTo(
-            new AggregateOrnamentationConfiguration(
-                new HashSet<OrnamentationConfiguration>
-                {
-                    new(OrnamentationType.Run, true, 1),
-                    new(OrnamentationType.Turn, true, 3),
-                    new(OrnamentationType.Mordent, true, 4)
-                }
-            )
-        );
+        var otherConfigurations = AggregateOrnamentationConfiguration.Default.Configurations
+            .Where(configuration => configuration.OrnamentationType
+                is not OrnamentationType.Run
+                and not OrnamentationType.Turn
+                and not OrnamentationType.Mordent
+            );
+
+        foreach (var defaultConfiguration in otherConfigurations)
+        {
+            state[defaultConfiguration.OrnamentationType]!.Should().BeEquivalentTo(defaultConfiguration);
+        }
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Store/Reducers/CompositionRuleConfigurationReducersTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Reducers/CompositionRuleConfigurationReducersTests.cs
@@ -35,15 +35,16 @@ internal sealed class CompositionRuleConfigurationReducersTests
         state[CompositionRule.AvoidRepeatedChords]!.Strictness.Should().Be(3);
         state[CompositionRule.AvoidRepeatedChords]!.IsEnabled.Should().BeTrue();
 
-        state.Aggregate.Should().BeEquivalentTo(
-            new AggregateCompositionRuleConfiguration(
-                new HashSet<CompositionRuleConfiguration>
-                {
-                    new(CompositionRule.AvoidDirectFifths, false, 4),
-                    new(CompositionRule.AvoidDissonance, true, 2),
-                    new(CompositionRule.AvoidRepeatedChords, true, 3)
-                }
-            )
-        );
+        var otherConfigurations = AggregateCompositionRuleConfiguration.Default.Configurations
+            .Where(configuration => configuration.Rule
+                is not CompositionRule.AvoidDirectFifths
+                and not CompositionRule.AvoidDissonance
+                and not CompositionRule.AvoidRepeatedChords
+            );
+
+        foreach (var defaultConfiguration in otherConfigurations)
+        {
+            state[defaultConfiguration.Rule]!.Should().BeEquivalentTo(defaultConfiguration);
+        }
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Store/Reducers/InstrumentConfigurationReducersTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Reducers/InstrumentConfigurationReducersTests.cs
@@ -81,12 +81,9 @@ internal sealed class InstrumentConfigurationReducersTests
         lastUserAppliedInstrumentThreeState.MidiProgram.Should().Be(GeneralMidi2Program.Celesta);
         lastUserAppliedInstrumentThreeState.IsEnabled.Should().BeTrue();
 
-        state.EnabledConfigurations.Should().BeEquivalentTo(
-            new HashSet<InstrumentConfiguration>
-            {
-                new(Instrument.Two, Notes.C5, Notes.C6, GeneralMidi2Program.Banjo),
-                new(Instrument.Three, Notes.C6, Notes.C7, GeneralMidi2Program.Celesta)
-            }
-        );
+        var otherConfiguration = InstrumentConfiguration.DefaultConfigurations[Instrument.Four];
+
+        state[Instrument.Four]!.Should().BeEquivalentTo(otherConfiguration);
+        state.LastUserAppliedConfigurations[Instrument.Four].Should().BeEquivalentTo(otherConfiguration);
     }
 }


### PR DESCRIPTION
## Description

Remove the need to dispatch configuration of defaults and instead push those defaults into the default state constructors.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
