### PR TITLE
Various Bug Fixes & Improvements

### DIFF
--- a/src/BaroquenMelody.App.Components/Pages/Home.razor
+++ b/src/BaroquenMelody.App.Components/Pages/Home.razor
@@ -107,17 +107,22 @@
     {
         if (!BaroquenMelodyState.Value.HasBeenSaved && BaroquenMelodyState.Value.BaroquenMelody is not null)
         {
-            var dialogReference = await Dialog.ShowAsync<ConfirmCompositionDialogue>("Save composition?");
+            var dialogReference = await DialogService.ShowAsync<ConfirmCompositionDialogue>("Save composition?", new DialogOptions());
             var dialogResult = await dialogReference.Result;
 
-            if (dialogResult?.Canceled ?? false)
+            if (dialogResult?.Canceled is true)
             {
                 return;
             }
 
             if (dialogResult?.Data is true)
             {
-                await Save();
+                var isSaved = await Save();
+
+                if (!isSaved)
+                {
+                    return;
+                }
             }
         }
 
@@ -134,7 +139,7 @@
         }
     }
 
-    private async Task Save()
+    private async Task<bool> Save()
     {
         var isSaved = await MidiSaver.SaveAsync(
             BaroquenMelodyState.Value.BaroquenMelody!,
@@ -147,11 +152,13 @@
             Snackbar.Add("Saved composition!", Severity.Success);
             Dispatcher.Dispatch(new MarkCompositionSaved());
         }
+
+        return isSaved;
     }
 
     private async Task SaveCompositionConfiguration()
     {
-        var dialogReference = await Dialog.ShowAsync<SaveCompositionConfigurationDialog>("Save composition configuration?");
+        var dialogReference = await DialogService.ShowAsync<SaveCompositionConfigurationDialog>("Save composition configuration?");
 
         var dialogResult = await dialogReference.Result;
 

--- a/src/BaroquenMelody.App.Components/Pages/SavedConfigurations.razor
+++ b/src/BaroquenMelody.App.Components/Pages/SavedConfigurations.razor
@@ -16,6 +16,7 @@
                           InputMode="InputMode.text"
                           Adornment="Adornment.Start"
                           AdornmentIcon="@Icons.Material.Outlined.Search"
+                          AdornmentColor="Color.Secondary"
                           IconSize="Size.Medium"/>
         </ToolBarContent>
         <HeaderContent>

--- a/src/BaroquenMelody.App.Components/Shared/CompositionConfigurationCard.razor
+++ b/src/BaroquenMelody.App.Components/Shared/CompositionConfigurationCard.razor
@@ -48,7 +48,9 @@
                 <NumericInputWithPopover T="int"
                                          Label="Minimum Measures"
                                          ValueChanged="HandleCompositionLengthChange"
-                                         ValueProvider="() => MinimumMeasures">
+                                         ValueProvider="() => MinimumMeasures"
+                                         Min="1"
+                                         Max="int.MaxValue">
                     <PopoverContent>
                         <MudText>The minimum number of <MudLink Color="Color.Tertiary" Href="https://en.wikipedia.org/wiki/Bar_(music)">measures</MudLink> in the composition.</MudText>
                     </PopoverContent>

--- a/src/BaroquenMelody.App.Components/Shared/CompositionProgress.razor
+++ b/src/BaroquenMelody.App.Components/Shared/CompositionProgress.razor
@@ -106,17 +106,22 @@ else
     {
         if (!BaroquenMelodyState.Value.HasBeenSaved && BaroquenMelodyState.Value.BaroquenMelody is not null)
         {
-            var dialogReference = await Dialog.ShowAsync<ConfirmCompositionDialogue>("Save composition?", new DialogOptions());
+            var dialogReference = await DialogService.ShowAsync<ConfirmCompositionDialogue>("Save composition?", new DialogOptions());
             var dialogResult = await dialogReference.Result;
 
-            if (dialogResult?.Canceled ?? false)
+            if (dialogResult?.Canceled is true)
             {
                 return;
             }
 
             if (dialogResult?.Data is true)
             {
-                await Save();
+                var isSaved = await Save();
+
+                if (!isSaved)
+                {
+                    return;
+                }
             }
         }
 
@@ -130,7 +135,7 @@ else
         await MidiLauncher.LaunchAsync(BaroquenMelodyState.Value.Path, cancellationTokenSource.Token);
     }
 
-    private async Task Save()
+    private async Task<bool> Save()
     {
         var isSaved = await MidiSaver.SaveAsync(
             BaroquenMelodyState.Value.BaroquenMelody!,
@@ -143,6 +148,8 @@ else
             Snackbar.Add("Saved composition!", Severity.Success);
             Dispatcher.Dispatch(new MarkCompositionSaved());
         }
+
+        return isSaved;
     }
 
 }

