### PR TITLE
Display Enabled / Disabled Status on Configuration Card

### DIFF
--- a/src/BaroquenMelody.App.Components/Shared/AutocompleteWithPopover.razor
+++ b/src/BaroquenMelody.App.Components/Shared/AutocompleteWithPopover.razor
@@ -29,7 +29,8 @@
                  AnchorOrigin="Origin.BottomCenter"
                  Clearable="true"
                  OpenOnFocus="false"
-                 AutoFocus="false">
+                 AutoFocus="false"
+                 Disabled="IsDisabled">
 </MudAutocomplete>
 
 @code
@@ -45,6 +46,8 @@
     [Parameter, EditorRequired] public required Func<string, CancellationToken, Task<IEnumerable<T>>> SearchFunc { get; set; }
 
     [Parameter, EditorRequired] public required EventCallback<T> ValueChanged { get; set; }
+
+    [Parameter] public bool IsDisabled { get; set; } = false;
 
     [Parameter] public string Icon { get; set; } = Icons.Material.Outlined.QuestionMark;
 

--- a/src/BaroquenMelody.App.Components/Shared/CompositionRuleConfigurationCard.razor
+++ b/src/BaroquenMelody.App.Components/Shared/CompositionRuleConfigurationCard.razor
@@ -12,7 +12,8 @@
                                          ValueChanged="HandleStrictnessChange"
                                          ValueProvider="() => Strictness"
                                          Min="0"
-                                         Max="100">
+                                         Max="100"
+                                         IsDisabled="IsDisabled">
                     <PopoverContent>
                         <MudText>The strictness of the rule being applied to the composition.</MudText>
                     </PopoverContent>
@@ -34,7 +35,8 @@
                            Max="100"
                            Step="1"
                            ValueLabelFormat="0'%'"
-                           Culture="CultureInfo.CurrentCulture"/>
+                           Culture="CultureInfo.CurrentCulture"
+                           Disabled="IsDisabled"/>
             </MudItem>
         </MudGrid>
     </MudCardContent>
@@ -47,6 +49,8 @@
     private int Strictness => CompositionRuleConfigurationState.Value[CompositionRule]?.Strictness ?? 0;
 
     private bool IsEnabled => CompositionRuleConfigurationState.Value[CompositionRule]?.IsEnabled ?? false;
+
+    private bool IsDisabled => !IsEnabled;
 
     private void HandleStrictnessChange(int value) => Dispatcher.Dispatch(new UpdateCompositionRuleConfiguration(CompositionRule, IsEnabled, value));
 

--- a/src/BaroquenMelody.App.Components/Shared/InstrumentConfigurationCard.razor
+++ b/src/BaroquenMelody.App.Components/Shared/InstrumentConfigurationCard.razor
@@ -16,7 +16,8 @@
                                          AnchorOrigin="InstrumentFilterAnchorOrigin"
                                          TransformOrigin="InstrumentFilterTransformOrigin"
                                          Icon="@Icons.Material.TwoTone.FilterAlt"
-                                         Label="Instrument">
+                                         Label="Instrument"
+                                         IsDisabled="IsDisabled">
                     <PopoverContent>
                         <MudText Align="Align.Center" Class="mt-n3" Typo="Typo.h6">Filter Instruments</MudText>
                         <MudPaper Class="d-flex flex-column overflow-x-auto mt-1 ml-n4 mr-n4 mb-n4" Outlined="true" Height="33vh">
@@ -47,7 +48,8 @@
                              Step="1"
                              MinDistance="CompositionConfiguration.MinInstrumentRange"
                              LabelText="@LowestPitchNote.ToString()"
-                             UpperLabelText="@HighestPitchNote.ToString()"/>
+                             UpperLabelText="@HighestPitchNote.ToString()"
+                             Disabled="IsDisabled" />
             </MudItem>
             <MudItem xs="12" sm="4" md="3" lg="2" xl="2" xxl="2">
                 <MudSelect T="int"
@@ -56,7 +58,8 @@
                            Variant="Variant.Outlined"
                            AdornmentIcon="@Icons.Material.Outlined.ArrowCircleDown"
                            Adornment="Adornment.End"
