### PR TITLE
Save Composition Configurations UI

### DIFF
--- a/src/BaroquenMelody.App.Components/Layout/MainLayout.razor
+++ b/src/BaroquenMelody.App.Components/Layout/MainLayout.razor
@@ -4,27 +4,30 @@
 
 <MudThemeProvider Theme="@ThemeProvider.Theme" IsDarkMode="ThemeProvider.IsDarkMode"/>
 <MudPopoverProvider/>
-<MudDialogProvider/>
 <MudSnackbarProvider/>
+<MudDialogProvider 
+    BackdropClick="false"
+    FullWidth="true"
+    MaxWidth="MaxWidth.Small"/>
 
 <MudLayout>
     <MudAppBar Elevation="3" Dense="true" Gutters="false">
-        <MudIconButton Class="ml-3" Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@(_ => ToggleDrawer())"/>
+        <MudIconButton Class="ml-3" Icon="@Icons.Material.Sharp.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@(_ => _isDrawerOpen = !_isDrawerOpen)"/>
         <MudSpacer/>
-        <MudTooltip  Delay="@ThemeProvider.TooltipDelay" Duration="@ThemeProvider.TooltipDuration" Text="source code">
-            <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://www.github.com/wbaldoumas/baroquen-melody"/>    
+        <MudTooltip Delay="@ThemeProvider.TooltipDelay" Duration="@ThemeProvider.TooltipDuration" Text="source code">
+            <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://www.github.com/wbaldoumas/baroquen-melody"/>
         </MudTooltip>
         <MudTooltip Delay="@ThemeProvider.TooltipDelay" Duration="@ThemeProvider.TooltipDuration" Text="@ThemeProvider.DarkLightModeTooltipText">
             <MudIconButton Icon="@(ThemeProvider.DarkLightModeButtonIcon)" Color="@(ThemeProvider.DarkLightModeIconColor)" OnClick="@ThemeProvider.ToggleDarkMode"/>
         </MudTooltip>
         <MudTooltip Delay="@ThemeProvider.TooltipDelay" Duration="@ThemeProvider.TooltipDuration" Text="more options" Placement="Placement.Left">
-            <MudMenu Icon="@Icons.Material.Filled.MoreVert"
+            <MudMenu Icon="@Icons.Material.Sharp.MoreVert"
                      Class="mr-3"
                      AriaLabel="more options">
-                <MudMenuItem Icon="@Icons.Material.Filled.Lightbulb" IconColor="Color.Warning" Href="https://github.com/wbaldoumas/baroquen-melody/issues/new?template=FEATURE_REQUEST.md">Feature request</MudMenuItem>
-                <MudMenuItem Icon="@Icons.Material.Outlined.BugReport" IconColor="Color.Tertiary" Href="https://github.com/wbaldoumas/baroquen-melody/issues/new?template=BUG_REPORT.md">Report a bug</MudMenuItem>
-                <MudMenuItem Icon="@Icons.Material.Outlined.Shield" IconColor="Color.Info" Href="https://github.com/wbaldoumas/baroquen-melody/security/policy">Report a vulnerability</MudMenuItem>
-                <MudMenuItem Icon="@Icons.Material.Filled.Favorite" IconColor="Color.Secondary">Donate</MudMenuItem>
+                <MudMenuItem Icon="@Icons.Material.Sharp.Lightbulb" IconColor="Color.Warning" Href="https://github.com/wbaldoumas/baroquen-melody/issues/new?template=FEATURE_REQUEST.md">Feature request</MudMenuItem>
+                <MudMenuItem Icon="@Icons.Material.Sharp.BugReport" IconColor="Color.Tertiary" Href="https://github.com/wbaldoumas/baroquen-melody/issues/new?template=BUG_REPORT.md">Report a bug</MudMenuItem>
+                <MudMenuItem Icon="@Icons.Material.Sharp.Shield" IconColor="Color.Info" Href="https://github.com/wbaldoumas/baroquen-melody/security/policy">Report a vulnerability</MudMenuItem>
+                <MudMenuItem Icon="@Icons.Material.Sharp.Favorite" IconColor="Color.Secondary">Donate</MudMenuItem>
             </MudMenu>
         </MudTooltip>
     </MudAppBar>
@@ -42,6 +45,4 @@
 @code
 {
     private bool _isDrawerOpen;
-
-    private void ToggleDrawer() => _isDrawerOpen = !_isDrawerOpen;
 }

--- a/src/BaroquenMelody.App.Components/Layout/NavMenu.razor
+++ b/src/BaroquenMelody.App.Components/Layout/NavMenu.razor
@@ -1,5 +1,6 @@
 ﻿<MudNavMenu Bordered="true" Color="Color.Primary" Rounded="true">
     <MudDivider />
-    <MudNavLink Href="" Match="NavLinkMatch.All" IconColor="Color.Secondary" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
-    <MudNavLink Href="about" Match="NavLinkMatch.Prefix" IconColor="Color.Secondary" Icon="@Icons.Material.Filled.QuestionMark">About</MudNavLink>
+    <MudNavLink Href="" Match="NavLinkMatch.All" IconColor="Color.Secondary" Icon="@Icons.Material.Sharp.Home">Home</MudNavLink>
+    <MudNavLink Href="configurations" Match="NavLinkMatch.Prefix" IconColor="Color.Secondary" Icon="@Icons.Material.Sharp.Folder">Saved Configurations</MudNavLink>
+    <MudNavLink Href="about" Match="NavLinkMatch.Prefix" IconColor="Color.Secondary" Icon="@Icons.Material.Sharp.QuestionMark">About</MudNavLink>
 </MudNavMenu>

--- a/src/BaroquenMelody.App.Components/Pages/Home.razor
+++ b/src/BaroquenMelody.App.Components/Pages/Home.razor
@@ -2,16 +2,10 @@
 
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
-<PageTitle>Home</PageTitle>
+<PageTitle>Baroquen Melody</PageTitle>
 
 <MudContainer Class="mb-3" Gutters="false">