--- a/src/BaroquenMelody.App.Components/Shared/InstrumentConfigurationCard.razor
+++ b/src/BaroquenMelody.App.Components/Shared/InstrumentConfigurationCard.razor
@@ -150,6 +150,7 @@
 
     private Dictionary<string, GeneralMidi2Program> MidiInstruments = EnumUtils<GeneralMidi2Program>
         .AsEnumerable()
+        .OrderBy(instrument => instrument.ToSpaceSeparatedString())
         .ToDictionary(
             instrument => instrument.ToSpaceSeparatedString(),
             instrument => instrument

--- a/src/BaroquenMelody.App.Components/Shared/NumericInputWithPopover.razor
+++ b/src/BaroquenMelody.App.Components/Shared/NumericInputWithPopover.razor
@@ -20,7 +20,9 @@
                  Variant="Variant.Outlined" 
                  Value="Value" 
                  Label="@Label" 
-                 ValueChanged="ValueChanged"/>
+                 ValueChanged="ValueChanged"
+                 Min="Min"
+                 Max="Max"/>
 
 @code
 {
@@ -32,9 +34,9 @@
 
     [Parameter, EditorRequired] public required EventCallback<T> ValueChanged { get; set; }
 
-    [Parameter] public int? Min { get; set; }
+    [Parameter] public T? Min { get; set; }
 
-    [Parameter] public int? Max { get; set; }
+    [Parameter] public T? Max { get; set; }
 
     private void OpenMeterPopover() => IsPopoverOpen = true;
 

--- a/src/BaroquenMelody.App.Components/Shared/SaveCompositionConfigurationDialog.razor
+++ b/src/BaroquenMelody.App.Components/Shared/SaveCompositionConfigurationDialog.razor
@@ -6,13 +6,13 @@
         <MudTextField @bind-Value="ConfigurationName" 
                       Label="Configuration Name" 
                       Variant="Variant.Outlined"
-                      Immediate="true"
-                      Mask="FileNameMask"/>
+                      Validation="ValidateFilename"
+                      Immediate="true"/>
     </DialogContent>
     <DialogActions>
         <MudButton Color="Color.Primary"
                    OnClick="SaveCompositionConfiguration"
-                   Disabled="string.IsNullOrEmpty(ConfigurationName)">
+                   Disabled="!IsValidFilename(ConfigurationName)">
             Save
         </MudButton>
         <MudButton OnClick="Cancel">
@@ -22,16 +22,14 @@
 </MudDialog>
 
 @code {
-    private string? ConfigurationName { get; set; }
-
-    private static readonly IMask FileNameMask = new RegexMask(@"^[\w\s-]+$");
+    private string ConfigurationName { get; set; } = string.Empty;
 
     [CascadingParameter] private MudDialogInstance? MudDialog { get; set; }
 
     private async Task SaveCompositionConfiguration()
     {
         var configurationFileExists = await CompositionConfigurationPersistenceService.DoesConfigurationExist(
-            ConfigurationName!,
+            ConfigurationName,
             new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token
         );
 
@@ -64,7 +62,7 @@
 
         var isSaved = await CompositionConfigurationPersistenceService.SaveConfigurationAsync(
             compositionConfiguration,
-            ConfigurationName!,
+            ConfigurationName,
             new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token
         );
 
@@ -73,4 +71,18 @@
 
     private void Cancel() => MudDialog?.Cancel();
 
+    private static readonly Func<string, IEnumerable<string>> ValidateFilename = filename =>
+    {
+        return ValidateFilename();
+
+        IEnumerable<string> ValidateFilename()
+        {
+            if (!IsValidFilename(filename))
+            {
+                yield return "Enter a valid filename";
+            }
+        }
+    };
+
+    private static bool IsValidFilename(string filename) => !string.IsNullOrEmpty(filename) && ValidFilenameRegex().IsMatch(filename);
 }

--- a/src/BaroquenMelody.App.Components/Shared/SaveCompositionConfigurationDialog.razor.cs
+++ b/src/BaroquenMelody.App.Components/Shared/SaveCompositionConfigurationDialog.razor.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.RegularExpressions;
+
+namespace BaroquenMelody.App.Components.Shared;
+
+/// <summary>
+///     A dialog for saving a composition configuration.
+/// </summary>
+public partial class SaveCompositionConfigurationDialog
+{
+    [GeneratedRegex(@"^[\w\s-]+$", RegexOptions.Compiled, matchTimeoutMilliseconds: 1000)]
+    private static partial Regex ValidFilenameRegex();
+}

--- a/src/BaroquenMelody.App.Components/_Imports.razor
+++ b/src/BaroquenMelody.App.Components/_Imports.razor
@@ -50,7 +50,6 @@
 @inject IMidiLauncher MidiLauncher
 @inject IMidiSaver MidiSaver
 @inject ISnackbar Snackbar
-@inject IDialogService Dialog
 @inject ICompositionConfigurationPersistenceService CompositionConfigurationPersistenceService
 @inject NavigationManager NavigationManager
 @inject IDialogService DialogService

--- a/src/BaroquenMelody.App/BaroquenMelody.App.csproj
+++ b/src/BaroquenMelody.App/BaroquenMelody.App.csproj
@@ -38,7 +38,7 @@
 
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">30.0</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
         <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>

--- a/src/BaroquenMelody.App/Infrastructure/FileSystem/MauiMidiSaver.cs
+++ b/src/BaroquenMelody.App/Infrastructure/FileSystem/MauiMidiSaver.cs
@@ -14,8 +14,8 @@ internal sealed class MauiMidiSaver : IMidiSaver
             return Task.FromCanceled<string>(cancellationToken);
         }
 
-        var timestamp = DateTime.Now.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture);
-        var path = Path.Combine(MauiFileSystem.CacheDirectory, $"temp-composition-{timestamp}.mid");
+        var timestamp = DateTime.Now.ToString("yyyyMMddHHmmssfff", CultureInfo.InvariantCulture);
+        var path = Path.Combine(MauiFileSystem.CacheDirectory, $"Baroquen Melody ({timestamp}).mid");
 
         baroquenMelody.MidiFile.Write(path);
 

--- a/src/BaroquenMelody.App/Platforms/Android/MainActivity.cs
+++ b/src/BaroquenMelody.App/Platforms/Android/MainActivity.cs
@@ -2,9 +2,15 @@
 using Android.Content.PM;
 using Android.OS;
 
+// ReSharper disable once CheckNamespace
 namespace BaroquenMelody.App;
 
 [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+        WebViewSoftInputPatch.Initialize();
+    }
 }

