### PR TITLE
Save Light / Dark Theme Preference

### DIFF
--- a/src/BaroquenMelody.App.Components/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BaroquenMelody.App.Components/Extensions/ServiceCollectionExtensions.cs
@@ -17,6 +17,5 @@ public static class ServiceCollectionExtensions
             config.SnackbarConfiguration.SnackbarVariant = Variant.Outlined;
         })
         .AddMudExtensions()
-        .AddBaroquenMelody()
-        .AddSingleton<IThemeProvider, ThemeProvider>();
+        .AddBaroquenMelody();
 }

--- a/src/BaroquenMelody.App/Infrastructure/Theme/MauiThemeProvider.cs
+++ b/src/BaroquenMelody.App/Infrastructure/Theme/MauiThemeProvider.cs
@@ -1,8 +1,9 @@
-﻿using MudBlazor;
+﻿using BaroquenMelody.App.Components;
+using MudBlazor;
 
-namespace BaroquenMelody.App.Components;
+namespace BaroquenMelody.App.Infrastructure.Theme;
 
-internal sealed class ThemeProvider : IThemeProvider
+internal sealed class MauiThemeProvider : IThemeProvider
 {
     private static readonly PaletteLight _lightPalette = new()
     {
@@ -51,7 +52,11 @@ internal sealed class ThemeProvider : IThemeProvider
         LayoutProperties = new LayoutProperties()
     };
 
-    public bool IsDarkMode { get; private set; } = true;
+    public bool IsDarkMode
+    {
+        get => Preferences.Get("IsDarkMode", true);
+        private set => Preferences.Set("IsDarkMode", value);
+    }
 
     public string DarkLightModeButtonIcon => IsDarkMode switch
     {
@@ -59,10 +64,10 @@ internal sealed class ThemeProvider : IThemeProvider
         false => Icons.Material.Rounded.DarkMode
     };
 
-    public Color DarkLightModeIconColor => IsDarkMode switch
+    public MudBlazor.Color DarkLightModeIconColor => IsDarkMode switch
     {
-        true => Color.Warning,
-        false => Color.Primary
+        true => MudBlazor.Color.Warning,
+        false => MudBlazor.Color.Primary
     };
 
     public string DarkLightModeTooltipText => IsDarkMode switch

--- a/src/BaroquenMelody.App/MauiProgram.cs
+++ b/src/BaroquenMelody.App/MauiProgram.cs
@@ -1,5 +1,7 @@
-﻿using BaroquenMelody.App.Components.Extensions;
+﻿using BaroquenMelody.App.Components;
+using BaroquenMelody.App.Components.Extensions;
 using BaroquenMelody.App.Infrastructure.FileSystem;
+using BaroquenMelody.App.Infrastructure.Theme;
 using BaroquenMelody.Library.Infrastructure.FileSystem;
 using CommunityToolkit.Maui;
 using Microsoft.AspNetCore.Components.WebView.Maui;
@@ -20,6 +22,7 @@ public static class MauiProgram
         builder.Services.AddMauiBlazorWebView();
         builder.Services.AddSingleton<IMidiLauncher, MauiMidiLauncher>();
         builder.Services.AddSingleton<IMidiSaver, MauiMidiSaver>();
+        builder.Services.AddSingleton<IThemeProvider, MauiThemeProvider>();
         builder.Services.AddBaroquenMelodyComponents();
 
 #if DEBUG


### PR DESCRIPTION
## Description

Use the MAUI `Preferences` abstraction to save light / dark mode as a user preference.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
