### PR TITLE
Handle Composition Failure Gracefully

### DIFF
--- a/benchmarks/BaroquenMelody.Benchmarks/Compositions/Rules/AggregateCompositionRuleBenchmarks.cs
+++ b/benchmarks/BaroquenMelody.Benchmarks/Compositions/Rules/AggregateCompositionRuleBenchmarks.cs
@@ -5,7 +5,6 @@ using BaroquenMelody.Library.Compositions.Rules;
 using BaroquenMelody.Library.Infrastructure.Collections;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Order;
-using System.Collections.Frozen;
 
 namespace BaroquenMelody.Benchmarks.Compositions.Rules;
 

--- a/src/BaroquenMelody.App.Components/Pages/Home.razor
+++ b/src/BaroquenMelody.App.Components/Pages/Home.razor
@@ -1,6 +1,7 @@
 ﻿@page "/"
 
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
+@implements IDisposable
 
 <PageTitle>Baroquen Melody</PageTitle>
 
@@ -103,6 +104,23 @@
         ? Color.Secondary
         : Color.Warning;
 
+    private IDisposable? _compositionProgressSubscription;
+
+    protected override Task OnInitializedAsync()
+    {
+        _compositionProgressSubscription = CompositionProgressState
+            .ObserveChanges()
+            .Subscribe(state =>
+            {
+                if (state.Value.CurrentStep == CompositionStep.Failed && _tabs?.ActivePanel != _compositionTab)
+                {
+                    Snackbar.Add("Composition failed! Try again or try a different configuration.", Severity.Error);
+                }
+            });
+
+        return base.OnInitializedAsync();
+    }
+
     private async Task Compose()
     {
         if (!BaroquenMelodyState.Value.HasBeenSaved && BaroquenMelodyState.Value.BaroquenMelody is not null)
@@ -144,7 +162,7 @@
         var isSaved = await MidiSaver.SaveAsync(
             BaroquenMelodyState.Value.BaroquenMelody!,
             BaroquenMelodyState.Value.Path,
-            new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token
+            CancellationToken.None
         ).ConfigureAwait(false);
 
         if (isSaved)
@@ -175,6 +193,20 @@
         {
             Snackbar.Add("Failed to save composition configuration!", Severity.Error);
         }
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _compositionProgressSubscription?.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
     }
 
 }

--- a/src/BaroquenMelody.App.Components/Shared/CompositionProgress.razor
+++ b/src/BaroquenMelody.App.Components/Shared/CompositionProgress.razor
@@ -4,7 +4,7 @@
 {
     <MudGrid Class="my-3" Justify="Justify.Center">
         <MudAnimate
-            Selector=".id1"
+            Selector=".compose-button"
             Duration="2"
             AnimationType="AnimationType.ShadowInset"
             Value="360"
@@ -24,7 +24,7 @@
                             Delay="ThemeProvider.TooltipDelay"
                             Duration="ThemeProvider.TooltipDuration"
                             Disabled="@InstrumentConfigurationState.Value.IsValid">
-                    <MudButton Class="id1 d-flex align-center justify-center"
+                    <MudButton Class="compose-button d-flex align-center justify-center"
                                Variant="Variant.Filled"
                                StartIcon="@Icons.Material.Filled.ElectricBolt"
                                Color="Color.Tertiary"
@@ -34,6 +34,36 @@
                         <MudText Typo="Typo.button" Style="font-size:large">Compose</MudText>
                     </MudButton>
                 </MudTooltip>
+            </div>
+        </MudItem>
+    </MudGrid>
+}
+else if (CompositionProgressState.Value.IsFailed)
+{
+    <MudGrid Class="my-3" Justify="Justify.Center">
+        <MudAnimate 
+            Selector=".composition-failed"
+            Duration="2"
+            AnimationType="AnimationType.ShadowInset"
+            Value="360"
+            ValueSecondary="null"
+            Hover="false"
+            Delay="0"
+            Infinite="true"
+            IterationCount="1"
+            AnimationTiming="AnimationTiming.EaseInOut"
+            AnimationDirection="AnimationDirection.AlternateReverse"
+            AnimationFillMode="AnimationFillMode.None"
+            Paused="false"/>
+        <MudItem xs="12" sm="12" md="12" lg="12" xl="12" xxl="12">
+            <div class="d-flex flex-shrink align-center justify-center ma-0" style="height:300px;">
+                <MudAlert Severity="Severity.Error"
+                          Class="composition-failed"
+                          Variant="Variant.Outlined"
+                          ShowCloseIcon="true"
+                          CloseIconClicked="() => Dispatcher.Dispatch(new ResetCompositionProgress())">
+                    Failed to compose. Try again, or try a different configuration.
+                </MudAlert>
             </div>
         </MudItem>
     </MudGrid>
@@ -140,7 +170,7 @@ else
         var isSaved = await MidiSaver.SaveAsync(
             BaroquenMelodyState.Value.BaroquenMelody!,
             BaroquenMelodyState.Value.Path,
-            new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token
+            CancellationToken.None
         ).ConfigureAwait(false);
 
         if (isSaved)

--- a/src/BaroquenMelody.App/Platforms/MacCatalyst/Program.cs
+++ b/src/BaroquenMelody.App/Platforms/MacCatalyst/Program.cs
@@ -1,5 +1,4 @@
-﻿using ObjCRuntime;
-using UIKit;
+﻿using UIKit;
 
 // ReSharper disable once CheckNamespace
 namespace BaroquenMelody.App;

--- a/src/BaroquenMelody.App/Platforms/Windows/App.xaml.cs
+++ b/src/BaroquenMelody.App/Platforms/Windows/App.xaml.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.UI.Xaml;
-
-// To learn more about WinUI, the WinUI project structure,
+﻿// To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
 namespace BaroquenMelody.App.WinUI;
 

--- a/src/BaroquenMelody.App/Platforms/iOS/Program.cs
+++ b/src/BaroquenMelody.App/Platforms/iOS/Program.cs
@@ -1,5 +1,4 @@
-﻿using ObjCRuntime;
-using UIKit;
+﻿using UIKit;
 
 // ReSharper disable once CheckNamespace
 namespace BaroquenMelody.App;

--- a/src/BaroquenMelody.Library/Compositions/Enums/CompositionStep.cs
+++ b/src/BaroquenMelody.Library/Compositions/Enums/CompositionStep.cs
@@ -38,5 +38,10 @@ public enum CompositionStep : byte
     /// <summary>
     ///     The composer has completed composing the composition.
     /// </summary>
-    Complete
+    Complete,
+
+    /// <summary>
+    ///     The composer has failed to compose the composition.
+    /// </summary>
+    Failed
 }