-    <MudGrid Class="mb-2" Justify="Justify.FlexEnd" Spacing="1">
-        <MudItem>
-            <MudButton Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Folder" IconColor="Color.Primary">Load Configuration</MudButton>
-        </MudItem>
-        <MudItem>
-            <MudButton Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Save" IconColor="Color.Secondary">Save Configuration</MudButton>
-        </MudItem>
+    <MudGrid Class="mb-2 d-flex justify-center justify-sm-end flex-grow-1 flex-sm-grow-0" Spacing="2">
         <MudItem>
             @if (!CompositionProgressState.Value.IsLoading)
             {
@@ -24,7 +18,8 @@
                                StartIcon="@Icons.Material.Filled.ElectricBolt"
                                Color="Color.Tertiary"
                                OnClick="Compose"
-                               Disabled="@(CompositionProgressState.Value.IsLoading || !InstrumentConfigurationState.Value.IsValid)">
+                               Disabled="@(CompositionProgressState.Value.IsLoading || !InstrumentConfigurationState.Value.IsValid)"
+                               FullWidth="true">
                         Compose
                     </MudButton>
                 </MudTooltip>
@@ -33,11 +28,21 @@
             {
                 <MudButton Variant="Variant.Filled"
                            Color="Color.Tertiary"
-                           Disabled="@CompositionProgressState.Value.IsLoading">
+                           Disabled="@CompositionProgressState.Value.IsLoading"
+                           FullWidth="true">
                     <MudProgressCircular Class="ms-n1" Size="Size.Small" Indeterminate="true"/>
                     <MudText Class="ms-2" Typo="Typo.button">Compose</MudText>
                 </MudButton>
             }
+        </MudItem>
+        <MudItem>
+            <MudButton Variant="Variant.Filled"
+                       StartIcon="@Icons.Material.Filled.Save"
+                       IconColor="Color.Primary"
+                       FullWidth="true"
+                       OnClick="SaveCompositionConfiguration">
+                Save Configuration
+            </MudButton>
         </MudItem>
     </MudGrid>
     <MudTabs Outlined="true"
@@ -102,7 +107,7 @@
     {
         if (!BaroquenMelodyState.Value.HasBeenSaved && BaroquenMelodyState.Value.BaroquenMelody is not null)
         {
-            var dialogReference = await Dialog.ShowAsync<ConfirmCompositionDialogue>("Save composition?", new DialogOptions());
+            var dialogReference = await Dialog.ShowAsync<ConfirmCompositionDialogue>("Save composition?");
             var dialogResult = await dialogReference.Result;
 
             if (dialogResult?.Canceled ?? false)
@@ -141,6 +146,27 @@
         {
             Snackbar.Add("Saved composition!", Severity.Success);
             Dispatcher.Dispatch(new MarkCompositionSaved());
+        }
+    }
+
+    private async Task SaveCompositionConfiguration()
+    {
+        var dialogReference = await Dialog.ShowAsync<SaveCompositionConfigurationDialog>("Save composition configuration?");
+
+        var dialogResult = await dialogReference.Result;
+
+        if (dialogResult?.Canceled is true)
+        {
+            return;
+        }
+
+        if (dialogResult?.Data is true)
+        {
+            Snackbar.Add("Saved composition configuration!", Severity.Success);
+        }
+        else
+        {
+            Snackbar.Add("Failed to save composition configuration!", Severity.Error);
         }
     }
 

--- a/src/BaroquenMelody.App.Components/Pages/SavedConfigurations.razor
+++ b/src/BaroquenMelody.App.Components/Pages/SavedConfigurations.razor
@@ -1,0 +1,122 @@
+﻿@page "/configurations"
+
+<PageTitle>Saved Configurations</PageTitle>
+
+<MudContainer Class="my-3" Gutters="false">
+    <MudTable Items="@ConfigurationFiles"
+              Loading="@Loading"
+              Outlined="true"
+              LoadingProgressColor="Color.Primary"
+              Hover="true"
+              Filter="configuration => configuration.ConfigurationFile.Name.Contains(Search, StringComparison.OrdinalIgnoreCase)">
+        <ToolBarContent>
+            <MudTextField @bind-Value="Search"
+                          Placeholder="Search"
+                          Immediate="true"
+                          InputMode="InputMode.text"
+                          Adornment="Adornment.Start"
+                          AdornmentIcon="@Icons.Material.Outlined.Search"
+                          IconSize="Size.Medium"/>
+        </ToolBarContent>
+        <HeaderContent>
+            <MudTh>Configuration</MudTh>
+            <MudTh>Date Created</MudTh>
+            <MudTh/>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Configuration">
+                <MudLink Color="Color.Tertiary" Class="cursor-pointer" OnClick="_ => LoadConfiguration(context.Configuration)">
+                    @(Path.GetFileNameWithoutExtension(context.ConfigurationFile.Name))
+                </MudLink>
+            </MudTd>
+            <MudTd DataLabel="Created" HideSmall="true">
+                @context.ConfigurationFile.CreationTime
+            </MudTd>
+            <MudTd>
+                <MudStack Row="true" Justify="Justify.Center">
+                    <MudTooltip Text="load configuration" Delay="@ThemeProvider.TooltipDelay" Duration="@ThemeProvider.TooltipDuration">
+                        <MudIconButton Icon="@Icons.Material.Filled.FileOpen"
+                                       Color="Color.Primary"
+                                       Variant="Variant.Outlined"
+                                       OnClick="_ => LoadConfiguration(context.Configuration)"/>
+                    </MudTooltip>
+                    <MudTooltip Text="delete configuration" Delay="@ThemeProvider.TooltipDelay" Duration="@ThemeProvider.TooltipDuration">
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                                       Color="Color.Secondary"
+                                       Variant="Variant.Outlined"
+                                       OnClick="_ => DeleteConfigurationAsync(context.ConfigurationFile.Name)"/>
+                    </MudTooltip>
+                </MudStack>
+            </MudTd>
+        </RowTemplate>
+        <NoRecordsContent>
+            <div class="d-flex flex-shrink align-center justify-center ma-0" style="height:200px;">
+                <MudText Typo="Typo.h6">no configurations found</MudText>
+            </div>
+        </NoRecordsContent>
+        <PagerContent>
+            <MudTablePager/>
+        </PagerContent>
+    </MudTable>
+</MudContainer>
+
+@code {
+    private IEnumerable<SavedCompositionConfiguration> ConfigurationFiles = [];
+
+    private bool Loading = true;
+
+    private string Search = string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            ConfigurationFiles = await CompositionConfigurationPersistenceService.LoadConfigurationsAsync(CancellationToken.None);
+        }
+        catch (Exception)
+        {
+            Snackbar.Add("Failed to load configurations!", Severity.Error);
+        }
+        finally
+        {
+            Loading = false;
+        }
+    }
+
+    private async Task DeleteConfigurationAsync(string configurationName)
+    {
+        var shouldDelete = await DialogService.ShowMessageBox(
+            "Warning",
+            "Delete existing configuration?",
+            yesText: "Delete",
+            cancelText: "Cancel"
+        );
+
+        if (shouldDelete is not true)
+        {
+            return;
+        }
+
+        var isDeleted = await CompositionConfigurationPersistenceService.DeleteConfigurationAsync(configurationName, CancellationToken.None);
+
+        if (!isDeleted)
+        {
+            Snackbar.Add("Failed to delete configuration!", Severity.Error);
+
+            return;
+        }
+
+        ConfigurationFiles = ConfigurationFiles.Where(configurationFile => !configurationFile.ConfigurationFile.Name.Equals(
+            configurationName,
+            StringComparison.OrdinalIgnoreCase
+        ));
+    }
+
+    private void LoadConfiguration(CompositionConfiguration compositionConfiguration)
+    {
+        Dispatcher.Dispatch(new LoadSavedCompositionConfiguration(compositionConfiguration));
+
+        NavigationManager.NavigateTo("");
+    }
+
+}