--- a/src/BaroquenMelody.App/Platforms/Android/MainApplication.cs
+++ b/src/BaroquenMelody.App/Platforms/Android/MainApplication.cs
@@ -1,6 +1,7 @@
 ﻿using Android.App;
 using Android.Runtime;
 
+// ReSharper disable once CheckNamespace
 namespace BaroquenMelody.App;
 
 [Application]

--- a/src/BaroquenMelody.App/Platforms/Android/WebViewSoftInputPatch.cs
+++ b/src/BaroquenMelody.App/Platforms/Android/WebViewSoftInputPatch.cs
@@ -1,0 +1,96 @@
+﻿using Android.Views;
+using Android.Widget;
+using System.Runtime.Versioning;
+using static Android.Resource;
+using Activity = Android.App.Activity;
+using Rect = Android.Graphics.Rect;
+using View = Android.Views.View;
+
+// ReSharper disable once CheckNamespace
+namespace BaroquenMelody.App;
+
+[SupportedOSPlatform("Android30.0")]
+public static class WebViewSoftInputPatch
+{
+    private static Activity Activity => Platform.CurrentActivity!;
+
+    private static View? _mChildOfContent;
+
+    private static FrameLayout.LayoutParams? _frameLayoutParams;
+
+    private static int _usableHeightPrevious;
+
+    public static void Initialize()
+    {
+        var content = (FrameLayout)(Activity.FindViewById(Id.Content) ?? throw new InvalidOperationException("Content can't be null."));
+
+        _mChildOfContent = content.GetChildAt(0);
+        _mChildOfContent!.ViewTreeObserver!.GlobalLayout += (_, _) => PossiblyResizeChildOfContent();
+        _frameLayoutParams = (FrameLayout.LayoutParams)_mChildOfContent.LayoutParameters!;
+    }
+
+    private static void PossiblyResizeChildOfContent()
+    {
+        var usableHeightNow = ComputeUsableHeight();
+
+        if (usableHeightNow != _usableHeightPrevious)
+        {
+            var usableHeightSansKeyboard = _mChildOfContent!.RootView!.Height;
+            var heightDifference = usableHeightSansKeyboard - usableHeightNow;
+
+            if (heightDifference < 0)
+            {
+                usableHeightSansKeyboard = _mChildOfContent.RootView.Width;
+                heightDifference = usableHeightSansKeyboard - usableHeightNow;
+            }
+
+            if (heightDifference > usableHeightSansKeyboard / 4)
+            {
+                _frameLayoutParams!.Height = usableHeightSansKeyboard - heightDifference;
+            }
+            else
+            {
+                _frameLayoutParams!.Height = usableHeightNow;
+            }
+        }
+
+        _mChildOfContent!.RequestLayout();
+        _usableHeightPrevious = usableHeightNow;
+    }
+
+    private static int ComputeUsableHeight()
+    {
+        var rect = new Rect();
+
+        _mChildOfContent!.GetWindowVisibleDisplayFrame(rect);
+
+        if (IsImmersiveMode())
+        {
+            return rect.Bottom;
+        }
+
+        return rect.Bottom - GetStatusBarHeight();
+    }
+
+    private static int GetStatusBarHeight()
+    {
+        var result = 0;
+        var resources = Activity.Resources!;
+        var resourceId = resources.GetIdentifier("status_bar_height", "dimen", "android");
+
+        if (resourceId > 0)
+        {
+            result = resources.GetDimensionPixelSize(resourceId);
+        }
+
+        return result;
+    }
+
+    private static bool IsImmersiveMode()
+    {
+        var decorView = Activity!.Window!.DecorView;
+        var uiOptions = decorView!.WindowInsetsController!.SystemBarsAppearance;
+
+        return (uiOptions & (int)SystemUiFlags.Immersive) == (int)SystemUiFlags.Immersive;
+    }
+}