--- a/src/BaroquenMelody.Library/Store/Actions/MarkCompositionFailed.cs
+++ b/src/BaroquenMelody.Library/Store/Actions/MarkCompositionFailed.cs
@@ -1,0 +1,3 @@
+﻿namespace BaroquenMelody.Library.Store.Actions;
+
+public sealed record MarkCompositionFailed;

--- a/src/BaroquenMelody.Library/Store/Effects/BaroquenMelodyEffects.cs
+++ b/src/BaroquenMelody.Library/Store/Effects/BaroquenMelodyEffects.cs
@@ -49,7 +49,13 @@ public sealed class BaroquenMelodyEffects(
                 catch (OperationCanceledException)
                 {
                     dispatcher.Dispatch(new ResetCompositionProgress());
-
+                }
+                catch (Exception)
+                {
+                    dispatcher.Dispatch(new MarkCompositionFailed());
+                }
+                finally
+                {
                     _cancellationTokenSource?.Dispose();
                 }
             },

--- a/src/BaroquenMelody.Library/Store/Reducers/CompositionProgressReducers.cs
+++ b/src/BaroquenMelody.Library/Store/Reducers/CompositionProgressReducers.cs
@@ -41,4 +41,10 @@ public static class CompositionProgressReducers
     {
         return new CompositionProgressState();
     }
+
+    [ReducerMethod]
+    public static CompositionProgressState ReduceMarkCompositionFailed(CompositionProgressState state, MarkCompositionFailed _)
+    {
+        return new CompositionProgressState { CurrentStep = CompositionStep.Failed };
+    }
 }