--- a/src/BaroquenMelody.App.Components/Shared/SaveCompositionConfigurationDialog.razor
+++ b/src/BaroquenMelody.App.Components/Shared/SaveCompositionConfigurationDialog.razor
@@ -1,0 +1,76 @@
+﻿<MudDialog>
+    <TitleContent>
+        Save Composition Configuration
+    </TitleContent>
+    <DialogContent>
+        <MudTextField @bind-Value="ConfigurationName" 
+                      Label="Configuration Name" 
+                      Variant="Variant.Outlined"
+                      Immediate="true"
+                      Mask="FileNameMask"/>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Color="Color.Primary"
+                   OnClick="SaveCompositionConfiguration"
+                   Disabled="string.IsNullOrEmpty(ConfigurationName)">
+            Save
+        </MudButton>
+        <MudButton OnClick="Cancel">
+            Cancel
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    private string? ConfigurationName { get; set; }
+
+    private static readonly IMask FileNameMask = new RegexMask(@"^[\w\s-]+$");
+
+    [CascadingParameter] private MudDialogInstance? MudDialog { get; set; }
+
+    private async Task SaveCompositionConfiguration()
+    {
+        var configurationFileExists = await CompositionConfigurationPersistenceService.DoesConfigurationExist(
+            ConfigurationName!,
+            new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token
+        );
+
+        if (configurationFileExists)
+        {
+            var shouldOverwrite = await DialogService.ShowMessageBox(
+                "Warning",
+                "Configuration already exists. Overwrite?",
+                yesText: "Overwrite",
+                cancelText: "Cancel"
+            );
+
+            if (shouldOverwrite is not true)
+            {
+                return;
+            }
+        }
+
+        var compositionConfiguration = new CompositionConfiguration(
+            InstrumentConfigurationState.Value.AllConfigurations,
+            PhrasingConfiguration.Default,
+            CompositionRuleConfigurationState.Value.Aggregate,
+            OrnamentationConfigurationState.Value.Aggregate,
+            CompositionConfigurationState.Value.TonicNote,
+            CompositionConfigurationState.Value.Mode,
+            CompositionConfigurationState.Value.Meter,
+            CompositionConfigurationState.Value.Meter.DefaultMusicalTimeSpan(),
+            CompositionConfigurationState.Value.MinimumMeasures
+        );
+
+        var isSaved = await CompositionConfigurationPersistenceService.SaveConfigurationAsync(
+            compositionConfiguration,
+            ConfigurationName!,
+            new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token
+        );
+
+        MudDialog?.Close(DialogResult.Ok(isSaved));
+    }
+
+    private void Cancel() => MudDialog?.Cancel();
+
+}

--- a/src/BaroquenMelody.App.Components/_Imports.razor
+++ b/src/BaroquenMelody.App.Components/_Imports.razor
@@ -51,3 +51,6 @@
 @inject IMidiSaver MidiSaver
 @inject ISnackbar Snackbar
 @inject IDialogService Dialog
+@inject ICompositionConfigurationPersistenceService CompositionConfigurationPersistenceService
+@inject NavigationManager NavigationManager
+@inject IDialogService DialogService

--- a/src/BaroquenMelody.App/BaroquenMelody.App.csproj
+++ b/src/BaroquenMelody.App/BaroquenMelody.App.csproj
@@ -30,7 +30,7 @@
         <ApplicationTitle>Baroquen Melody</ApplicationTitle>
 
         <!-- App Identifier -->
-        <ApplicationId>com.companyname.baroquenmelody.app</ApplicationId>
+        <ApplicationId>com.wbaldoumas.baroquenmelody.app</ApplicationId>
 
         <!-- Versions -->
         <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>

--- a/src/BaroquenMelody.App/Infrastructure/FileSystem/MauiDeviceDirectoryProvider.cs
+++ b/src/BaroquenMelody.App/Infrastructure/FileSystem/MauiDeviceDirectoryProvider.cs
@@ -1,0 +1,8 @@
+﻿using BaroquenMelody.Library.Infrastructure.FileSystem;
+
+namespace BaroquenMelody.App.Infrastructure.FileSystem;
+
+internal sealed class MauiDeviceDirectoryProvider : IDeviceDirectoryProvider
+{
+    public string AppDataDirectory => Microsoft.Maui.Storage.FileSystem.Current.AppDataDirectory;
+}

--- a/src/BaroquenMelody.App/Infrastructure/FileSystem/MauiMidiSaver.cs
+++ b/src/BaroquenMelody.App/Infrastructure/FileSystem/MauiMidiSaver.cs
@@ -39,10 +39,13 @@ internal sealed class MauiMidiSaver : IMidiSaver
             return false;
         }
 
-        using var stream = File.OpenRead(tempPath);
+        var stream = File.OpenRead(tempPath);
 
-        var fileSaverResult = await FileSaver.Default.SaveAsync("Baroquen Melody.mid", stream, cancellationToken).ConfigureAwait(false);
+        await using (stream.ConfigureAwait(false))
+        {
+            var fileSaverResult = await FileSaver.Default.SaveAsync("Baroquen Melody.mid", stream, cancellationToken).ConfigureAwait(false);
 
-        return fileSaverResult.IsSuccessful;
+            return fileSaverResult.IsSuccessful;
+        }
     }
 }

--- a/src/BaroquenMelody.App/MauiProgram.cs
+++ b/src/BaroquenMelody.App/MauiProgram.cs
@@ -5,7 +5,6 @@ using BaroquenMelody.App.Infrastructure.Theme;
 using BaroquenMelody.Library.Infrastructure.FileSystem;
 using CommunityToolkit.Maui;
 using Microsoft.AspNetCore.Components.WebView.Maui;
-using Microsoft.Extensions.Logging;
 
 namespace BaroquenMelody.App;
 
@@ -24,6 +23,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<IMidiLauncher, MauiMidiLauncher>();
         builder.Services.AddSingleton<IMidiSaver, MauiMidiSaver>();
         builder.Services.AddSingleton<IThemeProvider, MauiThemeProvider>();
+        builder.Services.AddSingleton<IDeviceDirectoryProvider, MauiDeviceDirectoryProvider>();
         builder.Services.AddBaroquenMelodyComponents();
 
 #if DEBUG

--- a/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
+++ b/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
@@ -28,6 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.IO.Abstractions" Version="21.0.29" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
   </ItemGroup>
 
@@ -39,10 +40,6 @@
     <InternalsVisibleTo Include="$(AssemblyName).Tests" />
     <InternalsVisibleTo Include="BaroquenMelody.Benchmarks" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Infrastructure\Serialization\JsonSerializerContexts\" />
   </ItemGroup>
 
 </Project>