--- a/src/BaroquenMelody.App/Platforms/MacCatalyst/AppDelegate.cs
+++ b/src/BaroquenMelody.App/Platforms/MacCatalyst/AppDelegate.cs
@@ -1,5 +1,6 @@
 ﻿using Foundation;
 
+// ReSharper disable once CheckNamespace
 namespace BaroquenMelody.App;
 
 [Register("AppDelegate")]

--- a/src/BaroquenMelody.App/Platforms/MacCatalyst/Program.cs
+++ b/src/BaroquenMelody.App/Platforms/MacCatalyst/Program.cs
@@ -1,6 +1,7 @@
 ﻿using ObjCRuntime;
 using UIKit;
 
+// ReSharper disable once CheckNamespace
 namespace BaroquenMelody.App;
 
 public class Program

--- a/src/BaroquenMelody.App/Platforms/Tizen/Main.cs
+++ b/src/BaroquenMelody.App/Platforms/Tizen/Main.cs
@@ -2,6 +2,7 @@ using Microsoft.Maui;
 using Microsoft.Maui.Hosting;
 using System;
 
+// ReSharper disable once CheckNamespace
 namespace BaroquenMelody.App;
 
 internal class Program : MauiApplication

--- a/src/BaroquenMelody.App/Platforms/iOS/AppDelegate.cs
+++ b/src/BaroquenMelody.App/Platforms/iOS/AppDelegate.cs
@@ -1,5 +1,6 @@
 ﻿using Foundation;
 
+// ReSharper disable once CheckNamespace
 namespace BaroquenMelody.App;
 
 [Register("AppDelegate")]

--- a/src/BaroquenMelody.App/Platforms/iOS/Program.cs
+++ b/src/BaroquenMelody.App/Platforms/iOS/Program.cs
@@ -1,6 +1,7 @@
 ﻿using ObjCRuntime;
 using UIKit;
 
+// ReSharper disable once CheckNamespace
 namespace BaroquenMelody.App;
 
 public class Program


### PR DESCRIPTION
## Description

Fixes

- Avoids composing over previous composition if user cancelled with the save file dialogue open while saving their current composition
- Fixes text input on mobile when saving configuration files (removes mask, adds validation instead)
- Correctly set min/max for minimum measures, strictness of rules, and probabilities of ornamentations
- Adds `WebViewSoftInputPatch` so that the numeric input on mobile doesn't cover the input controls when they're at the bottom of a scrollable page (see https://github.com/dotnet/maui/issues/14197#issuecomment-1535561632)
- Temp composition file names are saved with millisecond accuracy timestamps to avoid conflicts

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