--- a/src/BaroquenMelody.Library/Store/State/CompositionProgressState.cs
+++ b/src/BaroquenMelody.Library/Store/State/CompositionProgressState.cs
@@ -18,7 +18,9 @@ public sealed record CompositionProgressState(
 
     public bool IsWaiting => CurrentStep == CompositionStep.Waiting;
 
-    public bool IsLoading => !IsComplete && !IsWaiting;
+    public bool IsLoading => !IsComplete && !IsWaiting && !IsFailed;
+
+    public bool IsFailed => CurrentStep == CompositionStep.Failed;
 
     public string Message => CurrentStep switch
     {
@@ -29,6 +31,7 @@ public sealed record CompositionProgressState(
         CompositionStep.Phrasing => "Composing ending...", // Step completes too quickly to show a different message to the user.
         CompositionStep.Ending => "Composing ending...",
         CompositionStep.Complete => "Composition complete!",
+        CompositionStep.Failed => "Failed to compose composition.",
         _ => throw new ArgumentOutOfRangeException(nameof(CurrentStep), $"Unknown composition step: {CurrentStep}.")
     };
 

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ChordComposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Composers/ChordComposerTests.cs
@@ -50,7 +50,7 @@ internal sealed class ChordComposerTests
         _mockCompositionStrategy.GetPossibleChords(Arg.Any<IReadOnlyList<BaroquenChord>>()).Returns(
         [
             expectedChordA,
-            expectedChordB,
+            expectedChordB
         ]);
 
         var precedingChords = new List<BaroquenChord>

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/FollowsStandardProgressionTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/FollowsStandardProgressionTests.cs
@@ -3,7 +3,6 @@ using BaroquenMelody.Library.Compositions.Domain;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Rules;
 using BaroquenMelody.Library.Infrastructure.Collections.Extensions;
-using BaroquenMelody.Library.Infrastructure.Extensions;
 using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;

--- a/tests/BaroquenMelody.Library.Tests/Infrastructure/Collections/Extensions/EnumerableExtensionsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Infrastructure/Collections/Extensions/EnumerableExtensionsTests.cs
@@ -58,7 +58,7 @@ internal sealed class EnumerableExtensionsTests
             new() { NoteName.B },
             new() { NoteName.D },
             new() { NoteName.F },
-            new(),
+            new()
         };
 
         // act

--- a/tests/BaroquenMelody.Library.Tests/Store/Effects/BaroquenMelodyEffectsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Effects/BaroquenMelodyEffectsTests.cs
@@ -105,6 +105,24 @@ internal sealed class BaroquenMelodyEffectsTests
         _mockDispatcher.DidNotReceiveWithAnyArgs().Dispatch(Arg.Any<object>());
     }
 
+    [Test]
+    public async Task HandleCompose_handles_exception_and_marks_composition_failed()
+    {
+        // arrange
+        _mockInstrumentConfigurationState.Value.Returns(new InstrumentConfigurationState());
+        _mockCompositionRuleConfigurationState.Value.Returns(new CompositionRuleConfigurationState());
+        _mockCompositionOrnamentationConfigurationState.Value.Returns(new CompositionOrnamentationConfigurationState());
+        _mockCompositionConfigurationState.Value.Returns(new CompositionConfigurationState());
+        _mockBaroquenMelodyComposerConfigurator.Configure(Arg.Any<CompositionConfiguration>()).Returns(_mockComposer);
+        _mockComposer.Compose(Arg.Any<CancellationToken>()).Throws<Exception>();
+
+        // act
+        await _baroquenMelodyEffects.HandleCompose(new Compose(), _mockDispatcher);
+
+        // assert
+        _mockDispatcher.Received().Dispatch(Arg.Any<MarkCompositionFailed>());
+    }
+
     [TearDown]
     public void TearDown()
     {

--- a/tests/BaroquenMelody.Library.Tests/Store/Reducers/CompositionProgressReducersTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Reducers/CompositionProgressReducersTests.cs
@@ -74,4 +74,31 @@ internal sealed class CompositionProgressReducersTests
         newState.EndingProgress.Should().Be(0.0d);
         newState.OverallProgress.Should().Be(0.0d);
     }
+
+    [Test]
+    public void ReduceMarkCompositionFailed_returns_new_state_with_expected_values()
+    {
+        // arrange
+        var state = new CompositionProgressState(
+            new HashSet<CompositionStep> { CompositionStep.Theme },
+            CompositionStep.Theme,
+            ThemeProgress: 0.25d,
+            BodyProgress: 0.25d,
+            EndingProgress: 0.25d
+        );
+
+        var action = new MarkCompositionFailed();
+
+        // act
+        var newState = CompositionProgressReducers.ReduceMarkCompositionFailed(state, action);
+
+        // assert
+        newState.CompletedSteps.Should().BeEmpty();
+        newState.CurrentStep.Should().Be(CompositionStep.Failed);
+        newState.Message.Should().Be("Failed to compose composition.");
+        newState.ThemeProgress.Should().Be(0.0d);
+        newState.BodyProgress.Should().Be(0.0d);
+        newState.EndingProgress.Should().Be(0.0d);
+        newState.OverallProgress.Should().Be(0.0d);
+    }
 }

--- a/tests/BaroquenMelody.Library.Tests/Store/State/CompositionProgressStateTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/State/CompositionProgressStateTests.cs
@@ -26,6 +26,7 @@ internal sealed class CompositionProgressStateTests
     [TestCase(CompositionStep.Phrasing, "Composing ending...")]
     [TestCase(CompositionStep.Ending, "Composing ending...")]
     [TestCase(CompositionStep.Complete, "Composition complete!")]
+    [TestCase(CompositionStep.Failed, "Failed to compose composition.")]
     public void Message_returns_expected_message_for_current_step(CompositionStep step, string expectedMessage)
     {
         // arrange


### PR DESCRIPTION
## Description

Gracefully handle composition failure by displaying an error to the user prompting them to try again or try with a different configuration.

Also included in this change set is removal of timed cancellation tokens for composition save functionality (which would close the save dialog window early if the user takes their time).

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
