### PR TITLE
Composition Configuration Validation

### DIFF
--- a/src/BaroquenMelody.App.Components/Pages/Home.razor
+++ b/src/BaroquenMelody.App.Components/Pages/Home.razor
@@ -15,13 +15,19 @@
         <MudItem>
             @if (!CompositionProgressState.Value.IsLoading)
             {
-                <MudButton Variant="Variant.Filled"
-                           StartIcon="@Icons.Material.Filled.ElectricBolt"
-                           Color="Color.Tertiary"
-                           OnClick="Compose"
-                           Disabled="@CompositionProgressState.Value.IsLoading">
-                    Compose
-                </MudButton>
+                <MudTooltip Text="@InstrumentConfigurationState.Value.ValidationMessage"
+                            Color="Color.Warning"
+                            Delay="ThemeProvider.TooltipDelay"
+                            Duration="ThemeProvider.TooltipDuration"
+                            Disabled="@InstrumentConfigurationState.Value.IsValid">
+                    <MudButton Variant="Variant.Filled"
+                               StartIcon="@Icons.Material.Filled.ElectricBolt"
+                               Color="Color.Tertiary"
+                               OnClick="Compose"
+                               Disabled="@(CompositionProgressState.Value.IsLoading || !InstrumentConfigurationState.Value.IsValid)">
+                        Compose
+                    </MudButton>
+                </MudTooltip>
             }
             else
             {
@@ -46,8 +52,26 @@
         <MudTabPanel Text="General" Icon="@Icons.Material.Outlined.Settings">
             <CompositionConfigurationPanel/>
         </MudTabPanel>
-        <MudTabPanel Text="Instrumentation" Icon="@Icons.Material.Outlined.Piano">
-            <InstrumentConfigurationPanel/>
+        <MudTabPanel Text="Instrumentation" Icon="@InstrumentationTabIcon" IconColor="@InstrumentationTabIconColor">
+            <TabContent>
+                <MudText Typo="Typo.button" Class="d-flex align-content-center">
+                    <MudIcon Icon="@InstrumentationTabIcon" Color="@InstrumentationTabIconColor" Class="mr-2"/> Instrumentation
+                </MudText>
+            </TabContent>
+            <TabWrapperContent>
+                <MudTooltip Text="@InstrumentConfigurationState.Value.ValidationMessage"
+                            Placement="Placement.Top"
+                            Arrow="true"
+                            Color="Color.Warning"
+                            Disabled="@InstrumentConfigurationState.Value.IsValid"
+                            Delay="ThemeProvider.TooltipDelay"
+                            Duration="ThemeProvider.TooltipDuration">
+                    @context
+                </MudTooltip>
+            </TabWrapperContent>
+            <ChildContent>
+                <InstrumentConfigurationPanel/>
+            </ChildContent>
         </MudTabPanel>
         <MudTabPanel Text="Rules" Icon="@Icons.Material.Outlined.Rule">
             <CompositionRuleConfigurationPanel/>
@@ -65,6 +89,14 @@
     private MudTabs? _tabs;
 
     private MudTabPanel? _compositionTab;
+
+    private string InstrumentationTabIcon => InstrumentConfigurationState.Value.IsValid
+        ? Icons.Material.Outlined.Piano
+        : Icons.Material.Outlined.Warning;
+
+    private Color InstrumentationTabIconColor => InstrumentConfigurationState.Value.IsValid
+        ? Color.Secondary
+        : Color.Warning;
 
     private async Task Compose()
     {
@@ -111,4 +143,5 @@
             Dispatcher.Dispatch(new MarkCompositionSaved());
         }
     }
+
 }