--- a/src/BaroquenMelody.Library/Compositions/Composers/ThemeComposer.cs
+++ b/src/BaroquenMelody.Library/Compositions/Composers/ThemeComposer.cs
@@ -54,7 +54,7 @@ internal sealed class ThemeComposer(
 
     private void DispatchProgress(int attempt)
     {
-        dispatcher.Dispatch(new ProgressCompositionThemeProgress(((double)attempt / MaxFugueCompositionAttempts) * 100));
+        dispatcher.Dispatch(new ProgressCompositionThemeProgress((double)attempt / MaxFugueCompositionAttempts * 100));
     }
 
     private bool TryComposeFugalTheme(out BaroquenTheme? theme, CancellationToken cancellationToken)

--- a/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/CompositionConfiguration.cs
@@ -2,8 +2,10 @@
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Enums.Extensions;
 using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
+using BaroquenMelody.Library.Infrastructure.Serialization.JsonConverters;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
+using System.Text.Json.Serialization;
 using Note = Melanchall.DryWetMidi.MusicTheory.Note;
 
 namespace BaroquenMelody.Library.Compositions.Configurations;
@@ -30,7 +32,7 @@ public sealed record CompositionConfiguration(
     NoteName Tonic,
     Mode Mode,
     Meter Meter,
-    MusicalTimeSpan DefaultNoteTimeSpan,
+    [property: JsonConverter(typeof(MusicalTimespanJsonConverter))] MusicalTimeSpan DefaultNoteTimeSpan,
     int MinimumMeasures,
     int CompositionContextSize = 8,
     int Tempo = 120)

--- a/src/BaroquenMelody.Library/Compositions/Configurations/InstrumentConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/InstrumentConfiguration.cs
@@ -1,6 +1,8 @@
 ﻿using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Infrastructure.Serialization.JsonConverters;
 using Melanchall.DryWetMidi.MusicTheory;
 using Melanchall.DryWetMidi.Standards;
+using System.Text.Json.Serialization;
 
 namespace BaroquenMelody.Library.Compositions.Configurations;
 
@@ -14,8 +16,8 @@ namespace BaroquenMelody.Library.Compositions.Configurations;
 /// <param name="MidiProgram"> The instrument's midi program. </param>
 public sealed record InstrumentConfiguration(
     Instrument Instrument,
-    Note MinNote,
-    Note MaxNote,
+    [property: JsonConverter(typeof(NoteJsonConverter))] Note MinNote,
+    [property: JsonConverter(typeof(NoteJsonConverter))] Note MaxNote,
     GeneralMidi2Program MidiProgram = GeneralMidi2Program.AcousticGrandPiano,
     bool IsEnabled = true)
 {
@@ -23,9 +25,9 @@ public sealed record InstrumentConfiguration(
 
     public static readonly IDictionary<Instrument, InstrumentConfiguration> DefaultConfigurations = new Dictionary<Instrument, InstrumentConfiguration>
     {
-        { Instrument.One, new(Instrument.One, Notes.C5, Notes.E6) },
-        { Instrument.Two, new(Instrument.Two, Notes.G3, Notes.B4) },
-        { Instrument.Three, new(Instrument.Three, Notes.D3, Notes.F4) },
-        { Instrument.Four, new(Instrument.Four, Notes.C2, Notes.E3, IsEnabled: false) }
+        { Instrument.One, new InstrumentConfiguration(Instrument.One, Notes.C5, Notes.E6) },
+        { Instrument.Two, new InstrumentConfiguration(Instrument.Two, Notes.G3, Notes.B4) },
+        { Instrument.Three, new InstrumentConfiguration(Instrument.Three, Notes.D3, Notes.F4) },
+        { Instrument.Four, new InstrumentConfiguration(Instrument.Four, Notes.C2, Notes.E3, IsEnabled: false) }
     };
 }

--- a/src/BaroquenMelody.Library/Compositions/Configurations/SavedCompositionConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/SavedCompositionConfiguration.cs
@@ -1,0 +1,6 @@
+﻿namespace BaroquenMelody.Library.Compositions.Configurations;
+
+public sealed record SavedCompositionConfiguration(
+    CompositionConfiguration Configuration,
+    FileInfo ConfigurationFile
+);

--- a/src/BaroquenMelody.Library/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BaroquenMelody.Library/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations.Services;
+using BaroquenMelody.Library.Infrastructure.FileSystem;
 using Fluxor;
 using Microsoft.Extensions.DependencyInjection;
 using System.Diagnostics.CodeAnalysis;
+using System.IO.Abstractions;
 
 namespace BaroquenMelody.Library.Infrastructure.Extensions;
 
@@ -14,6 +16,10 @@ public static class ServiceCollectionExtensions
             fluxorOptions.WithLifetime(StoreLifetime.Singleton);
             fluxorOptions.ScanAssemblies(typeof(BaroquenMelodyComposerConfigurator).Assembly);
         })
+        .AddSingleton<IFileSystem, System.IO.Abstractions.FileSystem>()
+        .AddSingleton<IFile, FileWrapper>()
+        .AddSingleton<IDirectory, DirectoryWrapper>()
+        .AddSingleton<ICompositionConfigurationPersistenceService, CompositionConfigurationPersistenceService>()
         .AddSingleton<IBaroquenMelodyComposerConfigurator, BaroquenMelodyComposerConfigurator>()
         .AddSingleton<IOrnamentationConfigurationService, OrnamentationConfigurationService>()
         .AddSingleton<ICompositionRuleConfigurationService, CompositionRuleConfigurationService>()

--- a/src/BaroquenMelody.Library/Infrastructure/FileSystem/CompositionConfigurationPersistenceService.cs
+++ b/src/BaroquenMelody.Library/Infrastructure/FileSystem/CompositionConfigurationPersistenceService.cs
@@ -1,0 +1,127 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+using BaroquenMelody.Library.Infrastructure.Logging;
+using BaroquenMelody.Library.Infrastructure.Serialization.JsonSerializerContexts;
+using Microsoft.Extensions.Logging;
+using System.IO.Abstractions;
+using System.Text.Json;
+
+namespace BaroquenMelody.Library.Infrastructure.FileSystem;
+
+internal sealed class CompositionConfigurationPersistenceService(
+    IDeviceDirectoryProvider deviceDirectoryProvider,
+    IDirectory directory,
+    IFile file,
+    ILogger<BaroquenMelody> logger
+) : ICompositionConfigurationPersistenceService
+{
+    public async Task<bool> SaveConfigurationAsync(CompositionConfiguration compositionConfiguration, string name, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var serializedCompositionConfiguration = JsonSerializer.Serialize(
+                compositionConfiguration,
+                CompositionConfigurationJsonSerializerContext.Default.CompositionConfiguration
+            );
+
+            var filePath = Path.Combine(deviceDirectoryProvider.AppDataDirectory, $"{name}.dat");
+            var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true);
+
+            await using (fileStream.ConfigureAwait(false))
+            {
+                var binaryWriter = new BinaryWriter(fileStream);
+
+                await using (binaryWriter.ConfigureAwait(false))
+                {
+                    binaryWriter.Write(serializedCompositionConfiguration);
+                }
+            }
+
+            return true;
+        }
+        catch (Exception exception)
+        {
+            logger.LogException("Failed to save composition configuration", exception.GetType().ToString(), exception.Message, exception.StackTrace);
+
+            return false;
+        }
+    }
+
+    public async Task<IEnumerable<SavedCompositionConfiguration>> LoadConfigurationsAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (!directory.Exists(deviceDirectoryProvider.AppDataDirectory))
+            {
+                return [];
+            }
+
+            var loadConfigurationTasks = directory
+                .EnumerateFiles(deviceDirectoryProvider.AppDataDirectory)
+                .Where(configurationFile => configurationFile.EndsWith(".dat", StringComparison.OrdinalIgnoreCase))
+                .Select(configurationFile => new FileInfo(configurationFile))
+                .OrderByDescending(fileInfo => fileInfo.CreationTime)
+                .Select(async fileInfo =>
+                {
+                    var configuration = await LoadCompositionConfiguration(fileInfo.FullName).ConfigureAwait(false);
+
+                    return new SavedCompositionConfiguration(configuration, fileInfo);
+                });
+
+            var configurations = await Task.WhenAll(loadConfigurationTasks).ConfigureAwait(false);
+
+            return configurations;
+        }
+        catch (Exception exception)
+        {
+            logger.LogException("Failed to load composition configurations", exception.GetType().ToString(), exception.Message, exception.StackTrace);
+
+            throw;
+        }
+    }
+
+    public Task<bool> DeleteConfigurationAsync(string name, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var filePath = Path.Combine(deviceDirectoryProvider.AppDataDirectory, name);
+
+            if (file.Exists(filePath))
+            {
+                file.Delete(filePath);
+            }
+
+            return Task.FromResult(true);
+        }
+        catch (Exception exception)
+        {
+            logger.LogException("Failed to delete composition configuration", exception.GetType().ToString(), exception.Message, exception.StackTrace);
+
+            return Task.FromResult(false);
+        }
+    }
+
+    public Task<bool> DoesConfigurationExist(string name, CancellationToken cancellationToken) => Task.FromResult(
+        file.Exists(
+            Path.Combine(
+                deviceDirectoryProvider.AppDataDirectory,
+                $"{name}.dat"
+            )
+        )
+    );
+
+    private static async Task<CompositionConfiguration> LoadCompositionConfiguration(string file)
+    {
+        var fileStream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
+
+        await using (fileStream.ConfigureAwait(false))
+        {
+            using var binaryReader = new BinaryReader(fileStream);
+            var serializedCompositionConfiguration = binaryReader.ReadString();
+
+            return JsonSerializer.Deserialize(
+                serializedCompositionConfiguration,
+                CompositionConfigurationJsonSerializerContext.Default.CompositionConfiguration
+            )!;
+        }
+    }
+}

