### PR TITLE
MIDI Instrument Repository & Filtering

### DIFF
--- a/src/BaroquenMelody.App.Components/Shared/AutocompleteWithPopover.razor
+++ b/src/BaroquenMelody.App.Components/Shared/AutocompleteWithPopover.razor
@@ -1,9 +1,11 @@
 ﻿@typeparam T
 
-<MudOverlay @bind-Visible="IsPopoverOpen" AutoClose="true"/>
-<MudPopover AnchorOrigin="Origin.TopCenter"
+<MudOverlay @bind-Visible="IsPopoverOpen" LockScroll="false" AutoClose="true"/>
+<MudPopover AnchorOrigin="AnchorOrigin"
+            TransformOrigin="TransformOrigin"
             Open="IsPopoverOpen"
             Elevation="3"
+            OverflowBehavior="OverflowBehavior.FlipNever"
             Delay="ThemeProvider.TooltipDelay"
             Duration="ThemeProvider.TooltipDuration">
     <MudCard Class="rounded" Outlined="true" Elevation="3">
@@ -20,7 +22,7 @@
                  Label="@Label"
                  MaxItems="null"
                  OnAdornmentClick="OpenPopover"
-                 AdornmentIcon="@Icons.Material.Outlined.QuestionMark"
+                 AdornmentIcon="@Icon"
                  Adornment="Adornment.End"
                  IconSize="Size.Small"
                  Variant="Variant.Outlined"
@@ -43,6 +45,12 @@
     [Parameter, EditorRequired] public required Func<string, CancellationToken, Task<IEnumerable<T>>> SearchFunc { get; set; }
 
     [Parameter, EditorRequired] public required EventCallback<T> ValueChanged { get; set; }
+
+    [Parameter] public string Icon { get; set; } = Icons.Material.Outlined.QuestionMark;
+
+    [Parameter] public Origin AnchorOrigin { get; set; } = Origin.TopCenter;
+
+    [Parameter] public Origin TransformOrigin { get; set; } = Origin.TopLeft;
 
     private void OpenPopover() => IsPopoverOpen = true;
 

--- a/src/BaroquenMelody.App.Components/Shared/InstrumentConfigurationCard.razor
+++ b/src/BaroquenMelody.App.Components/Shared/InstrumentConfigurationCard.razor
@@ -9,13 +9,22 @@
         <MudGrid Justify="Justify.SpaceBetween">
             <MudItem xs="12" sm="6" md="5" lg="4" xl="3" xxl="2">
                 <AutocompleteWithPopover T="GeneralMidi2Program"
-                                         SearchFunc="InstrumentSearchFunc"
-                                         ToStringFunc="ToStringFunc"
+                                         SearchFunc="MidiInstrumentSearchFunc"
+                                         ToStringFunc="@(instrument => instrument.ToSpaceSeparatedString())"
                                          ValueProvider="() => MidiInstrument"
                                          ValueChanged="HandleMidiInstrumentChange"
+                                         AnchorOrigin="InstrumentFilterAnchorOrigin"
+                                         TransformOrigin="InstrumentFilterTransformOrigin"
+                                         Icon="@Icons.Material.TwoTone.FilterAlt"
                                          Label="Instrument">
                     <PopoverContent>
-                        <MudText>The <MudLink Color="Color.Tertiary" Href="https://en.wikipedia.org/wiki/MIDI">MIDI instrument</MudLink> to use in the composition.</MudText>
+                        <MudText Align="Align.Center" Class="mt-n3" Typo="Typo.h6">Filter Instruments</MudText>
+                        <MudPaper Class="d-flex flex-column overflow-x-auto mt-1 ml-n4 mr-n4 mb-n4" Outlined="true" Height="33vh">
+                            @foreach (var filter in MidiInstrumentFilters)
+                            {
+                                <MudCheckBox T="bool" Label="@filter.Type.ToSpaceSeparatedString()" Color="Color.Tertiary" UncheckedColor="Color.Secondary" Dense="true" Value="@filter.IsEnabled" ValueChanged="val => { filter.IsEnabled = val; HandleInstrumentFilterChange(); }"/>
+                            }
+                        </MudPaper>
                     </PopoverContent>
                 </AutocompleteWithPopover>
             </MudItem>
@@ -140,6 +149,15 @@
         }
     }
 
+    private sealed class MidiInstrumentFilter
+    {
+        public MidiInstrumentType Type { get; init; }
+
+        public bool IsEnabled { get; set; }
+    };
+
+    private IEnumerable<MidiInstrumentFilter> MidiInstrumentFilters = [];
+
     private IEnumerable<int> NoteIndices => Enumerable.Range(SliderMin, SliderMax + 1);
 
     private IEnumerable<int> LowestPitchNoteIndices => NoteIndices.Take(CompositionConfigurationState.Value.Notes.Count - CompositionConfiguration.MinInstrumentRange);
@@ -148,13 +166,11 @@
 
     private IDisposable? InstrumentConfigurationStateSubscription;
 
