### PR TITLE
Add Save Dialogue

### DIFF
--- a/src/BaroquenMelody.App.Components/BaroquenMelody.App.Components.csproj
+++ b/src/BaroquenMelody.App.Components/BaroquenMelody.App.Components.csproj
@@ -38,4 +38,8 @@
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Extensions\" />
+  </ItemGroup>
+
 </Project>

--- a/src/BaroquenMelody.App.Components/BaroquenMelody.App.Components.csproj
+++ b/src/BaroquenMelody.App.Components/BaroquenMelody.App.Components.csproj
@@ -38,8 +38,4 @@
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Extensions\" />
-  </ItemGroup>
-
 </Project>

--- a/src/BaroquenMelody.App.Components/Pages/Home.razor
+++ b/src/BaroquenMelody.App.Components/Pages/Home.razor
@@ -66,8 +66,24 @@
 
     private MudTabPanel? _compositionTab;
 
-    private void Compose()
+    private async Task Compose()
     {
+        if (!BaroquenMelodyState.Value.HasBeenSaved && BaroquenMelodyState.Value.BaroquenMelody is not null)
+        {
+            var dialogReference = await Dialog.ShowAsync<ConfirmCompositionDialogue>("Save composition?", new DialogOptions());
+            var dialogResult = await dialogReference.Result;
+
+            if (dialogResult?.Canceled ?? false)
+            {
+                return;
+            }
+
+            if (dialogResult?.Data is true)
+            {
+                await Save();
+            }
+        }
+
         Dispatcher.Dispatch(new Compose());
 
         ActivateCompositionTab();
@@ -78,6 +94,21 @@
         if (_tabs?.ActivePanel != _compositionTab)
         {
             _tabs?.ActivatePanel(_compositionTab);
+        }
+    }
+
+    private async Task Save()
+    {
+        var isSaved = await MidiSaver.SaveAsync(
+            BaroquenMelodyState.Value.BaroquenMelody!,
+            BaroquenMelodyState.Value.Path,
+            new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token
+        ).ConfigureAwait(false);
+
+        if (isSaved)
+        {
+            Snackbar.Add("Saved composition!", Severity.Success);
+            Dispatcher.Dispatch(new MarkCompositionSaved());
         }
     }
 }

--- a/src/BaroquenMelody.App.Components/Shared/CompositionProgress.razor
+++ b/src/BaroquenMelody.App.Components/Shared/CompositionProgress.razor
@@ -24,7 +24,7 @@
                            StartIcon="@Icons.Material.Filled.ElectricBolt"
                            Color="Color.Tertiary"
                            Style="width: 300px; height: 100px;"
-                           OnClick="() => Dispatcher.Dispatch(new Compose())">
+                           OnClick="Compose">
                     <MudText Typo="Typo.button" Style="font-size:large">Compose</MudText>
                 </MudButton>
             </div>
@@ -95,22 +95,47 @@ else
 
 @code {
 
-    private async Task Play() => await MidiLauncher.LaunchAsync(BaroquenMelodyState.Value.Path, GetTimedCancellationToken(10));
+    private async Task Compose()
+    {
+        if (!BaroquenMelodyState.Value.HasBeenSaved && BaroquenMelodyState.Value.BaroquenMelody is not null)
+        {
+            var dialogReference = await Dialog.ShowAsync<ConfirmCompositionDialogue>("Save composition?", new DialogOptions());
+            var dialogResult = await dialogReference.Result;
+
+            if (dialogResult?.Canceled ?? false)
+            {
+                return;
+            }
+
+            if (dialogResult?.Data is true)
+            {
+                await Save();
+            }
+        }
+
+        Dispatcher.Dispatch(new Compose());
+    }
+
+    private async Task Play()
+    {
+        var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        await MidiLauncher.LaunchAsync(BaroquenMelodyState.Value.Path, cancellationTokenSource.Token);
+    }
 
     private async Task Save()
     {
         var isSaved = await MidiSaver.SaveAsync(
             BaroquenMelodyState.Value.BaroquenMelody!,
             BaroquenMelodyState.Value.Path,
-            GetTimedCancellationToken(10)
-        );
+            new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token
+        ).ConfigureAwait(false);
 
         if (isSaved)
         {
             Snackbar.Add("Saved composition!", Severity.Success);
+            Dispatcher.Dispatch(new MarkCompositionSaved());
         }
     }