-                           AdornmentColor="Color.Secondary">
+                           AdornmentColor="Color.Secondary"
+                           Disabled="IsDisabled">
                     @foreach (var noteIndex in LowestPitchNoteIndices)
                     {
                         <MudSelectItem Value="noteIndex">@CompositionConfigurationState.Value.Notes[noteIndex]</MudSelectItem>
@@ -70,7 +73,8 @@
                            Variant="Variant.Outlined"
                            AdornmentIcon="@Icons.Material.Outlined.ArrowCircleUp"
                            Adornment="Adornment.End"
-                           AdornmentColor="Color.Secondary">
+                           AdornmentColor="Color.Secondary"
+                           Disabled="IsDisabled">
                     @foreach (var noteIndex in HighestPitchNoteIndices)
                     {
                         <MudSelectItem Value="noteIndex">@CompositionConfigurationState.Value.Notes[noteIndex]</MudSelectItem>
@@ -92,6 +96,8 @@
     private GeneralMidi2Program MidiInstrument => InstrumentConfigurationState.Value[Instrument]?.MidiProgram ?? GeneralMidi2Program.AcousticGrandPiano;
 
     private bool IsEnabled => InstrumentConfigurationState.Value[Instrument]?.IsEnabled ?? false;
+
+    private bool IsDisabled => !IsEnabled;
 
     private const int SliderMin = 0;
 

--- a/src/BaroquenMelody.App.Components/Shared/NumericInputWithPopover.razor
+++ b/src/BaroquenMelody.App.Components/Shared/NumericInputWithPopover.razor
@@ -22,7 +22,8 @@
                  Label="@Label" 
                  ValueChanged="ValueChanged"
                  Min="Min"
-                 Max="Max"/>
+                 Max="Max"
+                 Disabled="IsDisabled" />
 
 @code
 {
@@ -37,6 +38,8 @@
     [Parameter] public T? Min { get; set; }
 
     [Parameter] public T? Max { get; set; }
+
+    [Parameter] public bool IsDisabled { get; set; } = false;
 
     private void OpenMeterPopover() => IsPopoverOpen = true;
 

--- a/src/BaroquenMelody.App.Components/Shared/OrnamentationConfigurationCard.razor
+++ b/src/BaroquenMelody.App.Components/Shared/OrnamentationConfigurationCard.razor
@@ -12,7 +12,8 @@
                                          ValueChanged="HandleProbabilityChange"
                                          ValueProvider="() => Probability"
                                          Min="0"
-                                         Max="100">
+                                         Max="100"
+                                         IsDisabled="IsDisabled">
                     <PopoverContent>
                         <MudText>The probability of the ornamentation being applied to the composition.</MudText>
                     </PopoverContent>
@@ -34,7 +35,8 @@
                            Max="100"
                            Step="1"
                            ValueLabelFormat="0'%'"
-                           Culture="CultureInfo.CurrentCulture"/>
+                           Culture="CultureInfo.CurrentCulture"
+                           Disabled="IsDisabled"/>
             </MudItem>
         </MudGrid>
     </MudCardContent>
@@ -47,6 +49,8 @@
     private int Probability => OrnamentationConfigurationState.Value[OrnamentationType]?.Probability ?? 0;
 
     private bool IsEnabled => OrnamentationConfigurationState.Value[OrnamentationType]?.IsEnabled ?? false;
+
+    private bool IsDisabled => !IsEnabled;
 
     private void HandleProbabilityChange(int value) => Dispatcher.Dispatch(new UpdateCompositionOrnamentationConfiguration(OrnamentationType, IsEnabled, value));
 

--- a/src/BaroquenMelody.Library/Compositions/Configurations/Services/CompositionRuleConfigurationService.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/Services/CompositionRuleConfigurationService.cs
@@ -1,12 +1,16 @@
 ﻿using BaroquenMelody.Library.Compositions.Rules.Enums;
 using BaroquenMelody.Library.Infrastructure.Random;
 using BaroquenMelody.Library.Store.Actions;
+using BaroquenMelody.Library.Store.State;
 using Fluxor;
 using System.Collections.Frozen;
 
 namespace BaroquenMelody.Library.Compositions.Configurations.Services;
 
-internal sealed class CompositionRuleConfigurationService(IDispatcher dispatcher) : ICompositionRuleConfigurationService
+internal sealed class CompositionRuleConfigurationService(
+    IDispatcher dispatcher,
+    IState<CompositionRuleConfigurationState> state
+) : ICompositionRuleConfigurationService
 {
     private static readonly FrozenSet<CompositionRule> _configurableOrnamentations = AggregateCompositionRuleConfiguration
         .Default
@@ -28,7 +32,13 @@ internal sealed class CompositionRuleConfigurationService(IDispatcher dispatcher
     {
         foreach (var configuration in AggregateCompositionRuleConfiguration.Default.Configurations)
         {
-            var isEnabled = ThreadLocalRandom.Next() % 2 == 0;
+            var isEnabled = state.Value.Configurations[configuration.Rule].IsEnabled;
+
+            if (!isEnabled)
+            {
+                continue;
+            }
+
             var strictness = ThreadLocalRandom.Next(0, 101);
 
             dispatcher.Dispatch(new UpdateCompositionRuleConfiguration(configuration.Rule, isEnabled, strictness));

--- a/src/BaroquenMelody.Library/Compositions/Configurations/Services/OrnamentationConfigurationService.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/Services/OrnamentationConfigurationService.cs
@@ -1,12 +1,16 @@
 ﻿using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Infrastructure.Random;
 using BaroquenMelody.Library.Store.Actions;
+using BaroquenMelody.Library.Store.State;
 using Fluxor;
 using System.Collections.Frozen;
 
 namespace BaroquenMelody.Library.Compositions.Configurations.Services;
 
-internal sealed class OrnamentationConfigurationService(IDispatcher dispatcher) : IOrnamentationConfigurationService
+internal sealed class OrnamentationConfigurationService(
+    IDispatcher dispatcher,
+    IState<CompositionOrnamentationConfigurationState> state
+) : IOrnamentationConfigurationService
 {
     private static readonly FrozenSet<OrnamentationType> _configurableOrnamentations = AggregateOrnamentationConfiguration
         .Default
@@ -28,7 +32,13 @@ internal sealed class OrnamentationConfigurationService(IDispatcher dispatcher) 
     {
         foreach (var configuration in AggregateOrnamentationConfiguration.Default.Configurations)
         {
-            var isEnabled = ThreadLocalRandom.Next() % 2 == 0;
+            var isEnabled = state.Value.Configurations[configuration.OrnamentationType].IsEnabled;
+
+            if (!isEnabled)
+            {
+                continue;
+            }
+
             var probability = ThreadLocalRandom.Next(0, 101);
 
             dispatcher.Dispatch(new UpdateCompositionOrnamentationConfiguration(configuration.OrnamentationType, isEnabled, probability));

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/Services/CompositionRuleConfigurationServiceTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/Services/CompositionRuleConfigurationServiceTests.cs
@@ -2,6 +2,7 @@
 using BaroquenMelody.Library.Compositions.Configurations.Services;
 using BaroquenMelody.Library.Compositions.Rules.Enums;
 using BaroquenMelody.Library.Store.Actions;
+using BaroquenMelody.Library.Store.State;
 using FluentAssertions;
 using Fluxor;
 using NSubstitute;
@@ -14,14 +15,19 @@ internal sealed class CompositionRuleConfigurationServiceTests
 {
     private IDispatcher _mockDispatcher = null!;
 
+    private IState<CompositionRuleConfigurationState> _mockState = null!;
+
     private CompositionRuleConfigurationService _compositionRuleConfigurationService = null!;
 
     [SetUp]
     public void SetUp()
     {
         _mockDispatcher = Substitute.For<IDispatcher>();
+        _mockState = Substitute.For<IState<CompositionRuleConfigurationState>>();
 
-        _compositionRuleConfigurationService = new CompositionRuleConfigurationService(_mockDispatcher);
+        _mockState.Value.Returns(new CompositionRuleConfigurationState());
+
+        _compositionRuleConfigurationService = new CompositionRuleConfigurationService(_mockDispatcher, _mockState);
     }
 
     [Test]

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/Services/CompositionRuleConfigurationServiceTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/Services/CompositionRuleConfigurationServiceTests.cs
@@ -25,8 +25,6 @@ internal sealed class CompositionRuleConfigurationServiceTests
         _mockDispatcher = Substitute.For<IDispatcher>();
         _mockState = Substitute.For<IState<CompositionRuleConfigurationState>>();
 
-        _mockState.Value.Returns(new CompositionRuleConfigurationState());
-
         _compositionRuleConfigurationService = new CompositionRuleConfigurationService(_mockDispatcher, _mockState);
     }
 
@@ -73,12 +71,32 @@ internal sealed class CompositionRuleConfigurationServiceTests
     [Test]
     public void Randomize_dispatches_expected_actions()
     {
+        // arrange
+        var configurations = new Dictionary<CompositionRule, CompositionRuleConfiguration>
+        {
+            { CompositionRule.AvoidDirectFifths, new CompositionRuleConfiguration(CompositionRule.AvoidDirectFifths) },
+            { CompositionRule.AvoidDirectFourths, new CompositionRuleConfiguration(CompositionRule.AvoidDirectFourths) },
+            { CompositionRule.AvoidDirectOctaves, new CompositionRuleConfiguration(CompositionRule.AvoidDirectOctaves) },
+            { CompositionRule.AvoidDissonance, new CompositionRuleConfiguration(CompositionRule.AvoidDissonance) },
+            { CompositionRule.AvoidDissonantLeaps, new CompositionRuleConfiguration(CompositionRule.AvoidDissonantLeaps) },
+            { CompositionRule.AvoidOverDoubling, new CompositionRuleConfiguration(CompositionRule.AvoidOverDoubling) },
+            { CompositionRule.AvoidParallelFourths, new CompositionRuleConfiguration(CompositionRule.AvoidParallelFourths) },
+            { CompositionRule.AvoidParallelFifths, new CompositionRuleConfiguration(CompositionRule.AvoidParallelFifths) },
+            { CompositionRule.AvoidParallelOctaves, new CompositionRuleConfiguration(CompositionRule.AvoidParallelOctaves) },
+            { CompositionRule.AvoidRepetition, new CompositionRuleConfiguration(CompositionRule.AvoidRepetition) },
+            { CompositionRule.FollowStandardChordProgression, new CompositionRuleConfiguration(CompositionRule.FollowStandardChordProgression) },
+            { CompositionRule.HandleAscendingSeventh, new CompositionRuleConfiguration(CompositionRule.HandleAscendingSeventh) },
+            { CompositionRule.AvoidRepeatedChords, new CompositionRuleConfiguration(CompositionRule.AvoidRepeatedChords, IsEnabled: false) }
+        };
+
+        _mockState.Value.Returns(new CompositionRuleConfigurationState(configurations));
+
         // act
         _compositionRuleConfigurationService.Randomize();
 
         // assert
         _mockDispatcher
-            .Received(AggregateCompositionRuleConfiguration.Default.Configurations.Count)
+            .Received(configurations.Count - 1)
             .Dispatch(Arg.Any<UpdateCompositionRuleConfiguration>());
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/Services/OrnamentationConfigurationServiceTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/Services/OrnamentationConfigurationServiceTests.cs
@@ -25,8 +25,6 @@ internal sealed class OrnamentationConfigurationServiceTests
         _mockDispatcher = Substitute.For<IDispatcher>();
         _mockState = Substitute.For<IState<CompositionOrnamentationConfigurationState>>();
 
-        _mockState.Value.Returns(new CompositionOrnamentationConfigurationState());
-
         _ornamentationConfigurationService = new OrnamentationConfigurationService(_mockDispatcher, _mockState);
     }
 
@@ -79,12 +77,38 @@ internal sealed class OrnamentationConfigurationServiceTests
     [Test]
     public void Randomize_dispatches_expected_actions()
     {
+        // arrange
+        var configurations = new Dictionary<OrnamentationType, OrnamentationConfiguration>
+        {
+            { OrnamentationType.PassingTone, new OrnamentationConfiguration(OrnamentationType.PassingTone, true, 100) },
+            { OrnamentationType.DoublePassingTone, new OrnamentationConfiguration(OrnamentationType.DoublePassingTone, true, 100) },
+            { OrnamentationType.DelayedDoublePassingTone, new OrnamentationConfiguration(OrnamentationType.DelayedDoublePassingTone, true, 100) },
+            { OrnamentationType.DoubleTurn, new OrnamentationConfiguration(OrnamentationType.DoubleTurn, true, 100) },
+            { OrnamentationType.DelayedPassingTone, new OrnamentationConfiguration(OrnamentationType.DelayedPassingTone, true, 100) },
+            { OrnamentationType.DelayedNeighborTone, new OrnamentationConfiguration(OrnamentationType.DelayedNeighborTone, true, 100) },
+            { OrnamentationType.NeighborTone, new OrnamentationConfiguration(OrnamentationType.NeighborTone, true, 100) },
+            { OrnamentationType.Run, new OrnamentationConfiguration(OrnamentationType.Run, true, 100) },
+            { OrnamentationType.DoubleRun, new OrnamentationConfiguration(OrnamentationType.DoubleRun, true, 100) },
+            { OrnamentationType.Turn, new OrnamentationConfiguration(OrnamentationType.Turn, true, 100) },
+            { OrnamentationType.AlternateTurn, new OrnamentationConfiguration(OrnamentationType.AlternateTurn, true, 100) },
+            { OrnamentationType.DelayedRun, new OrnamentationConfiguration(OrnamentationType.DelayedRun, true, 100) },
+            { OrnamentationType.Mordent, new OrnamentationConfiguration(OrnamentationType.Mordent, true, 100) },
+            { OrnamentationType.DecorateInterval, new OrnamentationConfiguration(OrnamentationType.DecorateInterval, true, 100) },
+            { OrnamentationType.Pedal, new OrnamentationConfiguration(OrnamentationType.Pedal, true, 100) },
+            { OrnamentationType.RepeatedNote, new OrnamentationConfiguration(OrnamentationType.RepeatedNote, false, 100) },
+            { OrnamentationType.DelayedRepeatedNote, new OrnamentationConfiguration(OrnamentationType.DelayedRepeatedNote, true, 100) },
+            { OrnamentationType.Pickup, new OrnamentationConfiguration(OrnamentationType.Pickup, true, 100) },
+            { OrnamentationType.DelayedPickup, new OrnamentationConfiguration(OrnamentationType.DelayedPickup, true, 100) }
+        };
+
+        _mockState.Value.Returns(new CompositionOrnamentationConfigurationState(configurations));
+
         // act
         _ornamentationConfigurationService.Randomize();
 
         // assert
         _mockDispatcher
-            .Received(AggregateOrnamentationConfiguration.Default.Configurations.Count)
+            .Received(configurations.Count - 1)
             .Dispatch(Arg.Any<UpdateCompositionOrnamentationConfiguration>());
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/Services/OrnamentationConfigurationServiceTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/Services/OrnamentationConfigurationServiceTests.cs
@@ -2,6 +2,7 @@
 using BaroquenMelody.Library.Compositions.Configurations.Services;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
 using BaroquenMelody.Library.Store.Actions;
+using BaroquenMelody.Library.Store.State;
 using FluentAssertions;
 using Fluxor;
 using NSubstitute;
@@ -14,14 +15,19 @@ internal sealed class OrnamentationConfigurationServiceTests
 {
     private IDispatcher _mockDispatcher = null!;
 
+    private IState<CompositionOrnamentationConfigurationState> _mockState = null!;
+
     private OrnamentationConfigurationService _ornamentationConfigurationService = null!;
 
     [SetUp]
     public void SetUp()
     {
         _mockDispatcher = Substitute.For<IDispatcher>();
+        _mockState = Substitute.For<IState<CompositionOrnamentationConfigurationState>>();
 
-        _ornamentationConfigurationService = new OrnamentationConfigurationService(_mockDispatcher);
+        _mockState.Value.Returns(new CompositionOrnamentationConfigurationState());
+
+        _ornamentationConfigurationService = new OrnamentationConfigurationService(_mockDispatcher, _mockState);
     }
 
     [Test]


### PR DESCRIPTION
## Description

Display "enabled" / "disabled" status on configuration cards, disabling inputs when the given configuration is disabled.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