-    private FrozenDictionary<string, GeneralMidi2Program> MidiInstruments = EnumUtils<GeneralMidi2Program>
-        .AsEnumerable()
-        .OrderBy(instrument => instrument.ToSpaceSeparatedString())
-        .ToFrozenDictionary(
-            instrument => instrument.ToSpaceSeparatedString(),
-            instrument => instrument
-        );
+    private FrozenDictionary<string, GeneralMidi2Program> MidiInstruments = FrozenDictionary<string, GeneralMidi2Program>.Empty;
+
+    private Origin InstrumentFilterAnchorOrigin = Origin.TopRight;
+
+    private Origin InstrumentFilterTransformOrigin = Origin.TopLeft;
 
     protected override void OnInitialized()
     {
@@ -162,6 +178,26 @@
 
         _lowestPitchNoteIndex = CompositionConfigurationState.Value.Notes.IndexOf(LowestPitchNote);
         _highestPitchNoteIndex = CompositionConfigurationState.Value.Notes.IndexOf(HighestPitchNote);
+
+        if (PhysicalDeviceInfo.IsMobile)
+        {
+            InstrumentFilterAnchorOrigin = Origin.TopRight;
+            InstrumentFilterTransformOrigin = Origin.TopRight;
+        }
+
+        foreach (var midiInstrumentType in EnumUtils<MidiInstrumentType>.AsEnumerable().Where(midiInstrumentType => midiInstrumentType != MidiInstrumentType.All && midiInstrumentType != MidiInstrumentType.None))
+        {
+            MidiInstrumentFilters = MidiInstrumentFilters.Append(new MidiInstrumentFilter
+            {
+                Type = midiInstrumentType,
+                IsEnabled = true
+            });
+        }
+
+        MidiInstruments = MidiInstrumentRepository.GetAllMidiInstruments().ToFrozenDictionary(
+            instrument => instrument.ToSpaceSeparatedString(),
+            instrument => instrument
+        );
 
         InstrumentConfigurationStateSubscription = InstrumentConfigurationState
             .ObserveChanges()
@@ -173,6 +209,8 @@
                 _highestPitchNoteIndex = CompositionConfigurationState.Value.Notes.IndexOf(configuration.MaxNote);
             });
     }