-
-    private CancellationToken GetTimedCancellationToken(int timeout) => new CancellationTokenSource(TimeSpan.FromSeconds(timeout)).Token;
 
 }

--- a/src/BaroquenMelody.App.Components/Shared/ConfirmCompositionDialogue.razor
+++ b/src/BaroquenMelody.App.Components/Shared/ConfirmCompositionDialogue.razor
@@ -1,0 +1,33 @@
+﻿<MudDialog>
+    <DialogContent>
+        Previous composition has not yet been saved. Do you want to save it before creating a new one?
+    </DialogContent>
+    <DialogActions>
+        <MudButton Color="Color.Tertiary"
+                   Variant="Variant.Outlined"
+                   OnClick="SaveComposition">
+            Yes
+        </MudButton>
+        <MudButton Color="Color.Error"
+                   Variant="Variant.Outlined"
+                   OnClick="ContinueWithoutSave">
+            No
+        </MudButton>
+        <MudButton OnClick="Cancel"
+                   Variant="Variant.Outlined">
+            Cancel
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+
+    [CascadingParameter] private MudDialogInstance? MudDialog { get; set; }
+
+    private void SaveComposition() => MudDialog?.Close(DialogResult.Ok(true));
+
+    private void ContinueWithoutSave() => MudDialog?.Close(DialogResult.Ok(false));
+
+    private void Cancel() => MudDialog?.Cancel();
+
+}

--- a/src/BaroquenMelody.App.Components/_Imports.razor
+++ b/src/BaroquenMelody.App.Components/_Imports.razor
@@ -50,3 +50,4 @@
 @inject IMidiLauncher MidiLauncher
 @inject IMidiSaver MidiSaver
 @inject ISnackbar Snackbar
+@inject IDialogService Dialog

