### PR TITLE
Fix Preferences COM Exception

### DIFF
--- a/src/BaroquenMelody.App.Components/IThemeProvider.cs
+++ b/src/BaroquenMelody.App.Components/IThemeProvider.cs
@@ -6,7 +6,7 @@ public interface IThemeProvider
 {
     MudTheme Theme { get; }
 
-    bool IsDarkMode { get; }
+    bool IsDarkMode { get; set; }
 
     void ToggleDarkMode();
 

--- a/src/BaroquenMelody.App/App.xaml.cs
+++ b/src/BaroquenMelody.App/App.xaml.cs
@@ -1,13 +1,19 @@
-﻿namespace BaroquenMelody.App;
+﻿using BaroquenMelody.App.Components;
+
+namespace BaroquenMelody.App;
 
 /// <summary>
 ///     The entrypoint of the application.
 /// </summary>
 public partial class App : Application
 {
-    public App()
+    private readonly IThemeProvider _themeProvider;
+
+    public App(IThemeProvider themeProvider)
     {
         InitializeComponent();
+
+        _themeProvider = themeProvider;
 
         MainPage = new MainPage();
         MainPage.Title = "Baroquen Melody";
@@ -15,13 +21,20 @@ public partial class App : Application
 
     protected override Window CreateWindow(IActivationState? activationState)
     {
-        var window = base.CreateWindow(activationState);
+        var window = base.CreateWindow(activationState) ?? throw new InvalidOperationException("Window is null");
 
-        if (window is not null)
+        window.Title = "Baroquen Melody";
+
+        window.Created += (_, _) =>
         {
-            window.Title = "Baroquen Melody";
-        }
+            _themeProvider.IsDarkMode = Preferences.Default.Get("IsDarkMode", true);
+        };
 
-        return window ?? throw new InvalidOperationException("Window is null");
+        window.Destroying += (_, _) =>
+        {
+            Preferences.Default.Set("IsDarkMode", _themeProvider.IsDarkMode);
+        };
+
+        return window;
     }
 }

--- a/src/BaroquenMelody.App/App.xaml.cs
+++ b/src/BaroquenMelody.App/App.xaml.cs
@@ -15,6 +15,8 @@ public partial class App : Application
 
         _themeProvider = themeProvider;
 
+        _themeProvider.IsDarkMode = Preferences.Default.Get("IsDarkMode", true);
+
         MainPage = new MainPage();
         MainPage.Title = "Baroquen Melody";
     }
@@ -24,11 +26,6 @@ public partial class App : Application
         var window = base.CreateWindow(activationState) ?? throw new InvalidOperationException("Window is null");
 
         window.Title = "Baroquen Melody";
-
-        window.Created += (_, _) =>
-        {
-            _themeProvider.IsDarkMode = Preferences.Default.Get("IsDarkMode", true);
-        };
 
         window.Destroying += (_, _) =>
         {

--- a/src/BaroquenMelody.App/Infrastructure/Theme/MauiThemeProvider.cs
+++ b/src/BaroquenMelody.App/Infrastructure/Theme/MauiThemeProvider.cs
@@ -52,11 +52,7 @@ internal sealed class MauiThemeProvider : IThemeProvider
         LayoutProperties = new LayoutProperties()
     };
 
-    public bool IsDarkMode
-    {
-        get => Preferences.Get("IsDarkMode", true);
-        private set => Preferences.Set("IsDarkMode", value);
-    }
+    public bool IsDarkMode { get; set; } = true;
 
     public string DarkLightModeButtonIcon => IsDarkMode switch
     {


### PR DESCRIPTION
## Description

Fixes the following exception, which occurs when spamming the flyout nav menu and is related to reading preferences while composing:

```
Message: The handle is invalid.
Stack Trace: at ABI.Windows.Foundation.Collections.IMapMethods`2.HasKey(IObjectReference obj, K key) at 
Microsoft.Maui.Storage.PackagedPreferencesImplementation.Get[T](String key, T defaultValue, String sharedName) at 
BaroquenMelody.App.Infrastructure.Theme.MauiThemeProvider.get_IsDarkMode() at 
BaroquenMelody.App.Infrastructure.Theme.MauiThemeProvider.get_DarkLightModeButtonIcon() at 
BaroquenMelody.App.Components.Layout.MainLayout.<BuildRenderTree>b__0_9(RenderTreeBuilder __builder5) at 
MudBlazor.MudTooltip.BuildRenderTree(RenderTreeBuilder __builder) at 
Microsoft.AspNetCore.Components.Rendering.ComponentState.RenderIntoBatch(RenderBatchBuilder batchBuilder, RenderFragment renderFragment, Exception& renderFragmentException)
```

Moved theme preferences save / load into application lifecycle events to work around this issue and improve performance.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