+
+    private void HandleIsEnabledChange(bool isEnabled) => Dispatcher.Dispatch(new UpdateInstrumentConfiguration(Instrument, LowestPitchNote, HighestPitchNote, MidiInstrument, isEnabled, IsUserApplied: true));
 
     private void HandleLowestPitchNoteIndexChange(int noteIndex) => Dispatcher.Dispatch(
         new UpdateInstrumentConfiguration(
@@ -198,20 +236,51 @@
 
     private void HandleMidiInstrumentChange(GeneralMidi2Program instrument) => Dispatcher.Dispatch(new UpdateInstrumentConfiguration(Instrument, LowestPitchNote, HighestPitchNote, instrument, IsEnabled, IsUserApplied: true));
 
-    private void HandleIsEnabledChange(bool isEnabled) => Dispatcher.Dispatch(new UpdateInstrumentConfiguration(Instrument, LowestPitchNote, HighestPitchNote, MidiInstrument, isEnabled, IsUserApplied: true));
-
-    private async Task<IEnumerable<GeneralMidi2Program>> InstrumentSearchFunc(string search, CancellationToken cancellationToken)
+    private void HandleInstrumentFilterChange()
     {
-        var instruments = string.IsNullOrWhiteSpace(search)
+        if (!MidiInstrumentFilters.Any(filter => filter.IsEnabled))
+        {
+            MidiInstruments = MidiInstrumentRepository.GetAllMidiInstruments().ToFrozenDictionary(
+                instrument => instrument.ToSpaceSeparatedString(),
+                instrument => instrument
+            );
+
+            return;
+        }
+
+        var includedMidiInstruments = MidiInstrumentFilters.Where(filter => filter.IsEnabled).Aggregate(MidiInstrumentType.None, (current, filter) => current | filter.Type);
+        var midiInstruments = MidiInstrumentRepository.GetMidiInstruments(includedMidiInstruments).ToList();
+
+        MidiInstruments = midiInstruments.ToFrozenDictionary(
+            instrument => instrument.ToSpaceSeparatedString(),
+            instrument => instrument
+        );
+
+        if (MidiInstruments.ContainsKey(MidiInstrument.ToSpaceSeparatedString()))
+        {
+            return;
+        }
+
+        Dispatcher.Dispatch(new UpdateInstrumentConfiguration(
+            Instrument,
+            LowestPitchNote,
+            HighestPitchNote,
+            MidiInstruments.Values.Order().First(),
+            IsEnabled,
+            IsUserApplied: true
+        ));
+    }
+
+    private async Task<IEnumerable<GeneralMidi2Program>> MidiInstrumentSearchFunc(string search, CancellationToken cancellationToken)
+    {
+        var midiInstruments = string.IsNullOrWhiteSpace(search)
             ? MidiInstruments.Values
             : MidiInstruments.Keys
                 .Where(key => key.Contains(search, StringComparison.OrdinalIgnoreCase))
                 .Select(key => MidiInstruments[key]);
 
-        return await Task.FromResult(instruments);
+        return await Task.FromResult(midiInstruments.OrderBy(instrument => instrument.ToSpaceSeparatedString(), StringComparer.OrdinalIgnoreCase));
     }
-
-    private static string ToStringFunc(GeneralMidi2Program instrument) => instrument.ToSpaceSeparatedString();
 
     protected virtual void Dispose(bool disposing)
     {

--- a/src/BaroquenMelody.App.Components/_Imports.razor
+++ b/src/BaroquenMelody.App.Components/_Imports.razor
@@ -8,6 +8,7 @@
 @using BaroquenMelody.Library.Compositions.Configurations.Services
 @using BaroquenMelody.Library.Compositions.Domain
 @using BaroquenMelody.Library.Compositions.Enums.Extensions
+@using BaroquenMelody.Library.Compositions.Midi.Enums
 @using BaroquenMelody.Library.Compositions.MusicTheory.Enums
 @using BaroquenMelody.Library.Compositions.Ornamentation
 @using BaroquenMelody.Library.Compositions.Ornamentation.Enums
@@ -22,6 +23,8 @@
 @using System.Globalization
 @using System.Net.Http
 @using System.Net.Http.Json
+@using BaroquenMelody.Library.Compositions.Midi.Repositories
+@using BaroquenMelody.Library.Infrastructure.Devices
 @using BaroquenMelody.Library.Infrastructure.FileSystem
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
@@ -53,3 +56,5 @@
 @inject ICompositionConfigurationPersistenceService CompositionConfigurationPersistenceService
 @inject NavigationManager NavigationManager
 @inject IDialogService DialogService
+@inject IMidiInstrumentRepository MidiInstrumentRepository
+@inject IPhysicalDeviceInfo PhysicalDeviceInfo

--- a/src/BaroquenMelody.App/Infrastructure/Devices/MauiDeviceInfo.cs
+++ b/src/BaroquenMelody.App/Infrastructure/Devices/MauiDeviceInfo.cs
@@ -1,0 +1,8 @@
+﻿using BaroquenMelody.Library.Infrastructure.Devices;
+
+namespace BaroquenMelody.App.Infrastructure.Devices;
+
+internal sealed class MauiDeviceInfo : IPhysicalDeviceInfo
+{
+    public bool IsMobile => DeviceInfo.Current.Platform == DevicePlatform.Android || DeviceInfo.Current.Platform == DevicePlatform.iOS;
+}

--- a/src/BaroquenMelody.App/MauiProgram.cs
+++ b/src/BaroquenMelody.App/MauiProgram.cs
@@ -1,7 +1,9 @@
 ﻿using BaroquenMelody.App.Components;
 using BaroquenMelody.App.Components.Extensions;
+using BaroquenMelody.App.Infrastructure.Devices;
 using BaroquenMelody.App.Infrastructure.FileSystem;
 using BaroquenMelody.App.Infrastructure.Theme;
+using BaroquenMelody.Library.Infrastructure.Devices;
 using BaroquenMelody.Library.Infrastructure.FileSystem;
 using CommunityToolkit.Maui;
 using Microsoft.AspNetCore.Components.WebView.Maui;
@@ -21,6 +23,7 @@ public static class MauiProgram
             .ConfigureFonts(fonts => { fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular"); });
 
         builder.Services.AddMauiBlazorWebView();
+        builder.Services.AddSingleton<IPhysicalDeviceInfo, MauiDeviceInfo>();
         builder.Services.AddSingleton<IMidiLauncher, MauiMidiLauncher>();
         builder.Services.AddSingleton<IMidiSaver, MauiMidiSaver>();
         builder.Services.AddSingleton<IThemeProvider, MauiThemeProvider>();

--- a/src/BaroquenMelody.Library/Compositions/Midi/Enums/MidiInstrumentType.cs
+++ b/src/BaroquenMelody.Library/Compositions/Midi/Enums/MidiInstrumentType.cs
@@ -1,0 +1,70 @@
+﻿namespace BaroquenMelody.Library.Compositions.Midi.Enums;
+
+[Flags]
+public enum MidiInstrumentType
+{
+    /// <summary>
+    ///     No instrument type.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    ///     Keyboards.
+    /// </summary>
+    Keyboard = 1 << 0,
+
+    /// <summary>
+    ///     Chromatic percussion instruments.
+    /// </summary>
+    ChromaticPercussion = 1 << 1,
+
+    /// <summary>
+    ///     Organs.
+    /// </summary>
+    Organ = 1 << 2,
+
+    /// <summary>
+    ///     Guitars.
+    /// </summary>
+    Guitar = 1 << 3,
+
+    /// <summary>
+    ///     Basses.
+    /// </summary>
+    Bass = 1 << 4,
+
+    /// <summary>
+    ///     Strings.
+    /// </summary>
+    Strings = 1 << 5,
+
+    /// <summary>
+    ///     Ensemble instruments.
+    /// </summary>
+    Ensemble = 1 << 6,
+
+    /// <summary>
+    ///     Voices.
+    /// </summary>
+    Voice = 1 << 7,
+
+    /// <summary>
+    ///     Brass instruments.
+    /// </summary>
+    Brass = 1 << 8,
+
+    /// <summary>
+    ///     Woodwind instruments.
+    /// </summary>
+    Woodwind = 1 << 9,
+
+    /// <summary>
+    ///     Synthesizers.
+    /// </summary>
+    Synth = 1 << 10,
+
+    /// <summary>
+    ///     All instrument types.
+    /// </summary>
+    All = Keyboard | ChromaticPercussion | Organ | Guitar | Bass | Strings | Ensemble | Voice | Brass | Woodwind | Synth
+}

--- a/src/BaroquenMelody.Library/Compositions/Midi/Repositories/IMidiInstrumentRepository.cs
+++ b/src/BaroquenMelody.Library/Compositions/Midi/Repositories/IMidiInstrumentRepository.cs
@@ -1,0 +1,20 @@
+﻿using BaroquenMelody.Library.Compositions.Midi.Enums;
+using Melanchall.DryWetMidi.Standards;
+
+namespace BaroquenMelody.Library.Compositions.Midi.Repositories;
+
+public interface IMidiInstrumentRepository
+{
+    /// <summary>
+    ///     Get the <see cref="GeneralMidi2Program"/>s for the given <see cref="MidiInstrumentType"/>.
+    /// </summary>
+    /// <param name="midiInstrumentType">The <see cref="MidiInstrumentType"/> to get the <see cref="GeneralMidi2Program"/>s for.</param>
+    /// <returns>The <see cref="GeneralMidi2Program"/>s for the given <see cref="MidiInstrumentType"/>.</returns>
+    IEnumerable<GeneralMidi2Program> GetMidiInstruments(MidiInstrumentType midiInstrumentType);
+
+    /// <summary>
+    ///     Get all <see cref="GeneralMidi2Program"/>s.
+    /// </summary>
+    /// <returns>All <see cref="GeneralMidi2Program"/>s.</returns>
+    IEnumerable<GeneralMidi2Program> GetAllMidiInstruments();
+}

--- a/src/BaroquenMelody.Library/Compositions/Midi/Repositories/MidiInstrumentRepository.cs
+++ b/src/BaroquenMelody.Library/Compositions/Midi/Repositories/MidiInstrumentRepository.cs
@@ -1,0 +1,311 @@
+﻿using BaroquenMelody.Library.Compositions.Midi.Enums;
+using BaroquenMelody.Library.Infrastructure.Extensions;
+using Melanchall.DryWetMidi.Standards;
+
+namespace BaroquenMelody.Library.Compositions.Midi.Repositories;
+
+internal sealed class MidiInstrumentRepository : IMidiInstrumentRepository
+{
+    private static readonly IEnumerable<GeneralMidi2Program> Keyboard = new List<GeneralMidi2Program>
+    {
+        GeneralMidi2Program.AcousticGrandPiano,
+        GeneralMidi2Program.AcousticGrandPianoWide,
+        GeneralMidi2Program.AcousticGrandPianoDark,
+        GeneralMidi2Program.BrightAcousticPiano,
+        GeneralMidi2Program.BrightAcousticPianoWide,
+        GeneralMidi2Program.ElectricGrandPiano,
+        GeneralMidi2Program.ElectricGrandPianoWide,
+        GeneralMidi2Program.HonkyTonkPiano,
+        GeneralMidi2Program.HonkyTonkPianoWide,
+        GeneralMidi2Program.ElectricPiano1,
+        GeneralMidi2Program.DetunedElectricPiano1,
+        GeneralMidi2Program.ElectricPiano1VelocityMix,
+        GeneralMidi2Program.SixtiesElectricPiano,
+        GeneralMidi2Program.ElectricPiano2,
+        GeneralMidi2Program.DetunedElectricPiano2,
+        GeneralMidi2Program.ElectricPiano2VelocityMix,
+        GeneralMidi2Program.EpLegend,
+        GeneralMidi2Program.EpPhase,
+        GeneralMidi2Program.Harpsichord,
+        GeneralMidi2Program.HarpsichordOctaveMix,
+        GeneralMidi2Program.HarpsichordWide,
+        GeneralMidi2Program.HarpsichordWithKeyOff,
+        GeneralMidi2Program.Clavi,
+        GeneralMidi2Program.PulseClavi
+    };
+
+    private static readonly IEnumerable<GeneralMidi2Program> ChromaticPercussion = new List<GeneralMidi2Program>
+    {
+        GeneralMidi2Program.Celesta,
+        GeneralMidi2Program.Glockenspiel,
+        GeneralMidi2Program.MusicBox,
+        GeneralMidi2Program.Vibraphone,
+        GeneralMidi2Program.VibraphoneWide,
+        GeneralMidi2Program.Marimba,
+        GeneralMidi2Program.MarimbaWide,
+        GeneralMidi2Program.Xylophone,
+        GeneralMidi2Program.TubularBells,
+        GeneralMidi2Program.ChurchBell,
+        GeneralMidi2Program.Carillon,
+        GeneralMidi2Program.Dulcimer,
+        GeneralMidi2Program.YangChin,
+        GeneralMidi2Program.Timpani,
+        GeneralMidi2Program.Kalimba
+    };
+
+    private static readonly IEnumerable<GeneralMidi2Program> Organ = new List<GeneralMidi2Program>
+    {
+        GeneralMidi2Program.DrawbarOrgan,
+        GeneralMidi2Program.DetunedDrawbarOrgan,
+        GeneralMidi2Program.ItalianSixtiesOrgan,
+        GeneralMidi2Program.DrawbarOrgan2,
+        GeneralMidi2Program.PercussiveOrgan,
+        GeneralMidi2Program.DetunedPercussiveOrgan,
+        GeneralMidi2Program.PercussiveOrgan2,
+        GeneralMidi2Program.RockOrgan,
+        GeneralMidi2Program.ChurchOrgan,
+        GeneralMidi2Program.ChurchOrganOctaveMix,
+        GeneralMidi2Program.DetunedChurchOrgan,
+        GeneralMidi2Program.ReedOrgan,
+        GeneralMidi2Program.PuffOrgan,
+        GeneralMidi2Program.Accordion,
+        GeneralMidi2Program.Accordion2,
+        GeneralMidi2Program.Harmonica,
+        GeneralMidi2Program.TangoAccordion
+    };
+
+    private static readonly IEnumerable<GeneralMidi2Program> Guitar = new List<GeneralMidi2Program>
+    {
+        GeneralMidi2Program.AcousticGuitarNylon,
+        GeneralMidi2Program.Ukulele,
+        GeneralMidi2Program.AcousticGuitarNylonKeyOff,
+        GeneralMidi2Program.AcousticGuitarNylon2,
+        GeneralMidi2Program.AcousticGuitarSteel,
+        GeneralMidi2Program.TwelveStringsGuitar,
+        GeneralMidi2Program.Mandolin,
+        GeneralMidi2Program.SteelGuitarWithBodySound,
+        GeneralMidi2Program.ElectricGuitarJazz,
+        GeneralMidi2Program.ElectricGuitarPedalSteel,
+        GeneralMidi2Program.ElectricGuitarClean,
+        GeneralMidi2Program.ElectricGuitarDetunedClean,
+        GeneralMidi2Program.MidToneGuitar,
+        GeneralMidi2Program.ElectricGuitarMuted,
+        GeneralMidi2Program.ElectricGuitarFunkyCutting,
+        GeneralMidi2Program.ElectricGuitarMutedVeloSw,
+        GeneralMidi2Program.JazzMan,
+        GeneralMidi2Program.OverdrivenGuitar,
+        GeneralMidi2Program.GuitarPinch,
+        GeneralMidi2Program.DistortionGuitar,
+        GeneralMidi2Program.DistortionGuitarWithFeedback,
+        GeneralMidi2Program.DistortedRhythmGuitar,
+        GeneralMidi2Program.GuitarHarmonics,
+        GeneralMidi2Program.GuitarFeedback
+    };
+
+    private static readonly IEnumerable<GeneralMidi2Program> Bass = new List<GeneralMidi2Program>
+    {
+        GeneralMidi2Program.AcousticBass,
+        GeneralMidi2Program.ElectricBassFinger,
+        GeneralMidi2Program.FingerSlapBass,
+        GeneralMidi2Program.ElectricBassPick,
+        GeneralMidi2Program.FretlessBass,
+        GeneralMidi2Program.SlapBass1,
+        GeneralMidi2Program.SlapBass2,
+        GeneralMidi2Program.SynthBass1,
+        GeneralMidi2Program.SynthBassWarm,
+        GeneralMidi2Program.SynthBass3Resonance,
+        GeneralMidi2Program.ClaviBass,
+        GeneralMidi2Program.Hammer,
+        GeneralMidi2Program.SynthBass2,
+        GeneralMidi2Program.SynthBass4Attack,
+        GeneralMidi2Program.SynthBassRubber,
+        GeneralMidi2Program.AttackPulse
+    };
+
+    private static readonly IEnumerable<GeneralMidi2Program> Strings = new List<GeneralMidi2Program>
+    {
+        GeneralMidi2Program.Violin,
+        GeneralMidi2Program.ViolinSlowAttack,
+        GeneralMidi2Program.Viola,
+        GeneralMidi2Program.Cello,
+        GeneralMidi2Program.Contrabass,
+        GeneralMidi2Program.TremoloStrings,
+        GeneralMidi2Program.PizzicatoStrings,
+        GeneralMidi2Program.OrchestralHarp,
+        GeneralMidi2Program.Sitar,
+        GeneralMidi2Program.Sitar2Bend,
+        GeneralMidi2Program.Banjo,
+        GeneralMidi2Program.Shamisen,
+        GeneralMidi2Program.Koto,
+        GeneralMidi2Program.TaishoKoto,
+        GeneralMidi2Program.Fiddle
+    };
+
+    private static readonly IEnumerable<GeneralMidi2Program> Ensemble = new List<GeneralMidi2Program>
+    {
+        GeneralMidi2Program.StringEnsembles1,
+        GeneralMidi2Program.StringsAndBrass,
+        GeneralMidi2Program.SixtiesStrings,
+        GeneralMidi2Program.StringEnsembles2,
+        GeneralMidi2Program.SynthStrings1,
+        GeneralMidi2Program.SynthStrings3,
+        GeneralMidi2Program.SynthStrings2,
+        GeneralMidi2Program.OrchestraHit,
+        GeneralMidi2Program.BassHitPlus,
+        GeneralMidi2Program.SixthHit,
+        GeneralMidi2Program.EuroHit
+    };
+
+    private static readonly IEnumerable<GeneralMidi2Program> Voice = new List<GeneralMidi2Program>
+    {
+        GeneralMidi2Program.ChoirAahs,
+        GeneralMidi2Program.ChoirAahs2,
+        GeneralMidi2Program.VoiceOohs,
+        GeneralMidi2Program.Humming,
+        GeneralMidi2Program.SynthVoice,
+        GeneralMidi2Program.AnalogVoice
+    };
+
+    private static readonly IEnumerable<GeneralMidi2Program> Brass = new List<GeneralMidi2Program>
+    {
+        GeneralMidi2Program.Trumpet,
+        GeneralMidi2Program.DarkTrumpetSoft,
+        GeneralMidi2Program.Trombone,
+        GeneralMidi2Program.Trombone2,
+        GeneralMidi2Program.BrightTrombone,
+        GeneralMidi2Program.Tuba,
+        GeneralMidi2Program.MutedTrumpet,
+        GeneralMidi2Program.MutedTrumpet2,
+        GeneralMidi2Program.FrenchHorn,
+        GeneralMidi2Program.FrenchHorn2Warm,
+        GeneralMidi2Program.BrassSection,
+        GeneralMidi2Program.BrassSection2OctaveMix,
+        GeneralMidi2Program.SynthBrass1,
+        GeneralMidi2Program.SynthBrass3,
+        GeneralMidi2Program.AnalogSynthBrass1,
+        GeneralMidi2Program.JumpBrass,
+        GeneralMidi2Program.SynthBrass2,
+        GeneralMidi2Program.SynthBrass4,
+        GeneralMidi2Program.AnalogSynthBrass2
+    };
+
+    private static readonly IEnumerable<GeneralMidi2Program> Woodwind = new List<GeneralMidi2Program>
+    {
+        GeneralMidi2Program.SopranoSax,
+        GeneralMidi2Program.AltoSax,
+        GeneralMidi2Program.TenorSax,
+        GeneralMidi2Program.BaritoneSax,
+        GeneralMidi2Program.Oboe,
+        GeneralMidi2Program.EnglishHorn,
+        GeneralMidi2Program.Bassoon,
+        GeneralMidi2Program.Clarinet,
+        GeneralMidi2Program.Piccolo,
+        GeneralMidi2Program.Flute,
+        GeneralMidi2Program.Recorder,
+        GeneralMidi2Program.PanFlute,
+        GeneralMidi2Program.BlownBottle,
+        GeneralMidi2Program.Shakuhachi,
+        GeneralMidi2Program.Whistle,
+        GeneralMidi2Program.Ocarina,
+        GeneralMidi2Program.Shanai,
+        GeneralMidi2Program.BagPipe
+    };
+
+    private static readonly IEnumerable<GeneralMidi2Program> Synth = new List<GeneralMidi2Program>
+    {
+        GeneralMidi2Program.Lead1Square,
+        GeneralMidi2Program.Lead1ASquare2,
+        GeneralMidi2Program.Lead1BSine,
+        GeneralMidi2Program.Lead2Sawtooth,
+        GeneralMidi2Program.Lead2ASawtooth2,
+        GeneralMidi2Program.Lead2BSawPulse,
+        GeneralMidi2Program.Lead2CDoubleSawtooth,
+        GeneralMidi2Program.Lead2DSequencedAnalog,
+        GeneralMidi2Program.Lead3Calliope,
+        GeneralMidi2Program.Lead4Chiff,
+        GeneralMidi2Program.Lead5Charang,
+        GeneralMidi2Program.Lead5AWireLead,
+        GeneralMidi2Program.Lead6Voice,
+        GeneralMidi2Program.Lead7Fifths,
+        GeneralMidi2Program.Lead8BassLead,
+        GeneralMidi2Program.Lead8ASoftWrl
+    };
+
+    private static readonly IEnumerable<GeneralMidi2Program> All = Keyboard
+        .Concat(ChromaticPercussion)
+        .Concat(Organ)
+        .Concat(Guitar)
+        .Concat(Bass)
+        .Concat(Strings)
+        .Concat(Ensemble)
+        .Concat(Voice)
+        .Concat(Brass)
+        .Concat(Woodwind)
+        .Concat(Synth)
+        .OrderBy(instrument => instrument.ToSpaceSeparatedString(), StringComparer.OrdinalIgnoreCase)
+        .ToList();
+
+    public IEnumerable<GeneralMidi2Program> GetMidiInstruments(MidiInstrumentType midiInstrumentType)
+    {
+        var midiInstruments = new List<GeneralMidi2Program>();
+
+        if (midiInstrumentType.HasFlag(MidiInstrumentType.Keyboard))
+        {
+            midiInstruments.AddRange(Keyboard);
+        }
+
+        if (midiInstrumentType.HasFlag(MidiInstrumentType.ChromaticPercussion))
+        {
+            midiInstruments.AddRange(ChromaticPercussion);
+        }
+
+        if (midiInstrumentType.HasFlag(MidiInstrumentType.Organ))
+        {
+            midiInstruments.AddRange(Organ);
+        }
+
+        if (midiInstrumentType.HasFlag(MidiInstrumentType.Guitar))
+        {
+            midiInstruments.AddRange(Guitar);
+        }
+
+        if (midiInstrumentType.HasFlag(MidiInstrumentType.Bass))
+        {
+            midiInstruments.AddRange(Bass);
+        }
+
+        if (midiInstrumentType.HasFlag(MidiInstrumentType.Strings))
+        {
+            midiInstruments.AddRange(Strings);
+        }
+
+        if (midiInstrumentType.HasFlag(MidiInstrumentType.Ensemble))
+        {
+            midiInstruments.AddRange(Ensemble);
+        }
+
+        if (midiInstrumentType.HasFlag(MidiInstrumentType.Voice))
+        {
+            midiInstruments.AddRange(Voice);
+        }
+
+        if (midiInstrumentType.HasFlag(MidiInstrumentType.Brass))
+        {
+            midiInstruments.AddRange(Brass);
+        }
+
+        if (midiInstrumentType.HasFlag(MidiInstrumentType.Woodwind))
+        {
+            midiInstruments.AddRange(Woodwind);
+        }
+
+        if (midiInstrumentType.HasFlag(MidiInstrumentType.Synth))
+        {
+            midiInstruments.AddRange(Synth);
+        }
+
+        return midiInstruments;
+    }
+
+    public IEnumerable<GeneralMidi2Program> GetAllMidiInstruments() => All;
+}

--- a/src/BaroquenMelody.Library/Infrastructure/Devices/IPhysicalDeviceInfo.cs
+++ b/src/BaroquenMelody.Library/Infrastructure/Devices/IPhysicalDeviceInfo.cs
@@ -1,0 +1,12 @@
+﻿namespace BaroquenMelody.Library.Infrastructure.Devices;
+
+/// <summary>
+///     An abstraction for device information.
+/// </summary>
+public interface IPhysicalDeviceInfo
+{
+    /// <summary>
+    ///     Whether the device is a mobile device.
+    /// </summary>
+    bool IsMobile { get; }
+}

--- a/src/BaroquenMelody.Library/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BaroquenMelody.Library/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations.Services;
+using BaroquenMelody.Library.Compositions.Midi.Repositories;
 using BaroquenMelody.Library.Infrastructure.FileSystem;
 using Fluxor;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,5 +25,6 @@ public static class ServiceCollectionExtensions
         .AddSingleton<IOrnamentationConfigurationService, OrnamentationConfigurationService>()
         .AddSingleton<ICompositionRuleConfigurationService, CompositionRuleConfigurationService>()
         .AddSingleton<IInstrumentConfigurationService, InstrumentConfigurationService>()
-        .AddSingleton<ICompositionConfigurationService, CompositionConfigurationService>();
+        .AddSingleton<ICompositionConfigurationService, CompositionConfigurationService>()
+        .AddSingleton<IMidiInstrumentRepository, MidiInstrumentRepository>();
 }

--- a/tests/BaroquenMelody.Library.Tests/BaroquenMelody.Library.Tests.csproj
+++ b/tests/BaroquenMelody.Library.Tests/BaroquenMelody.Library.Tests.csproj
@@ -48,8 +48,4 @@
     <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Infrastructure\FileSystem\" />
-  </ItemGroup>
-
 </Project>

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/Services/InstrumentConfigurationServiceTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/Services/InstrumentConfigurationServiceTests.cs
@@ -1,11 +1,14 @@
-﻿using BaroquenMelody.Library.Compositions.Configurations.Services;
+﻿using Atrea.Utilities.Enums;
+using BaroquenMelody.Library.Compositions.Configurations.Services;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Compositions.Midi.Repositories;
 using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
 using BaroquenMelody.Library.Store.Actions;
 using BaroquenMelody.Library.Store.State;
 using FluentAssertions;
 using Fluxor;
 using Melanchall.DryWetMidi.MusicTheory;
+using Melanchall.DryWetMidi.Standards;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -14,9 +17,13 @@ namespace BaroquenMelody.Library.Tests.Compositions.Configuration.Services;
 [TestFixture]
 internal sealed class InstrumentConfigurationServiceTests
 {
+    private IMidiInstrumentRepository _mockMidiInstrumentRepository = null!;
+
     private IDispatcher _mockDispatcher = null!;
 
     private IState<CompositionConfigurationState> _mockCompositionConfigurationState = null!;
+
+    private IState<InstrumentConfigurationState> _mockInstrumentConfigurationState = null!;
 
     private InstrumentConfigurationService _instrumentConfigurationService = null!;
 
@@ -25,9 +32,19 @@ internal sealed class InstrumentConfigurationServiceTests
     {
         _mockDispatcher = Substitute.For<IDispatcher>();
         _mockCompositionConfigurationState = Substitute.For<IState<CompositionConfigurationState>>();
+        _mockInstrumentConfigurationState = Substitute.For<IState<InstrumentConfigurationState>>();
+        _mockMidiInstrumentRepository = Substitute.For<IMidiInstrumentRepository>();
+
+        _mockMidiInstrumentRepository.GetAllMidiInstruments().Returns(EnumUtils<GeneralMidi2Program>.AsEnumerable());
+        _mockInstrumentConfigurationState.Value.Returns(new InstrumentConfigurationState());
         _mockCompositionConfigurationState.Value.Returns(new CompositionConfigurationState(NoteName.C, Mode.Ionian, Meter.FourFour));
 
-        _instrumentConfigurationService = new InstrumentConfigurationService(_mockDispatcher, _mockCompositionConfigurationState);
+        _instrumentConfigurationService = new InstrumentConfigurationService(
+            _mockMidiInstrumentRepository,
+            _mockDispatcher,
+            _mockCompositionConfigurationState,
+            _mockInstrumentConfigurationState
+        );
     }
 
     [Test]
@@ -60,6 +77,6 @@ internal sealed class InstrumentConfigurationServiceTests
         _instrumentConfigurationService.Randomize();
 
         // assert
-        _mockDispatcher.Received(4).Dispatch(Arg.Any<UpdateInstrumentConfiguration>());
+        _mockDispatcher.Received(3).Dispatch(Arg.Any<UpdateInstrumentConfiguration>());
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Midi/Enums/MidiInstrumentTypeTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Midi/Enums/MidiInstrumentTypeTests.cs
@@ -1,0 +1,52 @@
+﻿using Atrea.Utilities.Enums;
+using BaroquenMelody.Library.Compositions.Midi.Enums;
+using BaroquenMelody.Library.Infrastructure.Random;
+using FluentAssertions;
+using LazyCart;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Midi.Enums;
+
+[TestFixture]
+internal sealed class MidiInstrumentTypeTests
+{
+    [Test]
+    public void HasFlag_returns_expected_values()
+    {
+        // arrange
+        var midiInstrumentTypes = EnumUtils<MidiInstrumentType>
+            .AsEnumerable()
+            .Where(midiInstrumentType => midiInstrumentType != MidiInstrumentType.None && midiInstrumentType != MidiInstrumentType.All)
+            .OrderBy(_ => ThreadLocalRandom.Next())
+            .ToList();
+
+        var midiInstrumentCombos = new LazyCartesianProduct<MidiInstrumentType, MidiInstrumentType, MidiInstrumentType>(
+            midiInstrumentTypes,
+            midiInstrumentTypes,
+            midiInstrumentTypes
+        );
+
+        // act + assert
+        for (var i = 0; i < midiInstrumentCombos.Size; i++)
+        {
+            var midiInstrumentCombo = midiInstrumentCombos[i];
+
+            // act
+            var bitFlag = midiInstrumentCombo.Item1 | midiInstrumentCombo.Item2 | midiInstrumentCombo.Item3;
+
+            // assert the flag combo has the expected flags
+            bitFlag.HasFlag(midiInstrumentCombo.Item1).Should().BeTrue();
+            bitFlag.HasFlag(midiInstrumentCombo.Item2).Should().BeTrue();
+            bitFlag.HasFlag(midiInstrumentCombo.Item3).Should().BeTrue();
+
+            // assert the flag combo does not have any other flags
+            foreach (var midiInstrumentType in midiInstrumentTypes.Where(midiInstrumentType =>
+                         midiInstrumentType != midiInstrumentCombo.Item1 &&
+                         midiInstrumentType != midiInstrumentCombo.Item2 &&
+                         midiInstrumentType != midiInstrumentCombo.Item3))
+            {
+                bitFlag.HasFlag(midiInstrumentType).Should().BeFalse();
+            }
+        }
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Midi/Repositories/MidiInstrumentRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Midi/Repositories/MidiInstrumentRepositoryTests.cs
@@ -1,7 +1,5 @@
-﻿using Atrea.Utilities.Enums;
-using BaroquenMelody.Library.Compositions.Midi.Enums;
+﻿using BaroquenMelody.Library.Compositions.Midi.Enums;
 using BaroquenMelody.Library.Compositions.Midi.Repositories;
-using BaroquenMelody.Library.Infrastructure.Random;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Standards;
 using NUnit.Framework;
@@ -24,6 +22,7 @@ internal sealed class MidiInstrumentRepositoryTests
     [TestCase(MidiInstrumentType.Brass, MidiInstrumentType.Woodwind, GeneralMidi2Program.Trumpet, GeneralMidi2Program.Flute, GeneralMidi2Program.AcousticGrandPiano)]
     [TestCase(MidiInstrumentType.Keyboard, MidiInstrumentType.Organ, GeneralMidi2Program.AcousticGrandPiano, GeneralMidi2Program.ChurchOrgan, GeneralMidi2Program.AcousticGuitarNylon)]
     [TestCase(MidiInstrumentType.ChromaticPercussion, MidiInstrumentType.Guitar, GeneralMidi2Program.Vibraphone, GeneralMidi2Program.AcousticGuitarNylon, GeneralMidi2Program.AcousticGrandPiano)]
+    [TestCase(MidiInstrumentType.Synth, MidiInstrumentType.Bass, GeneralMidi2Program.Lead1BSine, GeneralMidi2Program.AcousticBass, GeneralMidi2Program.Celesta)]
     public void GetMidiInstruments_returns_expected_values(
         MidiInstrumentType midiInstrumentTypeA,
         MidiInstrumentType midiInstrumentTypeB,
@@ -41,5 +40,19 @@ internal sealed class MidiInstrumentRepositoryTests
         midiInstruments.Should().Contain(expectedInstrumentA);
         midiInstruments.Should().Contain(expectedInstrumentB);
         midiInstruments.Should().NotContain(unexpectedInstrument);
+    }
+
+    [Test]
+    public void GetAllMidiInstruments_returns_expected_values()
+    {
+        // arrange
+        var expectedMidiInstruments = _midiInstrumentRepository.GetMidiInstruments(MidiInstrumentType.All).ToList();
+
+        // act
+        var actualMidiInstruments = _midiInstrumentRepository.GetAllMidiInstruments().ToList();
+
+        // assert
+        actualMidiInstruments.Should().NotBeEmpty();
+        actualMidiInstruments.Should().BeEquivalentTo(expectedMidiInstruments);
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Midi/Repositories/MidiInstrumentRepositoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Midi/Repositories/MidiInstrumentRepositoryTests.cs
@@ -1,0 +1,45 @@
+﻿using Atrea.Utilities.Enums;
+using BaroquenMelody.Library.Compositions.Midi.Enums;
+using BaroquenMelody.Library.Compositions.Midi.Repositories;
+using BaroquenMelody.Library.Infrastructure.Random;
+using FluentAssertions;
+using Melanchall.DryWetMidi.Standards;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Compositions.Midi.Repositories;
+
+[TestFixture]
+internal sealed class MidiInstrumentRepositoryTests
+{
+    private MidiInstrumentRepository _midiInstrumentRepository = null!;
+
+    [SetUp]
+    public void SetUp() => _midiInstrumentRepository = new MidiInstrumentRepository();
+
+    [Test]
+    [TestCase(MidiInstrumentType.Keyboard, MidiInstrumentType.ChromaticPercussion, GeneralMidi2Program.AcousticGrandPiano, GeneralMidi2Program.Vibraphone, GeneralMidi2Program.AcousticGuitarNylon)]
+    [TestCase(MidiInstrumentType.Organ, MidiInstrumentType.Guitar, GeneralMidi2Program.ChurchOrgan, GeneralMidi2Program.AcousticGuitarNylon, GeneralMidi2Program.AcousticGrandPiano)]
+    [TestCase(MidiInstrumentType.Bass, MidiInstrumentType.Strings, GeneralMidi2Program.AcousticBass, GeneralMidi2Program.Violin, GeneralMidi2Program.AcousticGrandPiano)]
+    [TestCase(MidiInstrumentType.Ensemble, MidiInstrumentType.Voice, GeneralMidi2Program.StringEnsembles1, GeneralMidi2Program.ChoirAahs, GeneralMidi2Program.AcousticGuitarNylon)]
+    [TestCase(MidiInstrumentType.Brass, MidiInstrumentType.Woodwind, GeneralMidi2Program.Trumpet, GeneralMidi2Program.Flute, GeneralMidi2Program.AcousticGrandPiano)]
+    [TestCase(MidiInstrumentType.Keyboard, MidiInstrumentType.Organ, GeneralMidi2Program.AcousticGrandPiano, GeneralMidi2Program.ChurchOrgan, GeneralMidi2Program.AcousticGuitarNylon)]
+    [TestCase(MidiInstrumentType.ChromaticPercussion, MidiInstrumentType.Guitar, GeneralMidi2Program.Vibraphone, GeneralMidi2Program.AcousticGuitarNylon, GeneralMidi2Program.AcousticGrandPiano)]
+    public void GetMidiInstruments_returns_expected_values(
+        MidiInstrumentType midiInstrumentTypeA,
+        MidiInstrumentType midiInstrumentTypeB,
+        GeneralMidi2Program expectedInstrumentA,
+        GeneralMidi2Program expectedInstrumentB,
+        GeneralMidi2Program unexpectedInstrument)
+    {
+        // arrange
+        var instrumentBitFlag = midiInstrumentTypeA | midiInstrumentTypeB;
+
+        // act
+        var midiInstruments = _midiInstrumentRepository.GetMidiInstruments(instrumentBitFlag).ToList();
+
+        // assert
+        midiInstruments.Should().Contain(expectedInstrumentA);
+        midiInstruments.Should().Contain(expectedInstrumentB);
+        midiInstruments.Should().NotContain(unexpectedInstrument);
+    }
+}


### PR DESCRIPTION
## Description

- Implement a `IMidiInstrumentRepository` to control which instruments are available.
- Add popover MIDI instrument filter to the MIDI instrument autocomplete on the instrument configuration card
- Get device info via a new `IPhysicalDeviceInfo` implementation to help determine anchor and transform origin of filter popover
- Avoid randomizing instruments that are disabled
- Don't randomize enabled / disabled instrument status

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
