### PR TITLE
Configuration Serialization

### DIFF
--- a/benchmarks/BaroquenMelody.Benchmarks/Compositions/BenchmarkData.cs
+++ b/benchmarks/BaroquenMelody.Benchmarks/Compositions/BenchmarkData.cs
@@ -1,6 +1,7 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
 
@@ -24,7 +25,8 @@ internal static class BenchmarkData
         ),
         AggregateCompositionRuleConfiguration.Default,
         AggregateOrnamentationConfiguration.Default,
-        BaroquenScale.Parse("D Dorian"),
+        NoteName.D,
+        Mode.Dorian,
         Meter.FourFour,
         MusicalTimeSpan.Half,
         25

--- a/src/BaroquenMelody.App/MauiProgram.cs
+++ b/src/BaroquenMelody.App/MauiProgram.cs
@@ -5,6 +5,7 @@ using BaroquenMelody.App.Infrastructure.Theme;
 using BaroquenMelody.Library.Infrastructure.FileSystem;
 using CommunityToolkit.Maui;
 using Microsoft.AspNetCore.Components.WebView.Maui;
+using Microsoft.Extensions.Logging;
 
 namespace BaroquenMelody.App;
 

--- a/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
+++ b/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
@@ -41,4 +41,8 @@
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Infrastructure\Serialization\JsonSerializerContexts\" />
+  </ItemGroup>
+
 </Project>