--- a/src/BaroquenMelody.App/Infrastructure/FileSystem/MauiMidiLauncher.cs
+++ b/src/BaroquenMelody.App/Infrastructure/FileSystem/MauiMidiLauncher.cs
@@ -16,7 +16,7 @@ internal sealed class MauiMidiLauncher(IState<BaroquenMelodyState> state, IDispa
         {
             path = await midiSaver.SaveTempAsync(state.Value.BaroquenMelody!, cancellationToken).ConfigureAwait(false);
 
-            dispatcher.Dispatch(new UpdateBaroquenMelody(state.Value.BaroquenMelody!, path));
+            dispatcher.Dispatch(new UpdateBaroquenMelody(state.Value.BaroquenMelody!, path, state.Value.HasBeenSaved));
         }
 
         await Launcher.Default.OpenAsync(new OpenFileRequest(Title, new ReadOnlyFile(path))).ConfigureAwait(false);

--- a/src/BaroquenMelody.App/MauiProgram.cs
+++ b/src/BaroquenMelody.App/MauiProgram.cs
@@ -1,11 +1,8 @@
 ﻿using BaroquenMelody.App.Components.Extensions;
 using BaroquenMelody.App.Infrastructure.FileSystem;
-using BaroquenMelody.Library.Infrastructure.Extensions;
 using BaroquenMelody.Library.Infrastructure.FileSystem;
 using CommunityToolkit.Maui;
 using Microsoft.AspNetCore.Components.WebView.Maui;
-using Microsoft.Extensions.Logging;
-using MudBlazor.Services;
 
 namespace BaroquenMelody.App;
 

--- a/src/BaroquenMelody.Library/Store/Actions/MarkCompositionSaved.cs
+++ b/src/BaroquenMelody.Library/Store/Actions/MarkCompositionSaved.cs
@@ -1,0 +1,3 @@
+﻿namespace BaroquenMelody.Library.Store.Actions;
+
+public sealed record MarkCompositionSaved;

--- a/src/BaroquenMelody.Library/Store/Actions/UpdateBaroquenMelody.cs
+++ b/src/BaroquenMelody.Library/Store/Actions/UpdateBaroquenMelody.cs
@@ -1,3 +1,3 @@
 ﻿namespace BaroquenMelody.Library.Store.Actions;
 
-public sealed record UpdateBaroquenMelody(BaroquenMelody BaroquenMelody, string Path);
+public sealed record UpdateBaroquenMelody(BaroquenMelody BaroquenMelody, string Path, bool HasBeenSaved);

--- a/src/BaroquenMelody.Library/Store/Effects/BaroquenMelodyEffects.cs
+++ b/src/BaroquenMelody.Library/Store/Effects/BaroquenMelodyEffects.cs
@@ -43,7 +43,7 @@ public sealed class BaroquenMelodyEffects(
                     var baroquenMelody = baroquenMelodyComposerConfigurator.Configure(compositionConfiguration).Compose(_cancellationTokenSource.Token);
                     var path = await midiSaver.SaveTempAsync(baroquenMelody, _cancellationTokenSource.Token).ConfigureAwait(false);
 
-                    dispatcher.Dispatch(new UpdateBaroquenMelody(baroquenMelody, path));
+                    dispatcher.Dispatch(new UpdateBaroquenMelody(baroquenMelody, path, false));
                 }
                 catch (OperationCanceledException)
                 {

--- a/src/BaroquenMelody.Library/Store/Reducers/BaroquenMelodyReducers.cs
+++ b/src/BaroquenMelody.Library/Store/Reducers/BaroquenMelodyReducers.cs
@@ -7,5 +7,8 @@ namespace BaroquenMelody.Library.Store.Reducers;
 public static class BaroquenMelodyReducers
 {
     [ReducerMethod]
-    public static BaroquenMelodyState ReduceUpdateBaroquenMelody(BaroquenMelodyState state, UpdateBaroquenMelody action) => new(action.BaroquenMelody, action.Path);
+    public static BaroquenMelodyState ReduceUpdateBaroquenMelody(BaroquenMelodyState state, UpdateBaroquenMelody action) => new(action.BaroquenMelody, action.Path, action.HasBeenSaved);
+
+    [ReducerMethod]
+    public static BaroquenMelodyState ReduceMarkCompositionSaved(BaroquenMelodyState state, MarkCompositionSaved _) => state with { HasBeenSaved = true };
 }

--- a/src/BaroquenMelody.Library/Store/State/BaroquenMelodyState.cs
+++ b/src/BaroquenMelody.Library/Store/State/BaroquenMelodyState.cs
@@ -3,10 +3,10 @@
 namespace BaroquenMelody.Library.Store.State;
 
 [FeatureState]
-public sealed record BaroquenMelodyState(BaroquenMelody? BaroquenMelody, string Path)
+public sealed record BaroquenMelodyState(BaroquenMelody? BaroquenMelody, string Path, bool HasBeenSaved)
 {
     public BaroquenMelodyState()
-        : this(null, string.Empty)
+        : this(null, string.Empty, false)
     {
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Store/Reducers/BaroquenMelodyReducersTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Reducers/BaroquenMelodyReducersTests.cs
@@ -25,4 +25,18 @@ internal sealed class BaroquenMelodyReducersTests
         newState.Path.Should().Be(action.Path);
         newState.HasBeenSaved.Should().BeTrue();
     }
+
+    [Test]
+    public void ReduceMarkCompositionSaved()
+    {
+        // arrange
+        var state = new BaroquenMelodyState { HasBeenSaved = false };
+        var action = new MarkCompositionSaved();
+
+        // act
+        var newState = BaroquenMelodyReducers.ReduceMarkCompositionSaved(state, action);
+
+        // assert
+        newState.HasBeenSaved.Should().BeTrue();
+    }
 }

--- a/tests/BaroquenMelody.Library.Tests/Store/Reducers/BaroquenMelodyReducersTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Reducers/BaroquenMelodyReducersTests.cs
@@ -15,7 +15,7 @@ internal sealed class BaroquenMelodyReducersTests
     {
         // arrange
         var state = new BaroquenMelodyState();
-        var action = new UpdateBaroquenMelody(new BaroquenMelody(new MidiFile()), "Test");
+        var action = new UpdateBaroquenMelody(new BaroquenMelody(new MidiFile()), "Test", true);
 
         // act
         var newState = BaroquenMelodyReducers.ReduceUpdateBaroquenMelody(state, action);
@@ -23,5 +23,6 @@ internal sealed class BaroquenMelodyReducersTests
         // assert
         newState.BaroquenMelody.Should().Be(action.BaroquenMelody);
         newState.Path.Should().Be(action.Path);
+        newState.HasBeenSaved.Should().BeTrue();
     }
 }


### PR DESCRIPTION
## Description

Add a save confirmation prompt dialogue, triggered when the "compose" button is pressed.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