--- a/src/BaroquenMelody.Library/Infrastructure/FileSystem/CompositionConfigurationPersistenceService.cs
+++ b/src/BaroquenMelody.Library/Infrastructure/FileSystem/CompositionConfigurationPersistenceService.cs
@@ -11,6 +11,7 @@ internal sealed class CompositionConfigurationPersistenceService(
     IDeviceDirectoryProvider deviceDirectoryProvider,
     IDirectory directory,
     IFile file,
+    IFileSystem fileSystem,
     ILogger<BaroquenMelody> logger
 ) : ICompositionConfigurationPersistenceService
 {
@@ -24,7 +25,7 @@ internal sealed class CompositionConfigurationPersistenceService(
             );
 
             var filePath = Path.Combine(deviceDirectoryProvider.AppDataDirectory, $"{name}.dat");
-            var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true);
+            var fileStream = fileSystem.FileStream.New(filePath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true);
 
             await using (fileStream.ConfigureAwait(false))
             {
@@ -109,9 +110,9 @@ internal sealed class CompositionConfigurationPersistenceService(
         )
     );
 
-    private static async Task<CompositionConfiguration> LoadCompositionConfiguration(string file)
+    private async Task<CompositionConfiguration> LoadCompositionConfiguration(string name)
     {
-        var fileStream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
+        var fileStream = fileSystem.FileStream.New(name, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
 
         await using (fileStream.ConfigureAwait(false))
         {

--- a/src/BaroquenMelody.Library/Infrastructure/FileSystem/ICompositionConfigurationPersistenceService.cs
+++ b/src/BaroquenMelody.Library/Infrastructure/FileSystem/ICompositionConfigurationPersistenceService.cs
@@ -1,0 +1,41 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+
+namespace BaroquenMelody.Library.Infrastructure.FileSystem;
+
+/// <summary>
+///     Represents a service that persists and retrieves composition configurations.
+/// </summary>
+public interface ICompositionConfigurationPersistenceService
+{
+    /// <summary>
+    ///     Saves the composition configuration.
+    /// </summary>
+    /// <param name="compositionConfiguration">The composition configuration to save.</param>
+    /// <param name="name">The name of the composition configuration.</param>
+    /// <param name="cancellationToken">A cancellation token to cooperatively cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task<bool> SaveConfigurationAsync(CompositionConfiguration compositionConfiguration, string name, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Loads all saved composition configurations.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token to cooperatively cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the saved composition configurations.</returns>
+    Task<IEnumerable<SavedCompositionConfiguration>> LoadConfigurationsAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Deletes the composition configuration with the specified name.
+    /// </summary>
+    /// <param name="name">The name of the composition configuration to delete.</param>
+    /// <param name="cancellationToken">A cancellation token to cooperatively cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task<bool> DeleteConfigurationAsync(string name, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Checks if a composition configuration with the specified name exists.
+    /// </summary>
+    /// <param name="name">The name to validate.</param>
+    /// <param name="cancellationToken">A cancellation token to cooperatively cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains a value indicating whether the configuration exists.</returns>
+    Task<bool> DoesConfigurationExist(string name, CancellationToken cancellationToken);
+}

--- a/src/BaroquenMelody.Library/Infrastructure/FileSystem/IDeviceDirectoryProvider.cs
+++ b/src/BaroquenMelody.Library/Infrastructure/FileSystem/IDeviceDirectoryProvider.cs
@@ -1,0 +1,6 @@
+﻿namespace BaroquenMelody.Library.Infrastructure.FileSystem;
+
+public interface IDeviceDirectoryProvider
+{
+    string AppDataDirectory { get; }
+}

--- a/src/BaroquenMelody.Library/Infrastructure/Logging/Log.cs
+++ b/src/BaroquenMelody.Library/Infrastructure/Logging/Log.cs
@@ -12,65 +12,71 @@ internal static partial class Log
     [LoggerMessage(
         EventId = 0,
         Level = LogLevel.Critical,
+        Message = "{message}: {exceptionType}: {exceptionMessage}\n Stack trace: {stackTrace}")]
+    public static partial void LogException(this ILogger logger, string message, string exceptionType, string exceptionMessage, string? stackTrace);
+
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Critical,
         Message = "No valid chord choices are currently available.")]
     public static partial void NoValidChordChoicesAvailable(this ILogger logger);
 
     [LoggerMessage(
-        EventId = 8,
+        EventId = 2,
         Level = LogLevel.Warning,
         Message = "Could not find a suitable bridging chord after {MaxAttempts} attempts.")]
     public static partial void CouldNotFindSuitableBridgingChord(this ILogger logger, int maxAttempts);
 
     [LoggerMessage(
-        EventId = 9,
+        EventId = 3,
         Level = LogLevel.Warning,
         Message = "Could not find a tonic chord after {MaxAttempts} attempts.")]
     public static partial void CouldNotFindTonicChord(this ILogger logger, int maxAttempts);
 
     [LoggerMessage(
-        EventId = 10,
+        EventId = 4,
         Level = LogLevel.Warning,
         Message = "Failed to compose a fugue theme after {Attempt} attempts. Maximum attempts: {MaxAttempts}.")]
     public static partial void FailedToComposeFugalThemeAttempt(this ILogger logger, int attempt, int maxAttempts);
 
     [LoggerMessage(
-        EventId = 11,
+        EventId = 5,
         Level = LogLevel.Warning,
         Message = "Failed to compose a fugue theme after {MaxAttempts} attempts.")]
     public static partial void FailedToComposeFugalTheme(this ILogger logger, int maxAttempts);
 
     [LoggerMessage(
-        EventId = 12,
+        EventId = 6,
         Level = LogLevel.Critical,
         Message = "Could not find a starting note for instrument {Instrument}.")]
     public static partial void CouldNotFindStartingNoteForInstrument(this ILogger logger, Instrument instrument);
 
     [LoggerMessage(
-        EventId = 13,
+        EventId = 7,
         Level = LogLevel.Debug,
         Message = "Applied ornamentation {Ornamentation} to instrument {Instrument}.")]
     public static partial void AppliedOrnamentation(this ILogger logger, OrnamentationType ornamentation, Instrument instrument);
 
     [LoggerMessage(
-        EventId = 14,
+        EventId = 8,
         Level = LogLevel.Debug,
         Message = "Repeated theme phrase.")]
     public static partial void RepeatedThemePhrase(this ILogger logger);
 
     [LoggerMessage(
-        EventId = 15,
+        EventId = 9,
         Level = LogLevel.Debug,
         Message = "Repeated non-theme phrase.")]
     public static partial void RepeatedNonThemePhrase(this ILogger logger);
 
     [LoggerMessage(
-        EventId = 16,
+        EventId = 10,
         Level = LogLevel.Debug,
         Message = "Composed bridging chord {ChordNumber} of {MaxBridgingChords}.")]
     public static partial void ComposedBridgingChord(this ILogger logger, int chordNumber, int maxBridgingChords);
 
     [LoggerMessage(
-        EventId = 17,
+        EventId = 12,
         Level = LogLevel.Debug,
         Message = "Composed chord {ChordNumber} to tonic of {MaxChordsToTonic}.")]
     public static partial void ComposedChordToTonic(this ILogger logger, int chordNumber, int maxChordsToTonic);

--- a/src/BaroquenMelody.Library/Infrastructure/Serialization/JsonSerializerContexts/CompositionConfigurationJsonSerializerContext.cs
+++ b/src/BaroquenMelody.Library/Infrastructure/Serialization/JsonSerializerContexts/CompositionConfigurationJsonSerializerContext.cs
@@ -8,6 +8,4 @@ namespace BaroquenMelody.Library.Infrastructure.Serialization.JsonSerializerCont
 /// </summary>
 [JsonSourceGenerationOptions(WriteIndented = true)]
 [JsonSerializable(typeof(CompositionConfiguration))]
-public partial class CompositionConfigurationJsonSerializerContext : JsonSerializerContext
-{
-}
+public partial class CompositionConfigurationJsonSerializerContext : JsonSerializerContext;

--- a/src/BaroquenMelody.Library/Store/Actions/LoadCompositionConfiguration.cs
+++ b/src/BaroquenMelody.Library/Store/Actions/LoadCompositionConfiguration.cs
@@ -1,0 +1,5 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+
+namespace BaroquenMelody.Library.Store.Actions;
+
+public sealed record LoadCompositionConfiguration(CompositionConfiguration CompositionConfiguration);

--- a/src/BaroquenMelody.Library/Store/Actions/LoadSavedCompositionConfiguration.cs
+++ b/src/BaroquenMelody.Library/Store/Actions/LoadSavedCompositionConfiguration.cs
@@ -1,0 +1,5 @@
+﻿using BaroquenMelody.Library.Compositions.Configurations;
+
+namespace BaroquenMelody.Library.Store.Actions;
+
+public sealed record LoadSavedCompositionConfiguration(CompositionConfiguration CompositionConfiguration);

--- a/src/BaroquenMelody.Library/Store/Effects/CompositionConfigurationEffects.cs
+++ b/src/BaroquenMelody.Library/Store/Effects/CompositionConfigurationEffects.cs
@@ -8,7 +8,7 @@ namespace BaroquenMelody.Library.Store.Effects;
 public sealed class CompositionConfigurationEffects(IState<InstrumentConfigurationState> instrumentConfigurationState)
 {
     [EffectMethod]
-    public async Task HandleUpdateCompositionConfiguration(UpdateCompositionConfiguration action, IDispatcher dispatcher)
+    public async Task HandleUpdateCompositionConfigurationAsync(UpdateCompositionConfiguration action, IDispatcher dispatcher)
     {
         var scale = new BaroquenScale(action.RootNote, action.Mode);
 
@@ -32,6 +32,46 @@ public sealed class CompositionConfigurationEffects(IState<InstrumentConfigurati
                     IsUserApplied: false
                 )
             );
+        }
+
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+    [EffectMethod]
+    public static async Task HandleLoadSavedCompositionConfigurationAsync(LoadSavedCompositionConfiguration action, IDispatcher dispatcher)
+    {
+        var configuration = action.CompositionConfiguration;
+
+        dispatcher.Dispatch(new LoadCompositionConfiguration(configuration));
+
+        foreach (var instrumentConfiguration in configuration.InstrumentConfigurations)
+        {
+            dispatcher.Dispatch(new UpdateInstrumentConfiguration(
+                instrumentConfiguration.Instrument,
+                instrumentConfiguration.MinNote,
+                instrumentConfiguration.MaxNote,
+                instrumentConfiguration.MidiProgram,
+                instrumentConfiguration.IsEnabled,
+                IsUserApplied: true
+            ));
+        }
+
+        foreach (var compositionRule in configuration.AggregateCompositionRuleConfiguration.Configurations)
+        {
+            dispatcher.Dispatch(new UpdateCompositionRuleConfiguration(
+                compositionRule.Rule,
+                compositionRule.IsEnabled,
+                compositionRule.Strictness
+            ));
+        }
+
+        foreach (var ornamentation in configuration.AggregateOrnamentationConfiguration.Configurations)
+        {
+            dispatcher.Dispatch(new UpdateCompositionOrnamentationConfiguration(
+                ornamentation.OrnamentationType,
+                ornamentation.IsEnabled,
+                ornamentation.Probability
+            ));
         }
 
         await Task.CompletedTask.ConfigureAwait(false);

--- a/src/BaroquenMelody.Library/Store/Reducers/CompositionConfigurationReducers.cs
+++ b/src/BaroquenMelody.Library/Store/Reducers/CompositionConfigurationReducers.cs
@@ -9,4 +9,12 @@ public static class CompositionConfigurationReducers
     [ReducerMethod]
     public static CompositionConfigurationState ReduceUpdateCompositionConfiguration(CompositionConfigurationState state, UpdateCompositionConfiguration action) =>
         new(action.RootNote, action.Mode, action.Meter, action.CompositionLength);
+
+    [ReducerMethod]
+    public static CompositionConfigurationState ReduceLoadCompositionConfiguration(CompositionConfigurationState state, LoadCompositionConfiguration action) => new(
+        action.CompositionConfiguration.Tonic,
+        action.CompositionConfiguration.Mode,
+        action.CompositionConfiguration.Meter,
+        action.CompositionConfiguration.MinimumMeasures
+    );
 }

--- a/src/BaroquenMelody.Library/Store/State/InstrumentConfigurationState.cs
+++ b/src/BaroquenMelody.Library/Store/State/InstrumentConfigurationState.cs
@@ -11,6 +11,8 @@ public sealed record InstrumentConfigurationState(IDictionary<Instrument, Instru
 
     public ISet<InstrumentConfiguration> EnabledConfigurations => Configurations.Values.Where(configuration => configuration.IsEnabled).ToHashSet();
 
+    public ISet<InstrumentConfiguration> AllConfigurations => Configurations.Values.ToHashSet();
+
     public InstrumentConfigurationState()
         : this(InstrumentConfiguration.DefaultConfigurations, InstrumentConfiguration.DefaultConfigurations)
     {

--- a/src/BaroquenMelody/App.cs
+++ b/src/BaroquenMelody/App.cs
@@ -1,6 +1,5 @@
 ﻿using BaroquenMelody.Library;
 using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums.Extensions;
 using BaroquenMelody.Library.Infrastructure.State;
 using BaroquenMelody.Library.Store.State;

--- a/tests/BaroquenMelody.Library.Tests/BaroquenMelody.Library.Tests.csproj
+++ b/tests/BaroquenMelody.Library.Tests/BaroquenMelody.Library.Tests.csproj
@@ -41,10 +41,15 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="21.0.29" />
   </ItemGroup>
 
   <ItemGroup>
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Infrastructure\FileSystem\" />
   </ItemGroup>
 
 </Project>

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Choices/SoloChordChoiceRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Choices/SoloChordChoiceRepositoryTests.cs
@@ -80,7 +80,7 @@ internal sealed class SoloChordChoiceRepositoryTests
         var id = soloChordChoiceRepository.GetChordChoiceId(
             new ChordChoice(
                 [
-                    new NoteChoice(Instrument.One, NoteMotion.Ascending, 2),
+                    new NoteChoice(Instrument.One, NoteMotion.Ascending, 2)
                 ]
             )
         );

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BaroquenChordTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Domain/BaroquenChordTests.cs
@@ -63,11 +63,10 @@ internal sealed class BaroquenChordTests
         cMajor.ResetOrnamentation(MusicalTimeSpan.Half);
 
         // assert
-        cMajor.Notes.Should().BeEquivalentTo(new[]
-        {
+        cMajor.Notes.Should().BeEquivalentTo([
             new BaroquenNote(Instrument.One, Notes.C1, MusicalTimeSpan.Half),
             new BaroquenNote(Instrument.Two, Notes.E1, MusicalTimeSpan.Half)
-        });
+        ]);
     }
 
     private static IEnumerable<TestCaseData> ContainsInstrumentTestCases

--- a/tests/BaroquenMelody.Library.Tests/Infrastructure/FileSystem/CompositionConfigurationPersistenceServiceTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Infrastructure/FileSystem/CompositionConfigurationPersistenceServiceTests.cs
@@ -1,0 +1,88 @@
+﻿using BaroquenMelody.Library.Infrastructure.FileSystem;
+using BaroquenMelody.Library.Tests.TestData;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NUnit.Framework;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+
+namespace BaroquenMelody.Library.Tests.Infrastructure.FileSystem;
+
+[TestFixture]
+internal sealed class CompositionConfigurationPersistenceServiceTests
+{
+    private IDeviceDirectoryProvider _mockDeviceDirectoryProvider = null!;
+
+    private IDirectory _mockDirectory = null!;
+
+    private IFile _mockFile = null!;
+
+    private IFileSystem _mockFileSystem = null!;
+
+    private ILogger<BaroquenMelody> _mockLogger = null!;
+
+    private CompositionConfigurationPersistenceService _persistenceService = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _mockDeviceDirectoryProvider = Substitute.For<IDeviceDirectoryProvider>();
+        _mockDirectory = Substitute.For<IDirectory>();
+        _mockFile = Substitute.For<IFile>();
+        _mockFileSystem = Substitute.For<IFileSystem>();
+        _mockLogger = Substitute.For<ILogger<BaroquenMelody>>();
+
+        _persistenceService = new CompositionConfigurationPersistenceService(
+            _mockDeviceDirectoryProvider,
+            _mockDirectory,
+            _mockFile,
+            _mockFileSystem,
+            _mockLogger
+        );
+    }
+
+    [Test]
+    public async Task SaveConfigurationAsync_WhenSucceeds_ReturnsTrue()
+    {
+        // act
+        _mockFileSystem.FileStream.New(
+                Arg.Any<string>(),
+                Arg.Any<FileMode>(),
+                Arg.Any<FileAccess>(),
+                Arg.Any<FileShare>(),
+                Arg.Any<int>(),
+                Arg.Any<bool>()
+            )
+            .Returns(
+                new MockFileStream(new MockFileSystem(new MockFileSystemOptions()), "tests", FileMode.Create)
+            );
+
+        var result = await _persistenceService.SaveConfigurationAsync(
+            Configurations.GetCompositionConfiguration(),
+            "test",
+            CancellationToken.None
+        );
+
+        // assert
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task SaveConfigurationAsync_WhenFails_ReturnsFalse()
+    {
+        // arrange
+        _mockFileSystem.FileStream.Throws(new InvalidOperationException());
+
+        // act
+        var result = await _persistenceService.SaveConfigurationAsync(
+            Configurations.GetCompositionConfiguration(),
+            "test",
+            CancellationToken.None
+        );
+
+        // assert
+        result.Should().BeFalse();
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Infrastructure/Serialization/CompositionConfigurationSerializationTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Infrastructure/Serialization/CompositionConfigurationSerializationTests.cs
@@ -1,7 +1,6 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
-using BaroquenMelody.Library.Infrastructure.Serialization.JsonConverters;
 using BaroquenMelody.Library.Infrastructure.Serialization.JsonSerializerContexts;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
@@ -37,19 +36,9 @@ internal sealed class CompositionConfigurationSerializationTests
             MinimumMeasures: 100
         );
 
-        var jsonSerializerOptions = new JsonSerializerOptions
-        {
-            TypeInfoResolver = CompositionConfigurationJsonSerializerContext.Default,
-            Converters =
-            {
-                new MusicalTimespanJsonConverter(),
-                new NoteJsonConverter()
-            }
-        };
-
         // act
-        var serializedConfiguration = JsonSerializer.Serialize(compositionConfiguration, jsonSerializerOptions);
-        var deserializedConfiguration = JsonSerializer.Deserialize<CompositionConfiguration>(serializedConfiguration, jsonSerializerOptions)!;
+        var serializedConfiguration = JsonSerializer.Serialize(compositionConfiguration, CompositionConfigurationJsonSerializerContext.Default.CompositionConfiguration);
+        var deserializedConfiguration = JsonSerializer.Deserialize(serializedConfiguration, CompositionConfigurationJsonSerializerContext.Default.CompositionConfiguration)!;
 
         // assert
         deserializedConfiguration.Tonic.Should().Be(compositionConfiguration.Tonic);

--- a/tests/BaroquenMelody.Library.Tests/Store/Effects/CompositionConfigurationEffectsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Effects/CompositionConfigurationEffectsTests.cs
@@ -4,6 +4,7 @@ using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
 using BaroquenMelody.Library.Store.Actions;
 using BaroquenMelody.Library.Store.Effects;
 using BaroquenMelody.Library.Store.State;
+using BaroquenMelody.Library.Tests.TestData;
 using Fluxor;
 using Melanchall.DryWetMidi.MusicTheory;
 using NSubstitute;
@@ -93,5 +94,60 @@ internal sealed class CompositionConfigurationEffectsTests
                                                  updateInstrumentConfiguration.IsUserApplied == false
             )
         );
+    }
+
+    [Test]
+    public async Task HandleLoadSavedCompositionConfigurationAsync_dispatches_expected_actions()
+    {
+        // arrange
+        var configuration = Configurations.GetCompositionConfiguration();
+
+        var action = new LoadSavedCompositionConfiguration(configuration);
+
+        // act
+        await CompositionConfigurationEffects.HandleLoadSavedCompositionConfigurationAsync(action, _mockDispatcher);
+
+        // assert
+        _mockDispatcher.Received().Dispatch(
+            Arg.Is<LoadCompositionConfiguration>(
+                loadCompositionConfiguration => loadCompositionConfiguration.CompositionConfiguration == configuration
+            )
+        );
+
+        foreach (var instrumentConfiguration in configuration.InstrumentConfigurations)
+        {
+            _mockDispatcher.Received().Dispatch(
+                Arg.Is<UpdateInstrumentConfiguration>(
+                    updateInstrumentConfiguration => updateInstrumentConfiguration.Instrument == instrumentConfiguration.Instrument &&
+                                                     updateInstrumentConfiguration.MinNote == instrumentConfiguration.MinNote &&
+                                                     updateInstrumentConfiguration.MaxNote == instrumentConfiguration.MaxNote &&
+                                                     updateInstrumentConfiguration.MidiProgram == instrumentConfiguration.MidiProgram &&
+                                                     updateInstrumentConfiguration.IsEnabled == instrumentConfiguration.IsEnabled &&
+                                                     updateInstrumentConfiguration.IsUserApplied == true
+                )
+            );
+        }
+
+        foreach (var compositionRule in configuration.AggregateCompositionRuleConfiguration.Configurations)
+        {
+            _mockDispatcher.Received().Dispatch(
+                Arg.Is<UpdateCompositionRuleConfiguration>(
+                    updateCompositionRuleConfiguration => updateCompositionRuleConfiguration.CompositionRule == compositionRule.Rule &&
+                                                          updateCompositionRuleConfiguration.IsEnabled == compositionRule.IsEnabled &&
+                                                          updateCompositionRuleConfiguration.Strictness == compositionRule.Strictness
+                )
+            );
+        }
+
+        foreach (var ornamentation in configuration.AggregateOrnamentationConfiguration.Configurations)
+        {
+            _mockDispatcher.Received().Dispatch(
+                Arg.Is<UpdateCompositionOrnamentationConfiguration>(
+                    updateCompositionOrnamentationConfiguration => updateCompositionOrnamentationConfiguration.OrnamentationType == ornamentation.OrnamentationType &&
+                                                                   updateCompositionOrnamentationConfiguration.IsEnabled == ornamentation.IsEnabled &&
+                                                                   updateCompositionOrnamentationConfiguration.Probability == ornamentation.Probability
+                )
+            );
+        }
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Store/Effects/CompositionConfigurationEffectsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Effects/CompositionConfigurationEffectsTests.cs
@@ -81,7 +81,7 @@ internal sealed class CompositionConfigurationEffectsTests
         var action = new UpdateCompositionConfiguration(NoteName.D, Mode.Ionian, Meter.FourFour);
 
         // act
-        await _compositionConfigurationEffects.HandleUpdateCompositionConfiguration(action, _mockDispatcher);
+        await _compositionConfigurationEffects.HandleUpdateCompositionConfigurationAsync(action, _mockDispatcher);
 
         // assert
         _mockDispatcher.Received().Dispatch(

--- a/tests/BaroquenMelody.Library.Tests/Store/Reducers/CompositionConfigurationReducersTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Reducers/CompositionConfigurationReducersTests.cs
@@ -3,6 +3,7 @@ using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
 using BaroquenMelody.Library.Store.Actions;
 using BaroquenMelody.Library.Store.Reducers;
 using BaroquenMelody.Library.Store.State;
+using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.MusicTheory;
 using NUnit.Framework;
@@ -28,5 +29,22 @@ internal sealed class CompositionConfigurationReducersTests
         state.MinimumMeasures.Should().Be(8);
         state.TonicNote.Should().Be(rootNote);
         state.Mode.Should().Be(mode);
+    }
+
+    [Test]
+    public void ReduceLoadCompositionConfiguration_updates_composition_configurations_as_expected()
+    {
+        // arrange
+        var configuration = Configurations.GetCompositionConfiguration();
+        var state = new CompositionConfigurationState();
+
+        // act
+        state = CompositionConfigurationReducers.ReduceLoadCompositionConfiguration(state, new LoadCompositionConfiguration(configuration));
+
+        // assert
+        state.Meter.Should().Be(configuration.Meter);
+        state.MinimumMeasures.Should().Be(configuration.MinimumMeasures);
+        state.TonicNote.Should().Be(configuration.Tonic);
+        state.Mode.Should().Be(configuration.Mode);
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Store/State/InstrumentConfigurationStateTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/State/InstrumentConfigurationStateTests.cs
@@ -28,7 +28,7 @@ internal sealed class InstrumentConfigurationStateTests
                 {
                     Instrument.Two,
                     new InstrumentConfiguration(Instrument.Two, Notes.C4, Notes.C5, GeneralMidi2Program.Dulcimer, isInstrumentTwoEnabled)
-                },
+                }
             },
             new Dictionary<Instrument, InstrumentConfiguration>()
         );