--- a/src/BaroquenMelody.Library/Compositions/Composers/Composer.cs
+++ b/src/BaroquenMelody.Library/Compositions/Composers/Composer.cs
@@ -55,7 +55,7 @@ internal sealed class Composer(
 
         var compositionBody = new List<Measure>();
 
-        while (compositionBody.Count < compositionConfiguration.CompositionLength)
+        while (compositionBody.Count < compositionConfiguration.MinimumMeasures)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -82,7 +82,7 @@ internal sealed class Composer(
 
     private void DispatchProgress(int currentMeasureCount)
     {
-        dispatcher.Dispatch(new ProgressCompositionBodyProgress((double)currentMeasureCount / compositionConfiguration.CompositionLength * 100));
+        dispatcher.Dispatch(new ProgressCompositionBodyProgress((double)currentMeasureCount / compositionConfiguration.MinimumMeasures * 100));
     }
 
     private Composition AddOrnamentation(Composition composition, CancellationToken cancellationToken)
@@ -118,7 +118,7 @@ internal sealed class Composer(
                 compositionPhraser.AttemptPhraseRepetition(phrasedMeasures);
             }
 
-            if (phrasedMeasures.Count >= compositionConfiguration.CompositionLength)
+            if (phrasedMeasures.Count >= compositionConfiguration.MinimumMeasures)
             {
                 break;
             }

--- a/src/BaroquenMelody.Library/Compositions/Composers/ThemeComposer.cs
+++ b/src/BaroquenMelody.Library/Compositions/Composers/ThemeComposer.cs
@@ -107,7 +107,7 @@ internal sealed class ThemeComposer(
             beats.Add(new Beat(nextChord));
         }
 
-        return new List<Measure>(compositionConfiguration.CompositionLength)
+        return new List<Measure>(compositionConfiguration.MinimumMeasures)
         {
             new(beats, compositionConfiguration.Meter)
         };

--- a/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
@@ -1,7 +1,9 @@
 ﻿using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Enums.Extensions;
+using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
 using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.MusicTheory;
 using Note = Melanchall.DryWetMidi.MusicTheory.Note;
 
 namespace BaroquenMelody.Library.Compositions.Configurations;
@@ -13,8 +15,9 @@ namespace BaroquenMelody.Library.Compositions.Configurations;
 /// <param name="PhrasingConfiguration"> The phrasing configuration to be used in the composition. </param>
 /// <param name="AggregateCompositionRuleConfiguration"> The configuration of the composition rules to use in the composition. </param>
 /// <param name="AggregateOrnamentationConfiguration"> The configuration of the ornamentations to use in the composition. </param>
-/// <param name="Scale"> The scale to be used in the composition. </param>
-/// <param name="CompositionLength"> The length of the composition in measures. </param>
+/// <param name="Tonic"> The tonic note of the composition. </param>
+/// <param name="Mode"> The mode of the composition. </param>
+/// <param name="MinimumMeasures"> The length of the composition in measures. </param>
 /// <param name="Meter"> The meter to be used in the composition. </param>
 /// <param name="DefaultNoteTimeSpan"> The default note time span to be used in the composition. </param>
 /// <param name="CompositionContextSize"> The size of the context to be used in the composition. </param>
@@ -24,10 +27,11 @@ public sealed record CompositionConfiguration(
     PhrasingConfiguration PhrasingConfiguration,
     AggregateCompositionRuleConfiguration AggregateCompositionRuleConfiguration,
     AggregateOrnamentationConfiguration AggregateOrnamentationConfiguration,
-    BaroquenScale Scale,
+    NoteName Tonic,
+    Mode Mode,
     Meter Meter,
     MusicalTimeSpan DefaultNoteTimeSpan,
-    int CompositionLength,
+    int MinimumMeasures,
     int CompositionContextSize = 8,
     int Tempo = 120)
 {
@@ -44,6 +48,8 @@ public sealed record CompositionConfiguration(
     public List<Instrument> Instruments { get; } = InstrumentConfigurations.Select(static instrumentConfiguration => instrumentConfiguration.Instrument).ToList();
 
     public int BeatsPerMeasure => Meter.BeatsPerMeasure();
+
+    public BaroquenScale Scale { get; } = new(Tonic, Mode);
 
     /// <summary>
     ///     Determine if the given note is within the range of the given instrument for the composition.

--- a/src/BaroquenMelody.Library/Compositions/Domain/BaroquenScale.cs
+++ b/src/BaroquenMelody.Library/Compositions/Domain/BaroquenScale.cs
@@ -89,7 +89,18 @@ public sealed class BaroquenScale
     /// </summary>
     public Scale Raw { get; }
 
-    public BaroquenScale(Scale raw)
+    /// <summary>
+    ///     The mode of the scale.
+    /// </summary>
+    public Mode Mode { get; }
+
+    public BaroquenScale(NoteName tonic, Mode mode)
+        : this(Scale.Parse($"{tonic} {mode}"))
+    {
+        Mode = mode;
+    }
+
+    private BaroquenScale(Scale raw)
     {
         Raw = raw;
         _notes = raw.GetNotes().ToList();
@@ -116,18 +127,6 @@ public sealed class BaroquenScale
         VI = [Submediant, Tonic, Mediant];
         VII = [LeadingTone, Supertonic, Subdominant];
     }
-
-    public BaroquenScale(NoteName tonic, Mode mode)
-        : this(Scale.Parse($"{tonic} {mode}"))
-    {
-    }
-
-    /// <summary>
-    ///     Converts a string representation of a musical scale into its equivalent <see cref="BaroquenScale"/>.
-    /// </summary>
-    /// <param name="scale">The string representation of a musical scale.</param>
-    /// <returns>The equivalent <see cref="BaroquenScale"/>.</returns>
-    public static BaroquenScale Parse(string scale) => new(Scale.Parse(scale));
 
     /// <summary>
     ///     Retrieve all notes in the scale.

--- a/src/BaroquenMelody.Library/Infrastructure/Serialization/JsonConverters/MusicalTimespanJsonConverter.cs
+++ b/src/BaroquenMelody.Library/Infrastructure/Serialization/JsonConverters/MusicalTimespanJsonConverter.cs
@@ -1,0 +1,12 @@
+﻿using Melanchall.DryWetMidi.Interaction;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BaroquenMelody.Library.Infrastructure.Serialization.JsonConverters;
+
+public sealed class MusicalTimespanJsonConverter : JsonConverter<MusicalTimeSpan>
+{
+    public override MusicalTimeSpan? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => MusicalTimeSpan.Parse(reader.GetString());
+
+    public override void Write(Utf8JsonWriter writer, MusicalTimeSpan value, JsonSerializerOptions options) => writer.WriteStringValue(value.ToString());
+}

--- a/src/BaroquenMelody.Library/Infrastructure/Serialization/JsonConverters/NoteJsonConverter.cs
+++ b/src/BaroquenMelody.Library/Infrastructure/Serialization/JsonConverters/NoteJsonConverter.cs
@@ -1,0 +1,12 @@
+﻿using Melanchall.DryWetMidi.MusicTheory;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BaroquenMelody.Library.Infrastructure.Serialization.JsonConverters;
+
+public sealed class NoteJsonConverter : JsonConverter<Note>
+{
+    public override Note? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => Note.Parse(reader.GetString());
+
+    public override void Write(Utf8JsonWriter writer, Note value, JsonSerializerOptions options) => writer.WriteStringValue(value.ToString());
+}

--- a/src/BaroquenMelody.Library/Infrastructure/Serialization/JsonSerializerContexts/CompositionConfigurationJsonSerializerContext.cs
+++ b/src/BaroquenMelody.Library/Infrastructure/Serialization/JsonSerializerContexts/CompositionConfigurationJsonSerializerContext.cs
@@ -1,0 +1,13 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+using System.Text.Json.Serialization;
+
+namespace BaroquenMelody.Library.Infrastructure.Serialization.JsonSerializerContexts;
+
+/// <summary>
+///     Provides a context for serializing and deserializing <see cref="CompositionConfiguration"/> objects.
+/// </summary>
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(CompositionConfiguration))]
+public partial class CompositionConfigurationJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/src/BaroquenMelody.Library/Store/Effects/BaroquenMelodyEffects.cs
+++ b/src/BaroquenMelody.Library/Store/Effects/BaroquenMelodyEffects.cs
@@ -29,7 +29,8 @@ public sealed class BaroquenMelodyEffects(
             PhrasingConfiguration.Default,
             compositionRuleConfigurationState.Value.Aggregate,
             compositionOrnamentationConfigurationState.Value.Aggregate,
-            compositionConfigurationState.Value.Scale,
+            compositionConfigurationState.Value.TonicNote,
+            compositionConfigurationState.Value.Mode,
             compositionConfigurationState.Value.Meter,
             compositionConfigurationState.Value.Meter.DefaultMusicalTimeSpan(),
             compositionConfigurationState.Value.MinimumMeasures

--- a/src/BaroquenMelody/App.cs
+++ b/src/BaroquenMelody/App.cs
@@ -51,7 +51,8 @@ internal sealed class App : IDisposable
             PhrasingConfiguration.Default,
             _compositionRuleConfigurationState.Value.Aggregate,
             _compositionOrnamentationConfigurationState.Value.Aggregate,
-            BaroquenScale.Parse($"{_compositionConfigurationState.Value.TonicNote} {_compositionConfigurationState.Value.Mode}"),
+            _compositionConfigurationState.Value.TonicNote,
+            _compositionConfigurationState.Value.Mode,
             _compositionConfigurationState.Value.Meter,
             _compositionConfigurationState.Value.Meter.DefaultMusicalTimeSpan(),
             _compositionConfigurationState.Value.MinimumMeasures

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ComposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ComposerTests.cs
@@ -106,7 +106,7 @@ internal sealed class ComposerTests
 
         // assert
         composition.Should().NotBeNull();
-        composition.Measures.Should().HaveCountGreaterOrEqualTo(_compositionConfiguration.CompositionLength);
+        composition.Measures.Should().HaveCountGreaterOrEqualTo(_compositionConfiguration.MinimumMeasures);
 
         foreach (var measure in composition.Measures)
         {
@@ -116,7 +116,7 @@ internal sealed class ComposerTests
         _mockCompositionStrategy.Received(1).GenerateInitialChord();
 
         _mockCompositionStrategy
-            .Received(_compositionConfiguration.CompositionLength * _compositionConfiguration.BeatsPerMeasure + 4) // 4 more to account for theme generation and cadence handling
+            .Received(_compositionConfiguration.MinimumMeasures * _compositionConfiguration.BeatsPerMeasure + 4) // 4 more to account for theme generation and cadence handling
             .GetPossibleChordChoices(Arg.Any<IReadOnlyList<BaroquenChord>>());
 
         _mockCompositionDecorator.Received(4).Decorate(Arg.Any<Composition>());

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/CompositionConfigurationTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/CompositionConfigurationTests.cs
@@ -1,9 +1,10 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Extensions;
+using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.MusicTheory;
 using NUnit.Framework;
 
 namespace BaroquenMelody.Library.Tests.Compositions.Configuration;
@@ -31,10 +32,11 @@ internal sealed class CompositionConfigurationTests
             PhrasingConfiguration.Default,
             AggregateCompositionRuleConfiguration.Default,
             AggregateOrnamentationConfiguration.Default,
-            BaroquenScale.Parse("C Major"),
+            NoteName.C,
+            Mode.Aeolian,
             Meter.FourFour,
             MusicalTimeSpan.Half,
-            CompositionLength: 100
+            MinimumMeasures: 100
         );
     }
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BaroquenScaleTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BaroquenScaleTests.cs
@@ -13,7 +13,7 @@ internal sealed class BaroquenScaleTests
     public void ScaleDegrees_ReturnExpectedNoteNames()
     {
         // arrange
-        var scale = BaroquenScale.Parse("C Major");
+        var scale = new BaroquenScale(NoteName.C, Mode.Ionian);
 
         // act + assert
         scale.Tonic.Should().Be(NoteName.C);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Extensions/BaroquenNoteExtensionsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Extensions/BaroquenNoteExtensionsTests.cs
@@ -2,6 +2,7 @@
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Extensions;
+using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -17,7 +18,7 @@ internal sealed class BaroquenNoteExtensionsTests
     {
         // arrange
         var note = new BaroquenNote(Instrument.One, Notes.A4, MusicalTimeSpan.Half);
-        var scale = BaroquenScale.Parse("C Major");
+        var scale = new BaroquenScale(NoteName.C, Mode.Ionian);
         var noteChoice = new NoteChoice(Instrument.One, NoteMotion.Ascending, 2);
 
         // act
@@ -32,7 +33,7 @@ internal sealed class BaroquenNoteExtensionsTests
     {
         // arrange
         var note = new BaroquenNote(Instrument.One, Notes.C5, MusicalTimeSpan.Half);
-        var scale = BaroquenScale.Parse("C Major");
+        var scale = new BaroquenScale(NoteName.C, Mode.Ionian);
         var noteChoice = new NoteChoice(Instrument.One, NoteMotion.Descending, 2);
 
         // act
@@ -47,7 +48,7 @@ internal sealed class BaroquenNoteExtensionsTests
     {
         // arrange
         var note = new BaroquenNote(Instrument.One, Notes.C5, MusicalTimeSpan.Half);
-        var scale = BaroquenScale.Parse("C Major");
+        var scale = new BaroquenScale(NoteName.C, Mode.Aeolian);
         var noteChoice = new NoteChoice(Instrument.One, NoteMotion.Oblique, 0);
 
         // act
@@ -62,7 +63,7 @@ internal sealed class BaroquenNoteExtensionsTests
     {
         // arrange
         var note = new BaroquenNote(Instrument.One, Notes.C5, MusicalTimeSpan.Half);
-        var scale = BaroquenScale.Parse("C Major");
+        var scale = new BaroquenScale(NoteName.C, Mode.Aeolian);
         var noteChoice = new NoteChoice(Instrument.One, (NoteMotion)99, 0);
 
         // act

--- a/tests/BaroquenMelody.Library.Tests/Infrastructure/Serialization/CompositionConfigurationSerializationTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Infrastructure/Serialization/CompositionConfigurationSerializationTests.cs
@@ -1,0 +1,107 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
+using BaroquenMelody.Library.Infrastructure.Serialization.JsonConverters;
+using BaroquenMelody.Library.Infrastructure.Serialization.JsonSerializerContexts;
+using FluentAssertions;
+using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.MusicTheory;
+using Melanchall.DryWetMidi.Standards;
+using NUnit.Framework;
+using System.Text.Json;
+
+namespace BaroquenMelody.Library.Tests.Infrastructure.Serialization;
+
+[TestFixture]
+internal sealed class CompositionConfigurationSerializationTests
+{
+    [Test]
+    public void Serialization_works_as_expected()
+    {
+        // arrange
+        var compositionConfiguration = new CompositionConfiguration(
+            new HashSet<InstrumentConfiguration>
+            {
+                new(Instrument.One, Notes.C4, Notes.G5, GeneralMidi2Program.Accordion, false),
+                new(Instrument.Two, Notes.C3, Notes.G4),
+                new(Instrument.Three, Notes.C2, Notes.G3),
+                new(Instrument.Four, Notes.C1, Notes.G2)
+            },
+            PhrasingConfiguration.Default,
+            AggregateCompositionRuleConfiguration.Default,
+            AggregateOrnamentationConfiguration.Default,
+            NoteName.C,
+            Mode.Aeolian,
+            Meter.FourFour,
+            MusicalTimeSpan.Half,
+            MinimumMeasures: 100
+        );
+
+        var jsonSerializerOptions = new JsonSerializerOptions
+        {
+            TypeInfoResolver = CompositionConfigurationJsonSerializerContext.Default,
+            Converters =
+            {
+                new MusicalTimespanJsonConverter(),
+                new NoteJsonConverter()
+            }
+        };
+
+        // act
+        var serializedConfiguration = JsonSerializer.Serialize(compositionConfiguration, jsonSerializerOptions);
+        var deserializedConfiguration = JsonSerializer.Deserialize<CompositionConfiguration>(serializedConfiguration, jsonSerializerOptions)!;
+
+        // assert
+        deserializedConfiguration.Tonic.Should().Be(compositionConfiguration.Tonic);
+        deserializedConfiguration.Mode.Should().Be(compositionConfiguration.Mode);
+        deserializedConfiguration.Meter.Should().Be(compositionConfiguration.Meter);
+        deserializedConfiguration.DefaultNoteTimeSpan.Should().Be(compositionConfiguration.DefaultNoteTimeSpan);
+        deserializedConfiguration.MinimumMeasures.Should().Be(compositionConfiguration.MinimumMeasures);
+
+        deserializedConfiguration.InstrumentConfigurations.Should().HaveCount(4);
+
+        foreach (var deserializedInstrumentConfiguration in deserializedConfiguration.InstrumentConfigurations)
+        {
+            var originalInstrumentConfiguration = compositionConfiguration.InstrumentConfigurations.First(instrumentConfiguration =>
+                instrumentConfiguration.Instrument == deserializedInstrumentConfiguration.Instrument
+            );
+
+            deserializedInstrumentConfiguration.Instrument.Should().Be(originalInstrumentConfiguration.Instrument);
+            deserializedInstrumentConfiguration.MinNote.Should().Be(originalInstrumentConfiguration.MinNote);
+            deserializedInstrumentConfiguration.MaxNote.Should().Be(originalInstrumentConfiguration.MaxNote);
+            deserializedInstrumentConfiguration.MidiProgram.Should().Be(originalInstrumentConfiguration.MidiProgram);
+            deserializedInstrumentConfiguration.IsEnabled.Should().Be(originalInstrumentConfiguration.IsEnabled);
+        }
+
+        deserializedConfiguration.PhrasingConfiguration.PhraseLengths.Should().BeEquivalentTo(PhrasingConfiguration.Default.PhraseLengths);
+        deserializedConfiguration.PhrasingConfiguration.MaxPhraseRepetitions.Should().Be(PhrasingConfiguration.Default.MaxPhraseRepetitions);
+        deserializedConfiguration.PhrasingConfiguration.MinPhraseRepetitionPoolSize.Should().Be(PhrasingConfiguration.Default.MinPhraseRepetitionPoolSize);
+        deserializedConfiguration.PhrasingConfiguration.PhraseRepetitionProbability.Should().Be(PhrasingConfiguration.Default.PhraseRepetitionProbability);
+
+        deserializedConfiguration.AggregateCompositionRuleConfiguration.Configurations.Should().HaveCount(AggregateCompositionRuleConfiguration.Default.Configurations.Count);
+
+        foreach (var deserializedCompositionRuleConfiguration in deserializedConfiguration.AggregateCompositionRuleConfiguration.Configurations)
+        {
+            var originalCompositionRuleConfiguration = compositionConfiguration.AggregateCompositionRuleConfiguration.Configurations.First(compositionRuleConfiguration =>
+                compositionRuleConfiguration.Rule == deserializedCompositionRuleConfiguration.Rule
+            );
+
+            deserializedCompositionRuleConfiguration.Rule.Should().Be(originalCompositionRuleConfiguration.Rule);
+            deserializedCompositionRuleConfiguration.IsEnabled.Should().Be(originalCompositionRuleConfiguration.IsEnabled);
+            deserializedCompositionRuleConfiguration.Strictness.Should().Be(originalCompositionRuleConfiguration.Strictness);
+        }
+
+        deserializedConfiguration.AggregateOrnamentationConfiguration.Configurations.Should().HaveCount(AggregateOrnamentationConfiguration.Default.Configurations.Count);
+
+        foreach (var deserializedOrnamentationConfiguration in deserializedConfiguration.AggregateOrnamentationConfiguration.Configurations)
+        {
+            var originalOrnamentationConfiguration = compositionConfiguration.AggregateOrnamentationConfiguration.Configurations.First(ornamentationConfiguration =>
+                ornamentationConfiguration.OrnamentationType == deserializedOrnamentationConfiguration.OrnamentationType
+            );
+
+            deserializedOrnamentationConfiguration.OrnamentationType.Should().Be(originalOrnamentationConfiguration.OrnamentationType);
+            deserializedOrnamentationConfiguration.IsEnabled.Should().Be(originalOrnamentationConfiguration.IsEnabled);
+            deserializedOrnamentationConfiguration.Probability.Should().Be(originalOrnamentationConfiguration.Probability);
+        }
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/TestData/Configurations.cs
+++ b/tests/BaroquenMelody.Library.Tests/TestData/Configurations.cs
@@ -1,6 +1,7 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
 
@@ -16,10 +17,11 @@ internal static class Configurations
         PhrasingConfiguration.Default,
         AggregateCompositionRuleConfiguration.Default,
         AggregateOrnamentationConfiguration.Default,
-        BaroquenScale.Parse("C Major"),
+        NoteName.C,
+        Mode.Ionian,
         Meter.FourFour,
         MusicalTimeSpan.Half,
-        CompositionLength: compositionLength
+        MinimumMeasures: compositionLength
     );
 
     private static HashSet<InstrumentConfiguration> GenerateInstrumentConfigurations(int numberOfInstruments) => numberOfInstruments switch


### PR DESCRIPTION
## Description

Enable serialization of composition configurations. This is a precursor to allowing users to save configurations.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