--- a/src/BaroquenMelody.App.Components/Shared/CompositionProgress.razor
+++ b/src/BaroquenMelody.App.Components/Shared/CompositionProgress.razor
@@ -2,7 +2,7 @@
 
 @if (CompositionProgressState.Value.IsWaiting)
 {
-    <MudGrid Justify="Justify.Center">
+    <MudGrid Class="my-3" Justify="Justify.Center">
         <MudAnimate
             Selector=".id1"
             Duration="2"
@@ -19,14 +19,21 @@
             Paused="false"/>
         <MudItem xs="12" sm="12" md="12" lg="12" xl="12" xxl="12">
             <div class="d-flex flex-shrink align-center justify-center ma-0" style="height:300px;">
-                <MudButton Class="id1 d-flex align-center justify-center"
-                           Variant="Variant.Filled"
-                           StartIcon="@Icons.Material.Filled.ElectricBolt"
-                           Color="Color.Tertiary"
-                           Style="width: 300px; height: 100px;"
-                           OnClick="Compose">
-                    <MudText Typo="Typo.button" Style="font-size:large">Compose</MudText>
-                </MudButton>
+                <MudTooltip Text="@InstrumentConfigurationState.Value.ValidationMessage"
+                            Color="Color.Warning"
+                            Delay="ThemeProvider.TooltipDelay"
+                            Duration="ThemeProvider.TooltipDuration"
+                            Disabled="@InstrumentConfigurationState.Value.IsValid">
+                    <MudButton Class="id1 d-flex align-center justify-center"
+                               Variant="Variant.Filled"
+                               StartIcon="@Icons.Material.Filled.ElectricBolt"
+                               Color="Color.Tertiary"
+                               Style="width: 300px; height: 100px;"
+                               OnClick="Compose"
+                               Disabled="@(!InstrumentConfigurationState.Value.IsValid)">
+                        <MudText Typo="Typo.button" Style="font-size:large">Compose</MudText>
+                    </MudButton>
+                </MudTooltip>
             </div>
         </MudItem>
     </MudGrid>

--- a/src/BaroquenMelody.App.Components/Shared/InstrumentConfigurationPanel.razor
+++ b/src/BaroquenMelody.App.Components/Shared/InstrumentConfigurationPanel.razor
@@ -1,5 +1,12 @@
-﻿<RandomizeResetButtonGroup OnRandomizeClick="InstrumentConfigurationService.Randomize"
+﻿@inherits Fluxor.Blazor.Web.Components.FluxorComponent
+
+<RandomizeResetButtonGroup OnRandomizeClick="InstrumentConfigurationService.Randomize"
                            OnResetClick="InstrumentConfigurationService.ConfigureDefaults"/>
+
+@if (!InstrumentConfigurationState.Value.IsValid)
+{
+    <MudAlert Severity="Severity.Warning" Class="mx-3" Variant="Variant.Outlined">Please enable at least two instruments.</MudAlert>
+}
 @foreach (var instrument in InstrumentConfigurationService.ConfigurableInstruments)
 {
     <InstrumentConfigurationCard Instrument="instrument"/>

--- a/src/BaroquenMelody.Library/Store/State/InstrumentConfigurationState.cs
+++ b/src/BaroquenMelody.Library/Store/State/InstrumentConfigurationState.cs
@@ -7,6 +7,8 @@ namespace BaroquenMelody.Library.Store.State;
 [FeatureState]
 public sealed record InstrumentConfigurationState(IDictionary<Instrument, InstrumentConfiguration> Configurations, IDictionary<Instrument, InstrumentConfiguration> LastUserAppliedConfigurations)
 {
+    private const int MinimumEnabledConfigurations = 2;
+
     public ISet<InstrumentConfiguration> EnabledConfigurations => Configurations.Values.Where(configuration => configuration.IsEnabled).ToHashSet();
 
     public InstrumentConfigurationState()
@@ -15,4 +17,8 @@ public sealed record InstrumentConfigurationState(IDictionary<Instrument, Instru
     }
 
     public InstrumentConfiguration? this[Instrument instrument] => Configurations.TryGetValue(instrument, out var configuration) ? configuration : null;
+
+    public bool IsValid => EnabledConfigurations.Count >= MinimumEnabledConfigurations;
+
+    public string ValidationMessage => IsValid ? string.Empty : "Cannot compose. Invalid instrumentation.";
 }

--- a/tests/BaroquenMelody.Library.Tests/Store/State/InstrumentConfigurationStateTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/State/InstrumentConfigurationStateTests.cs
@@ -1,0 +1,47 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Store.State;
+using FluentAssertions;
+using Melanchall.DryWetMidi.MusicTheory;
+using Melanchall.DryWetMidi.Standards;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Store.State;
+
+[TestFixture]
+internal sealed class InstrumentConfigurationStateTests
+{
+    [Test]
+    [TestCase(true, true, true)]
+    [TestCase(true, false, false)]
+    public void IsValid_returns_expected_value(bool isInstrumentOneEnabled, bool isInstrumentTwoEnabled, bool expectedIsValid)
+    {
+        // act
+        var state = new InstrumentConfigurationState(
+            new Dictionary<Instrument, InstrumentConfiguration>
+            {
+                {
+                    Instrument.One,
+                    new InstrumentConfiguration(Instrument.One, Notes.C4, Notes.C5, GeneralMidi2Program.Dulcimer, isInstrumentOneEnabled)
+                },
+                {
+                    Instrument.Two,
+                    new InstrumentConfiguration(Instrument.Two, Notes.C4, Notes.C5, GeneralMidi2Program.Dulcimer, isInstrumentTwoEnabled)
+                },
+            },
+            new Dictionary<Instrument, InstrumentConfiguration>()
+        );
+
+        // assert
+        state.IsValid.Should().Be(expectedIsValid);
+
+        if (!expectedIsValid)
+        {
+            state.ValidationMessage.Should().NotBeNullOrEmpty();
+        }
+        else
+        {
+            state.ValidationMessage.Should().BeNullOrEmpty();
+        }
+    }
+}


### PR DESCRIPTION
## Description

Validate instrument configurations before allowing the user to compose, preventing the possibility of invalid instrumentation to cause errors. 

- Disable "Compose" buttons when instrumentation is invalid
- Show tooltip to the user describing invalid state
- Show warning icon on "Instrumentation" tab when instrumentation is invalid

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