--- a/tests/BaroquenMelody.Library.Tests/Store/State/InstrumentConfigurationStateTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/State/InstrumentConfigurationStateTests.cs
@@ -45,4 +45,32 @@ internal sealed class InstrumentConfigurationStateTests
             state.ValidationMessage.Should().BeNullOrEmpty();
         }
     }
+
+    [Test]
+    public void AllConfigurations_returns_expected_configurations()
+    {
+        // act
+        var state = new InstrumentConfigurationState(
+            new Dictionary<Instrument, InstrumentConfiguration>
+            {
+                {
+                    Instrument.One,
+                    new InstrumentConfiguration(Instrument.One, Notes.C4, Notes.C5, GeneralMidi2Program.Dulcimer)
+                },
+                {
+                    Instrument.Two,
+                    new InstrumentConfiguration(Instrument.Two, Notes.C4, Notes.C5, GeneralMidi2Program.Dulcimer)
+                }
+            },
+            new Dictionary<Instrument, InstrumentConfiguration>()
+        );
+
+        // assert
+        state.AllConfigurations.Should().BeEquivalentTo(
+            [
+                new InstrumentConfiguration(Instrument.One, Notes.C4, Notes.C5, GeneralMidi2Program.Dulcimer),
+                new InstrumentConfiguration(Instrument.Two, Notes.C4, Notes.C5, GeneralMidi2Program.Dulcimer)
+            ]
+        );
+    }
 }

--- a/tests/BaroquenMelody.Library.Tests/TestData/Configurations.cs
+++ b/tests/BaroquenMelody.Library.Tests/TestData/Configurations.cs
@@ -1,5 +1,4 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
-using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
 using Melanchall.DryWetMidi.Interaction;


### PR DESCRIPTION
## Description

Implemented functionality to save and load composition configurations.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
