### PR TITLE
Handle Locked Configuration Status

### DIFF
--- a/src/BaroquenMelody.App.Components/Shared/CardHeaderSwitch.razor
+++ b/src/BaroquenMelody.App.Components/Shared/CardHeaderSwitch.razor
@@ -3,18 +3,48 @@
         <MudText Typo="Typo.h6">@HeaderText</MudText>
     </CardHeaderContent>
     <CardHeaderActions>
-        <MudSwitch T="bool" Value="IsEnabled" ValueChanged="ValueChanged" Label="Enabled" Color="Color.Tertiary" />
+        <MudTooltip Delay="ThemeProvider.TooltipDelay" Duration="ThemeProvider.TooltipDuration" Text="@TooltipText" Placement="Placement.Left">
+            <MudIconButton Icon="@Icon" OnClick="CycleConfigurationStatus" Color="IconColor" Size="Size.Medium"/>
+        </MudTooltip>
     </CardHeaderActions>
 </MudCardHeader>
 
 @code
 {
-    [Parameter, EditorRequired]
-    public required string HeaderText { get; set; }
+    [Parameter, EditorRequired] public required string HeaderText { get; set; }
 
-    [Parameter, EditorRequired]
-    public required bool IsEnabled { get; set; }
+    [Parameter, EditorRequired] public required ConfigurationStatus ConfigurationStatus { get; set; } = ConfigurationStatus.Enabled;
 
-    [Parameter, EditorRequired]
-    public required EventCallback<bool> ValueChanged { get; set; }
+    [Parameter, EditorRequired] public required EventCallback<ConfigurationStatus> ValueChanged { get; set; }
+
+    private void CycleConfigurationStatus()
+    {
+        ConfigurationStatus = ConfigurationStatus.Cycle();
+        ValueChanged.InvokeAsync(ConfigurationStatus);
+    }
+
+    private string Icon => ConfigurationStatus switch
+    {
+        ConfigurationStatus.Enabled => Icons.Material.Outlined.CheckCircle,
+        ConfigurationStatus.Disabled => Icons.Material.Outlined.RemoveCircle,
+        ConfigurationStatus.Locked => Icons.Material.Outlined.Lock,
+        _ => throw new ArgumentOutOfRangeException()
+    };
+
+    private Color IconColor => ConfigurationStatus switch
+    {
+        ConfigurationStatus.Enabled => Color.Tertiary,
+        ConfigurationStatus.Disabled => Color.Default,
+        ConfigurationStatus.Locked => Color.Primary,
+        _ => throw new ArgumentOutOfRangeException()
+    };
+
+    private string TooltipText => ConfigurationStatus switch
+    {
+        ConfigurationStatus.Enabled => "lock configuration",
+        ConfigurationStatus.Disabled => "enable configuration",
+        ConfigurationStatus.Locked => "disable configuration",
+        _ => throw new ArgumentOutOfRangeException()
+    };
+
 }

--- a/src/BaroquenMelody.App.Components/Shared/CompositionRuleConfigurationCard.razor
+++ b/src/BaroquenMelody.App.Components/Shared/CompositionRuleConfigurationCard.razor
@@ -13,7 +13,7 @@
                                          ValueProvider="() => Strictness"
                                          Min="0"
                                          Max="100"
-                                         IsDisabled="IsDisabled">
+                                         IsDisabled="Status.IsFrozen()">
                     <PopoverContent>
                         <MudText>The strictness of the rule being applied to the composition.</MudText>
                     </PopoverContent>
@@ -36,7 +36,7 @@
                            Step="1"
                            ValueLabelFormat="0'%'"
                            Culture="CultureInfo.CurrentCulture"
-                           Disabled="IsDisabled"/>
+                           Disabled="Status.IsFrozen()" />
             </MudItem>
         </MudGrid>
     </MudCardContent>
@@ -49,8 +49,6 @@
     private int Strictness => CompositionRuleConfigurationState.Value[CompositionRule]?.Strictness ?? 0;
 
     private ConfigurationStatus Status => CompositionRuleConfigurationState.Value[CompositionRule]?.Status ?? ConfigurationStatus.Enabled;
-
-    private bool IsDisabled => Status is ConfigurationStatus.Disabled or ConfigurationStatus.Locked;
 
     private void HandleStrictnessChange(int value) => Dispatcher.Dispatch(new UpdateCompositionRuleConfiguration(CompositionRule, Status, value));
 

--- a/src/BaroquenMelody.App.Components/Shared/CompositionRuleConfigurationCard.razor
+++ b/src/BaroquenMelody.App.Components/Shared/CompositionRuleConfigurationCard.razor
@@ -2,7 +2,7 @@
 
 <MudCard Class="rounded mb-3 mx-3" Elevation="3" Outlined="true">
     <CardHeaderSwitch HeaderText="@(CompositionRule.ToSpaceSeparatedString())"
-                      IsEnabled="@IsEnabled"
+                      ConfigurationStatus="@Status"
                       ValueChanged="HandleIsEnabledChange"/>
     <MudCardContent>
         <MudGrid>
@@ -48,11 +48,11 @@
 
     private int Strictness => CompositionRuleConfigurationState.Value[CompositionRule]?.Strictness ?? 0;
 
-    private bool IsEnabled => CompositionRuleConfigurationState.Value[CompositionRule]?.IsEnabled ?? false;
+    private ConfigurationStatus Status => CompositionRuleConfigurationState.Value[CompositionRule]?.Status ?? ConfigurationStatus.Enabled;
 
-    private bool IsDisabled => !IsEnabled;
+    private bool IsDisabled => Status is ConfigurationStatus.Disabled or ConfigurationStatus.Locked;
 
-    private void HandleStrictnessChange(int value) => Dispatcher.Dispatch(new UpdateCompositionRuleConfiguration(CompositionRule, IsEnabled, value));
+    private void HandleStrictnessChange(int value) => Dispatcher.Dispatch(new UpdateCompositionRuleConfiguration(CompositionRule, Status, value));
 
-    private void HandleIsEnabledChange(bool value) => Dispatcher.Dispatch(new UpdateCompositionRuleConfiguration(CompositionRule, value, Strictness));
+    private void HandleIsEnabledChange(ConfigurationStatus status) => Dispatcher.Dispatch(new UpdateCompositionRuleConfiguration(CompositionRule, status, Strictness));
 }

--- a/src/BaroquenMelody.App.Components/Shared/InstrumentConfigurationCard.razor
+++ b/src/BaroquenMelody.App.Components/Shared/InstrumentConfigurationCard.razor
@@ -3,7 +3,7 @@
 
 <MudCard Class="rounded my-3 mx-3" Elevation="3" Outlined="true">
     <CardHeaderSwitch HeaderText="@($"Instrument {Instrument}")"
-                      IsEnabled="@IsEnabled"
+                      ConfigurationStatus="@Status"
                       ValueChanged="HandleIsEnabledChange"/>
     <MudCardContent>
         <MudGrid Justify="Justify.SpaceBetween">
@@ -95,9 +95,9 @@
 
     private GeneralMidi2Program MidiInstrument => InstrumentConfigurationState.Value[Instrument]?.MidiProgram ?? GeneralMidi2Program.AcousticGrandPiano;
 
-    private bool IsEnabled => InstrumentConfigurationState.Value[Instrument]?.IsEnabled ?? false;
+    private ConfigurationStatus Status => InstrumentConfigurationState.Value[Instrument]?.Status ?? ConfigurationStatus.Disabled;
 
-    private bool IsDisabled => !IsEnabled;
+    private bool IsDisabled => Status is ConfigurationStatus.Disabled or ConfigurationStatus.Locked;
 
     private const int SliderMin = 0;
 
@@ -216,7 +216,7 @@
             });
     }
 
-    private void HandleIsEnabledChange(bool isEnabled) => Dispatcher.Dispatch(new UpdateInstrumentConfiguration(Instrument, LowestPitchNote, HighestPitchNote, MidiInstrument, isEnabled, IsUserApplied: true));
+    private void HandleIsEnabledChange(ConfigurationStatus status) => Dispatcher.Dispatch(new UpdateInstrumentConfiguration(Instrument, LowestPitchNote, HighestPitchNote, MidiInstrument, status, IsUserApplied: true));
 
     private void HandleLowestPitchNoteIndexChange(int noteIndex) => Dispatcher.Dispatch(
         new UpdateInstrumentConfiguration(
@@ -224,7 +224,7 @@
             CompositionConfigurationState.Value.Notes[noteIndex],
             HighestPitchNote,
             MidiInstrument,
-            IsEnabled,
+            Status,
             IsUserApplied: true
         )
     );
@@ -235,12 +235,12 @@
             LowestPitchNote,
             CompositionConfigurationState.Value.Notes[noteIndex],
             MidiInstrument,
-            IsEnabled,
+            Status,
             IsUserApplied: true
         )
     );
 
-    private void HandleMidiInstrumentChange(GeneralMidi2Program instrument) => Dispatcher.Dispatch(new UpdateInstrumentConfiguration(Instrument, LowestPitchNote, HighestPitchNote, instrument, IsEnabled, IsUserApplied: true));
+    private void HandleMidiInstrumentChange(GeneralMidi2Program instrument) => Dispatcher.Dispatch(new UpdateInstrumentConfiguration(Instrument, LowestPitchNote, HighestPitchNote, instrument, Status, IsUserApplied: true));
 
     private void HandleInstrumentFilterChange()
     {
@@ -272,7 +272,7 @@
             LowestPitchNote,
             HighestPitchNote,
             MidiInstruments.Values.Order().First(),
-            IsEnabled,
+            Status,
             IsUserApplied: true
         ));
     }

--- a/src/BaroquenMelody.App.Components/Shared/InstrumentConfigurationCard.razor
+++ b/src/BaroquenMelody.App.Components/Shared/InstrumentConfigurationCard.razor
@@ -17,7 +17,7 @@
                                          TransformOrigin="InstrumentFilterTransformOrigin"
                                          Icon="@Icons.Material.TwoTone.FilterAlt"
                                          Label="Instrument"
-                                         IsDisabled="IsDisabled">
+                                         IsDisabled="Status.IsFrozen()">
                     <PopoverContent>
                         <MudText Align="Align.Center" Class="mt-n3" Typo="Typo.h6">Filter Instruments</MudText>
                         <MudPaper Class="d-flex flex-column overflow-x-auto mt-1 ml-n4 mr-n4 mb-n4" Outlined="true" Height="33vh">
@@ -49,7 +49,7 @@
                              MinDistance="CompositionConfiguration.MinInstrumentRange"
                              LabelText="@LowestPitchNote.ToString()"
                              UpperLabelText="@HighestPitchNote.ToString()"
-                             Disabled="IsDisabled" />
+                             Disabled="Status.IsFrozen()" />
             </MudItem>
             <MudItem xs="12" sm="4" md="3" lg="2" xl="2" xxl="2">
                 <MudSelect T="int"
@@ -59,7 +59,7 @@
                            AdornmentIcon="@Icons.Material.Outlined.ArrowCircleDown"
                            Adornment="Adornment.End"
                            AdornmentColor="Color.Secondary"
-                           Disabled="IsDisabled">
+                           Disabled="Status.IsFrozen()">
                     @foreach (var noteIndex in LowestPitchNoteIndices)
                     {
                         <MudSelectItem Value="noteIndex">@CompositionConfigurationState.Value.Notes[noteIndex]</MudSelectItem>
@@ -74,7 +74,7 @@
                            AdornmentIcon="@Icons.Material.Outlined.ArrowCircleUp"
                            Adornment="Adornment.End"
                            AdornmentColor="Color.Secondary"
-                           Disabled="IsDisabled">
+                           Disabled="Status.IsFrozen()">
                     @foreach (var noteIndex in HighestPitchNoteIndices)
                     {
                         <MudSelectItem Value="noteIndex">@CompositionConfigurationState.Value.Notes[noteIndex]</MudSelectItem>
@@ -96,8 +96,6 @@
     private GeneralMidi2Program MidiInstrument => InstrumentConfigurationState.Value[Instrument]?.MidiProgram ?? GeneralMidi2Program.AcousticGrandPiano;
 
     private ConfigurationStatus Status => InstrumentConfigurationState.Value[Instrument]?.Status ?? ConfigurationStatus.Disabled;
-
-    private bool IsDisabled => Status is ConfigurationStatus.Disabled or ConfigurationStatus.Locked;
 
     private const int SliderMin = 0;
 

--- a/src/BaroquenMelody.App.Components/Shared/OrnamentationConfigurationCard.razor
+++ b/src/BaroquenMelody.App.Components/Shared/OrnamentationConfigurationCard.razor
@@ -13,7 +13,7 @@
                                          ValueProvider="() => Probability"
                                          Min="0"
                                          Max="100"
-                                         IsDisabled="IsDisabled">
+                                         IsDisabled="Status.IsFrozen()">
                     <PopoverContent>
                         <MudText>The probability of the ornamentation being applied to the composition.</MudText>
                     </PopoverContent>
@@ -36,7 +36,7 @@
                            Step="1"
                            ValueLabelFormat="0'%'"
                            Culture="CultureInfo.CurrentCulture"
-                           Disabled="IsDisabled"/>
+                           Disabled="Status.IsFrozen()" />
             </MudItem>
         </MudGrid>
     </MudCardContent>
@@ -49,8 +49,6 @@
     private int Probability => OrnamentationConfigurationState.Value[OrnamentationType]?.Probability ?? 0;
 
     private ConfigurationStatus Status => OrnamentationConfigurationState.Value[OrnamentationType]?.Status ?? ConfigurationStatus.Enabled;
-
-    private bool IsDisabled => Status is ConfigurationStatus.Disabled or ConfigurationStatus.Locked;
 
     private void HandleProbabilityChange(int value) => Dispatcher.Dispatch(new UpdateCompositionOrnamentationConfiguration(OrnamentationType, Status, value));
 

--- a/src/BaroquenMelody.App.Components/Shared/OrnamentationConfigurationCard.razor
+++ b/src/BaroquenMelody.App.Components/Shared/OrnamentationConfigurationCard.razor
@@ -2,7 +2,7 @@
 
 <MudCard Class="rounded mb-3 mx-3" Elevation="3" Outlined="true">
     <CardHeaderSwitch HeaderText="@(OrnamentationType.ToSpaceSeparatedString())"
-                      IsEnabled="@IsEnabled"
+                      ConfigurationStatus="Status"
                       ValueChanged="HandleIsEnabledChange"/>
     <MudCardContent>
         <MudGrid>
@@ -48,11 +48,11 @@
 
     private int Probability => OrnamentationConfigurationState.Value[OrnamentationType]?.Probability ?? 0;
 
-    private bool IsEnabled => OrnamentationConfigurationState.Value[OrnamentationType]?.IsEnabled ?? false;
+    private ConfigurationStatus Status => OrnamentationConfigurationState.Value[OrnamentationType]?.Status ?? ConfigurationStatus.Enabled;
 
-    private bool IsDisabled => !IsEnabled;
+    private bool IsDisabled => Status is ConfigurationStatus.Disabled or ConfigurationStatus.Locked;
 
-    private void HandleProbabilityChange(int value) => Dispatcher.Dispatch(new UpdateCompositionOrnamentationConfiguration(OrnamentationType, IsEnabled, value));
+    private void HandleProbabilityChange(int value) => Dispatcher.Dispatch(new UpdateCompositionOrnamentationConfiguration(OrnamentationType, Status, value));
 
-    private void HandleIsEnabledChange(bool value) => Dispatcher.Dispatch(new UpdateCompositionOrnamentationConfiguration(OrnamentationType, value, Probability));
+    private void HandleIsEnabledChange(ConfigurationStatus status) => Dispatcher.Dispatch(new UpdateCompositionOrnamentationConfiguration(OrnamentationType, status, Probability));
 }

--- a/src/BaroquenMelody.App.Components/_Imports.razor
+++ b/src/BaroquenMelody.App.Components/_Imports.razor
@@ -36,6 +36,8 @@
 @using Melanchall.DryWetMidi.Standards
 @using MudBlazor
 @using MudExtensions
+@using BaroquenMelody.Library.Infrastructure.Configuration.Enums
+@using BaroquenMelody.Library.Infrastructure.Configuration.Enums.Extensions
 
 @inject IState<CompositionOrnamentationConfigurationState> OrnamentationConfigurationState
 @inject IState<CompositionRuleConfigurationState> CompositionRuleConfigurationState

--- a/src/BaroquenMelody.App/Infrastructure/Theme/MauiThemeProvider.cs
+++ b/src/BaroquenMelody.App/Infrastructure/Theme/MauiThemeProvider.cs
@@ -72,9 +72,9 @@ internal sealed class MauiThemeProvider : IThemeProvider
         false => "Switch to Dark mode"
     };
 
-    public double TooltipDelay => 250;
+    public double TooltipDelay => 333;
 
-    public double TooltipDuration => 250;
+    public double TooltipDuration => 333;
 
     public void ToggleDarkMode() => IsDarkMode = !IsDarkMode;
 }

--- a/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
+++ b/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
@@ -42,4 +42,8 @@
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Infrastructure\Configuration\Enums\Extensions\" />
+  </ItemGroup>
+
 </Project>

--- a/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
+++ b/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
@@ -42,8 +42,4 @@
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Infrastructure\Configuration\Enums\Extensions\" />
-  </ItemGroup>
-
 </Project>

--- a/src/BaroquenMelody.Library/Compositions/Configurations/AggregateOrnamentationConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/AggregateOrnamentationConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums;
 using System.Diagnostics.CodeAnalysis;
 
 namespace BaroquenMelody.Library.Compositions.Configurations;
@@ -9,25 +10,25 @@ public sealed record AggregateOrnamentationConfiguration(ISet<OrnamentationConfi
     public static AggregateOrnamentationConfiguration Default { get; } = new(
         new HashSet<OrnamentationConfiguration>
         {
-            new(OrnamentationType.PassingTone, true, 80),
-            new(OrnamentationType.DoublePassingTone, true, 80),
-            new(OrnamentationType.DelayedDoublePassingTone, true, 80),
-            new(OrnamentationType.DoubleTurn, true, 30),
-            new(OrnamentationType.DelayedPassingTone, true, 80),
-            new(OrnamentationType.DelayedNeighborTone, true, 25),
-            new(OrnamentationType.NeighborTone, true, 25),
-            new(OrnamentationType.Run, true, 80),
-            new(OrnamentationType.DoubleRun, true, 25),
-            new(OrnamentationType.Turn, true, 80),
-            new(OrnamentationType.AlternateTurn, true, 80),
-            new(OrnamentationType.DelayedRun, true, 25),
-            new(OrnamentationType.Mordent, true, 20),
-            new(OrnamentationType.DecorateInterval, true, 60),
-            new(OrnamentationType.Pedal, true, 80),
-            new(OrnamentationType.RepeatedNote, true, 15),
-            new(OrnamentationType.DelayedRepeatedNote, true, 15),
-            new(OrnamentationType.Pickup, true, 25),
-            new(OrnamentationType.DelayedPickup, true, 25)
+            new(OrnamentationType.PassingTone, ConfigurationStatus.Enabled, 80),
+            new(OrnamentationType.DoublePassingTone, ConfigurationStatus.Enabled, 80),
+            new(OrnamentationType.DelayedDoublePassingTone, ConfigurationStatus.Enabled, 80),
+            new(OrnamentationType.DoubleTurn, ConfigurationStatus.Enabled, 30),
+            new(OrnamentationType.DelayedPassingTone, ConfigurationStatus.Enabled, 80),
+            new(OrnamentationType.DelayedNeighborTone, ConfigurationStatus.Enabled, 25),
+            new(OrnamentationType.NeighborTone, ConfigurationStatus.Enabled, 25),
+            new(OrnamentationType.Run, ConfigurationStatus.Enabled, 80),
+            new(OrnamentationType.DoubleRun, ConfigurationStatus.Enabled, 25),
+            new(OrnamentationType.Turn, ConfigurationStatus.Enabled, 80),
+            new(OrnamentationType.AlternateTurn, ConfigurationStatus.Enabled, 80),
+            new(OrnamentationType.DelayedRun, ConfigurationStatus.Enabled, 25),
+            new(OrnamentationType.Mordent, ConfigurationStatus.Enabled, 20),
+            new(OrnamentationType.DecorateInterval, ConfigurationStatus.Enabled, 60),
+            new(OrnamentationType.Pedal, ConfigurationStatus.Enabled, 80),
+            new(OrnamentationType.RepeatedNote, ConfigurationStatus.Enabled, 15),
+            new(OrnamentationType.DelayedRepeatedNote, ConfigurationStatus.Enabled, 15),
+            new(OrnamentationType.Pickup, ConfigurationStatus.Enabled, 25),
+            new(OrnamentationType.DelayedPickup, ConfigurationStatus.Enabled, 25)
         }
     );
 }

--- a/src/BaroquenMelody.Library/Compositions/Configurations/CompositionRuleConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/CompositionRuleConfiguration.cs
@@ -1,4 +1,7 @@
 ﻿using BaroquenMelody.Library.Compositions.Rules.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums.Extensions;
+using System.Text.Json.Serialization;
 
 namespace BaroquenMelody.Library.Compositions.Configurations;
 
@@ -6,10 +9,13 @@ namespace BaroquenMelody.Library.Compositions.Configurations;
 ///     Represents a configuration for a composition rule.
 /// </summary>
 /// <param name="Rule">The composition rule type.</param>
-/// <param name="IsEnabled">Whether the rule is enabled.</param>
+/// <param name="Status">Whether the rule is enabled, locked, or disabled.</param>
 /// <param name="Strictness">How strictly the rule should be enforced.</param>
-public sealed record CompositionRuleConfiguration(
-    CompositionRule Rule,
-    bool IsEnabled = true,
-    int Strictness = 100
-);
+public sealed record CompositionRuleConfiguration(CompositionRule Rule, ConfigurationStatus Status = ConfigurationStatus.Enabled, int Strictness = 100)
+{
+    [JsonIgnore]
+    public bool IsEnabled { get; } = Status.IsEnabled();
+
+    [JsonIgnore]
+    public bool IsFrozen { get; } = Status.IsFrozen();
+}

--- a/src/BaroquenMelody.Library/Compositions/Configurations/InstrumentConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/InstrumentConfiguration.cs
@@ -1,4 +1,6 @@
 ﻿using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums.Extensions;
 using BaroquenMelody.Library.Infrastructure.Serialization.JsonConverters;
 using Melanchall.DryWetMidi.MusicTheory;
 using Melanchall.DryWetMidi.Standards;
@@ -13,15 +15,23 @@ namespace BaroquenMelody.Library.Compositions.Configurations;
 /// <param name="Instrument"> The instrument to be configured. </param>
 /// <param name="MinNote"> The instrument's minimum note value. </param>
 /// <param name="MaxNote"> The instrument's maximum note value. </param>
-/// <param name="IsEnabled"> Whether the instrument is enabled. </param>
+/// <param name="Status"> Whether the instrument is enabled, locked, or disabled. </param>
 /// <param name="MidiProgram"> The instrument's midi program. </param>
 public sealed record InstrumentConfiguration(
     Instrument Instrument,
-    [property: JsonConverter(typeof(NoteJsonConverter))] Note MinNote,
-    [property: JsonConverter(typeof(NoteJsonConverter))] Note MaxNote,
+    [property: JsonConverter(typeof(NoteJsonConverter))]
+    Note MinNote,
+    [property: JsonConverter(typeof(NoteJsonConverter))]
+    Note MaxNote,
     GeneralMidi2Program MidiProgram = GeneralMidi2Program.AcousticGrandPiano,
-    bool IsEnabled = true)
+    ConfigurationStatus Status = ConfigurationStatus.Enabled)
 {
+    [JsonIgnore]
+    public bool IsEnabled { get; } = Status.IsEnabled();
+
+    [JsonIgnore]
+    public bool IsFrozen { get; } = Status.IsFrozen();
+
     public bool IsNoteWithinInstrumentRange(Note note) => MinNote.NoteNumber <= note.NoteNumber && note.NoteNumber <= MaxNote.NoteNumber;
 
     public static readonly FrozenDictionary<Instrument, InstrumentConfiguration> DefaultConfigurations = new Dictionary<Instrument, InstrumentConfiguration>
@@ -29,6 +39,6 @@ public sealed record InstrumentConfiguration(
         { Instrument.One, new InstrumentConfiguration(Instrument.One, Notes.C5, Notes.E6) },
         { Instrument.Two, new InstrumentConfiguration(Instrument.Two, Notes.G3, Notes.B4) },
         { Instrument.Three, new InstrumentConfiguration(Instrument.Three, Notes.D3, Notes.F4) },
-        { Instrument.Four, new InstrumentConfiguration(Instrument.Four, Notes.C2, Notes.E3, IsEnabled: false) }
+        { Instrument.Four, new InstrumentConfiguration(Instrument.Four, Notes.C2, Notes.E3, Status: ConfigurationStatus.Disabled) }
     }.ToFrozenDictionary();
 }

--- a/src/BaroquenMelody.Library/Compositions/Configurations/OrnamentationConfiguration.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/OrnamentationConfiguration.cs
@@ -1,4 +1,7 @@
 ﻿using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums.Extensions;
+using System.Text.Json.Serialization;
 
 namespace BaroquenMelody.Library.Compositions.Configurations;
 
@@ -6,6 +9,13 @@ namespace BaroquenMelody.Library.Compositions.Configurations;
 ///    Represents a configuration for an ornamentation in a composition.
 /// </summary>
 /// <param name="OrnamentationType">The type of ornamentation.</param>
-/// <param name="IsEnabled">Whether the ornamentation is enabled.</param>
+/// <param name="Status">Whether the ornamentation is enabled, locked, or disabled.</param>
 /// <param name="Probability">The probability that the ornamentation will be applied.</param>
-public sealed record OrnamentationConfiguration(OrnamentationType OrnamentationType, bool IsEnabled, int Probability);
+public sealed record OrnamentationConfiguration(OrnamentationType OrnamentationType, ConfigurationStatus Status, int Probability)
+{
+    [JsonIgnore]
+    public bool IsEnabled { get; } = Status.IsEnabled();
+
+    [JsonIgnore]
+    public bool IsFrozen { get; } = Status.IsFrozen();
+}

--- a/src/BaroquenMelody.Library/Compositions/Configurations/Services/CompositionRuleConfigurationService.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/Services/CompositionRuleConfigurationService.cs
@@ -24,7 +24,7 @@ internal sealed class CompositionRuleConfigurationService(
     {
         foreach (var configuration in AggregateCompositionRuleConfiguration.Default.Configurations)
         {
-            dispatcher.Dispatch(new UpdateCompositionRuleConfiguration(configuration.Rule, configuration.IsEnabled, configuration.Strictness));
+            dispatcher.Dispatch(new UpdateCompositionRuleConfiguration(configuration.Rule, configuration.Status, configuration.Strictness));
         }
     }
 
@@ -32,16 +32,15 @@ internal sealed class CompositionRuleConfigurationService(
     {
         foreach (var configuration in AggregateCompositionRuleConfiguration.Default.Configurations)
         {
-            var isEnabled = state.Value.Configurations[configuration.Rule].IsEnabled;
-
-            if (!isEnabled)
+            if (state.Value.Configurations[configuration.Rule].IsFrozen)
             {
                 continue;
             }
 
+            var status = state.Value.Configurations[configuration.Rule].Status;
             var strictness = ThreadLocalRandom.Next(0, 101);
 
-            dispatcher.Dispatch(new UpdateCompositionRuleConfiguration(configuration.Rule, isEnabled, strictness));
+            dispatcher.Dispatch(new UpdateCompositionRuleConfiguration(configuration.Rule, status, strictness));
         }
     }
 }

--- a/src/BaroquenMelody.Library/Compositions/Configurations/Services/InstrumentConfigurationService.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/Services/InstrumentConfigurationService.cs
@@ -1,5 +1,6 @@
 ﻿using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Midi.Repositories;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums;
 using BaroquenMelody.Library.Infrastructure.Random;
 using BaroquenMelody.Library.Store.Actions;
 using BaroquenMelody.Library.Store.State;
@@ -30,7 +31,7 @@ internal sealed class InstrumentConfigurationService(
         ConfigureDefaults(Instrument.One);
         ConfigureDefaults(Instrument.Two);
         ConfigureDefaults(Instrument.Three);
-        ConfigureDefaults(Instrument.Four, isEnabled: false);
+        ConfigureDefaults(Instrument.Four, status: ConfigurationStatus.Disabled);
     }
 
     public void Randomize()
@@ -41,7 +42,7 @@ internal sealed class InstrumentConfigurationService(
         Randomize(Instrument.Four);
     }
 
-    private void ConfigureDefaults(Instrument instrument, bool isEnabled = true)
+    private void ConfigureDefaults(Instrument instrument, ConfigurationStatus status = ConfigurationStatus.Enabled)
     {
         var defaultConfiguration = InstrumentConfiguration.DefaultConfigurations[instrument];
 
@@ -59,7 +60,7 @@ internal sealed class InstrumentConfigurationService(
                 closestMinNote,
                 closestMaxNote,
                 defaultConfiguration.MidiProgram,
-                isEnabled,
+                status,
                 IsUserApplied: true
             )
         );
@@ -67,12 +68,12 @@ internal sealed class InstrumentConfigurationService(
 
     private void Randomize(Instrument instrument)
     {
-        var isEnabled = instrumentConfigurationState.Value.Configurations[instrument].IsEnabled;
-
-        if (!isEnabled)
+        if (instrumentConfigurationState.Value.Configurations[instrument].IsFrozen)
         {
             return;
         }
+
+        var status = instrumentConfigurationState.Value.Configurations[instrument].Status;
 
         var minNoteIndex = ThreadLocalRandom.Next(0, compositionConfigurationState.Value.Notes.Count - CompositionConfiguration.MinInstrumentRange);
         var maxNoteIndex = ThreadLocalRandom.Next(minNoteIndex + CompositionConfiguration.MinInstrumentRange, Math.Min(compositionConfigurationState.Value.Notes.Count, minNoteIndex + CompositionConfiguration.MaxInstrumentRange));
@@ -89,7 +90,7 @@ internal sealed class InstrumentConfigurationService(
                 minNote,
                 maxNote,
                 midiInstrument,
-                isEnabled,
+                status,
                 IsUserApplied: true
             )
         );

--- a/src/BaroquenMelody.Library/Compositions/Configurations/Services/OrnamentationConfigurationService.cs
+++ b/src/BaroquenMelody.Library/Compositions/Configurations/Services/OrnamentationConfigurationService.cs
@@ -24,7 +24,7 @@ internal sealed class OrnamentationConfigurationService(
     {
         foreach (var configuration in AggregateOrnamentationConfiguration.Default.Configurations)
         {
-            dispatcher.Dispatch(new UpdateCompositionOrnamentationConfiguration(configuration.OrnamentationType, configuration.IsEnabled, configuration.Probability));
+            dispatcher.Dispatch(new UpdateCompositionOrnamentationConfiguration(configuration.OrnamentationType, configuration.Status, configuration.Probability));
         }
     }
 
@@ -32,16 +32,15 @@ internal sealed class OrnamentationConfigurationService(
     {
         foreach (var configuration in AggregateOrnamentationConfiguration.Default.Configurations)
         {
-            var isEnabled = state.Value.Configurations[configuration.OrnamentationType].IsEnabled;
-
-            if (!isEnabled)
+            if (state.Value.Configurations[configuration.OrnamentationType].IsFrozen)
             {
                 continue;
             }
 
+            var status = state.Value.Configurations[configuration.OrnamentationType].Status;
             var probability = ThreadLocalRandom.Next(0, 101);
 
-            dispatcher.Dispatch(new UpdateCompositionOrnamentationConfiguration(configuration.OrnamentationType, isEnabled, probability));
+            dispatcher.Dispatch(new UpdateCompositionOrnamentationConfiguration(configuration.OrnamentationType, status, probability));
         }
     }
 }

--- a/src/BaroquenMelody.Library/Infrastructure/Configuration/Enums/ConfigurationStatus.cs
+++ b/src/BaroquenMelody.Library/Infrastructure/Configuration/Enums/ConfigurationStatus.cs
@@ -1,0 +1,19 @@
+﻿namespace BaroquenMelody.Library.Infrastructure.Configuration.Enums;
+
+public enum ConfigurationStatus : byte
+{
+    /// <summary>
+    ///     The configuration is enabled.
+    /// </summary>
+    Enabled,
+
+    /// <summary>
+    ///     The configuration is locked.
+    /// </summary>
+    Locked,
+
+    /// <summary>
+    ///     The configuration is disabled.
+    /// </summary>
+    Disabled
+}

--- a/src/BaroquenMelody.Library/Infrastructure/Configuration/Enums/Extensions/ConfigurationStatusExtensions.cs
+++ b/src/BaroquenMelody.Library/Infrastructure/Configuration/Enums/Extensions/ConfigurationStatusExtensions.cs
@@ -1,0 +1,32 @@
+﻿namespace BaroquenMelody.Library.Infrastructure.Configuration.Enums.Extensions;
+
+public static class ConfigurationStatusExtensions
+{
+    /// <summary>
+    ///     Cycle the configuration status.
+    /// </summary>
+    /// <param name="status">The source configuration status.</param>
+    /// <returns>The next configuration status.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the source configuration status is not a valid value.</exception>
+    public static ConfigurationStatus Cycle(this ConfigurationStatus status) => status switch
+    {
+        ConfigurationStatus.Enabled => ConfigurationStatus.Locked,
+        ConfigurationStatus.Locked => ConfigurationStatus.Disabled,
+        ConfigurationStatus.Disabled => ConfigurationStatus.Enabled,
+        _ => throw new ArgumentOutOfRangeException(nameof(status), status, null)
+    };
+
+    /// <summary>
+    ///     Whether the configuration is enabled (enabled or locked).
+    /// </summary>
+    /// <param name="status">The source configuration status.</param>
+    /// <returns>Whether the configuration is enabled.</returns>
+    public static bool IsEnabled(this ConfigurationStatus status) => status is ConfigurationStatus.Enabled or ConfigurationStatus.Locked;
+
+    /// <summary>
+    ///     Whether the configuration is frozen (locked or disabled).
+    /// </summary>
+    /// <param name="status">The source configuration status.</param>
+    /// <returns>Whether the configuration is frozen.</returns>
+    public static bool IsFrozen(this ConfigurationStatus status) => status is ConfigurationStatus.Locked or ConfigurationStatus.Disabled;
+}

--- a/src/BaroquenMelody.Library/Store/Actions/UpdateCompositionOrnamentationConfiguration.cs
+++ b/src/BaroquenMelody.Library/Store/Actions/UpdateCompositionOrnamentationConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums;
 
 namespace BaroquenMelody.Library.Store.Actions;
 
-public sealed record UpdateCompositionOrnamentationConfiguration(OrnamentationType OrnamentationType, bool IsEnabled, int Probability);
+public sealed record UpdateCompositionOrnamentationConfiguration(OrnamentationType OrnamentationType, ConfigurationStatus Status, int Probability);

--- a/src/BaroquenMelody.Library/Store/Actions/UpdateCompositionRuleConfiguration.cs
+++ b/src/BaroquenMelody.Library/Store/Actions/UpdateCompositionRuleConfiguration.cs
@@ -1,5 +1,10 @@
 ﻿using BaroquenMelody.Library.Compositions.Rules.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums;
 
 namespace BaroquenMelody.Library.Store.Actions;
 
-public sealed record UpdateCompositionRuleConfiguration(CompositionRule CompositionRule, bool IsEnabled, int Strictness);
+public sealed record UpdateCompositionRuleConfiguration(
+    CompositionRule CompositionRule,
+    ConfigurationStatus Status,
+    int Strictness
+);

--- a/src/BaroquenMelody.Library/Store/Actions/UpdateInstrumentConfiguration.cs
+++ b/src/BaroquenMelody.Library/Store/Actions/UpdateInstrumentConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums;
 using Melanchall.DryWetMidi.MusicTheory;
 using Melanchall.DryWetMidi.Standards;
 
@@ -9,6 +10,6 @@ public sealed record UpdateInstrumentConfiguration(
     Note MinNote,
     Note MaxNote,
     GeneralMidi2Program MidiProgram,
-    bool IsEnabled,
+    ConfigurationStatus Status,
     bool IsUserApplied
 );

--- a/src/BaroquenMelody.Library/Store/Effects/CompositionConfigurationEffects.cs
+++ b/src/BaroquenMelody.Library/Store/Effects/CompositionConfigurationEffects.cs
@@ -28,7 +28,7 @@ public sealed class CompositionConfigurationEffects(IState<InstrumentConfigurati
                     closestMinNote,
                     closestMaxNote,
                     instrumentConfiguration.MidiProgram,
-                    instrumentConfiguration.IsEnabled,
+                    instrumentConfiguration.Status,
                     IsUserApplied: false
                 )
             );
@@ -51,7 +51,7 @@ public sealed class CompositionConfigurationEffects(IState<InstrumentConfigurati
                 instrumentConfiguration.MinNote,
                 instrumentConfiguration.MaxNote,
                 instrumentConfiguration.MidiProgram,
-                instrumentConfiguration.IsEnabled,
+                instrumentConfiguration.Status,
                 IsUserApplied: true
             ));
         }
@@ -60,7 +60,7 @@ public sealed class CompositionConfigurationEffects(IState<InstrumentConfigurati
         {
             dispatcher.Dispatch(new UpdateCompositionRuleConfiguration(
                 compositionRule.Rule,
-                compositionRule.IsEnabled,
+                compositionRule.Status,
                 compositionRule.Strictness
             ));
         }
@@ -69,7 +69,7 @@ public sealed class CompositionConfigurationEffects(IState<InstrumentConfigurati
         {
             dispatcher.Dispatch(new UpdateCompositionOrnamentationConfiguration(
                 ornamentation.OrnamentationType,
-                ornamentation.IsEnabled,
+                ornamentation.Status,
                 ornamentation.Probability
             ));
         }

--- a/src/BaroquenMelody.Library/Store/Reducers/CompositionOrnamentationConfigurationReducers.cs
+++ b/src/BaroquenMelody.Library/Store/Reducers/CompositionOrnamentationConfigurationReducers.cs
@@ -15,7 +15,7 @@ public static class CompositionOrnamentationConfigurationReducers
     {
         var configurations = new Dictionary<OrnamentationType, OrnamentationConfiguration>(state.Configurations)
         {
-            [action.OrnamentationType] = new(action.OrnamentationType, action.IsEnabled, action.Probability)
+            [action.OrnamentationType] = new(action.OrnamentationType, action.Status, action.Probability)
         };
 
         return new CompositionOrnamentationConfigurationState(configurations);

--- a/src/BaroquenMelody.Library/Store/Reducers/CompositionRuleConfigurationReducers.cs
+++ b/src/BaroquenMelody.Library/Store/Reducers/CompositionRuleConfigurationReducers.cs
@@ -13,7 +13,7 @@ public static class CompositionRuleConfigurationReducers
     {
         var configurations = new Dictionary<CompositionRule, CompositionRuleConfiguration>(state.Configurations)
         {
-            [action.CompositionRule] = new(action.CompositionRule, action.IsEnabled, action.Strictness)
+            [action.CompositionRule] = new(action.CompositionRule, action.Status, action.Strictness)
         };
 
         return new CompositionRuleConfigurationState(configurations);

--- a/src/BaroquenMelody.Library/Store/Reducers/InstrumentConfigurationReducers.cs
+++ b/src/BaroquenMelody.Library/Store/Reducers/InstrumentConfigurationReducers.cs
@@ -13,7 +13,7 @@ public static class InstrumentConfigurationReducers
     {
         var configurations = new Dictionary<Instrument, InstrumentConfiguration>(state.Configurations)
         {
-            [action.Instrument] = new(action.Instrument, action.MinNote, action.MaxNote, action.MidiProgram, action.IsEnabled)
+            [action.Instrument] = new(action.Instrument, action.MinNote, action.MaxNote, action.MidiProgram, action.Status)
         };
 
         if (!action.IsUserApplied)
@@ -23,7 +23,7 @@ public static class InstrumentConfigurationReducers
 
         var lastUserAppliedConfigurations = new Dictionary<Instrument, InstrumentConfiguration>(state.LastUserAppliedConfigurations)
         {
-            [action.Instrument] = new(action.Instrument, action.MinNote, action.MaxNote, action.MidiProgram, action.IsEnabled)
+            [action.Instrument] = new(action.Instrument, action.MinNote, action.MaxNote, action.MidiProgram, action.Status)
         };
 
         return new InstrumentConfigurationState(configurations, lastUserAppliedConfigurations);

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/Services/CompositionRuleConfigurationServiceTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/Services/CompositionRuleConfigurationServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Configurations.Services;
 using BaroquenMelody.Library.Compositions.Rules.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums;
 using BaroquenMelody.Library.Store.Actions;
 using BaroquenMelody.Library.Store.State;
 using FluentAssertions;
@@ -85,8 +86,8 @@ internal sealed class CompositionRuleConfigurationServiceTests
             { CompositionRule.AvoidParallelOctaves, new CompositionRuleConfiguration(CompositionRule.AvoidParallelOctaves) },
             { CompositionRule.AvoidRepetition, new CompositionRuleConfiguration(CompositionRule.AvoidRepetition) },
             { CompositionRule.FollowStandardChordProgression, new CompositionRuleConfiguration(CompositionRule.FollowStandardChordProgression) },
-            { CompositionRule.HandleAscendingSeventh, new CompositionRuleConfiguration(CompositionRule.HandleAscendingSeventh) },
-            { CompositionRule.AvoidRepeatedChords, new CompositionRuleConfiguration(CompositionRule.AvoidRepeatedChords, IsEnabled: false) }
+            { CompositionRule.HandleAscendingSeventh, new CompositionRuleConfiguration(CompositionRule.HandleAscendingSeventh, Status: ConfigurationStatus.Locked) },
+            { CompositionRule.AvoidRepeatedChords, new CompositionRuleConfiguration(CompositionRule.AvoidRepeatedChords, Status: ConfigurationStatus.Disabled) }
         };
 
         _mockState.Value.Returns(new CompositionRuleConfigurationState(configurations));
@@ -96,7 +97,7 @@ internal sealed class CompositionRuleConfigurationServiceTests
 
         // assert
         _mockDispatcher
-            .Received(configurations.Count - 1)
+            .Received(configurations.Count - 2)
             .Dispatch(Arg.Any<UpdateCompositionRuleConfiguration>());
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/Services/InstrumentConfigurationServiceTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/Services/InstrumentConfigurationServiceTests.cs
@@ -1,8 +1,10 @@
 ﻿using Atrea.Utilities.Enums;
+using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Configurations.Services;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.Midi.Repositories;
 using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums;
 using BaroquenMelody.Library.Store.Actions;
 using BaroquenMelody.Library.Store.State;
 using FluentAssertions;
@@ -36,7 +38,6 @@ internal sealed class InstrumentConfigurationServiceTests
         _mockMidiInstrumentRepository = Substitute.For<IMidiInstrumentRepository>();
 
         _mockMidiInstrumentRepository.GetAllMidiInstruments().Returns(EnumUtils<GeneralMidi2Program>.AsEnumerable());
-        _mockInstrumentConfigurationState.Value.Returns(new InstrumentConfigurationState());
         _mockCompositionConfigurationState.Value.Returns(new CompositionConfigurationState(NoteName.C, Mode.Ionian, Meter.FourFour));
 
         _instrumentConfigurationService = new InstrumentConfigurationService(
@@ -73,10 +74,55 @@ internal sealed class InstrumentConfigurationServiceTests
     [Test]
     public void Randomize_dispatches_expected_actions()
     {
+        // arrange
+        var configurations = new Dictionary<Instrument, InstrumentConfiguration>
+        {
+            {
+                Instrument.One,
+                new InstrumentConfiguration(
+                    Instrument.One,
+                    Notes.C4,
+                    Notes.C5,
+                    GeneralMidi2Program.Accordion
+                )
+            },
+            {
+                Instrument.Two,
+                new InstrumentConfiguration(
+                    Instrument.Two,
+                    Notes.C5,
+                    Notes.C6,
+                    GeneralMidi2Program.Banjo
+                )
+            },
+            {
+                Instrument.Three,
+                new InstrumentConfiguration(
+                    Instrument.Three,
+                    Notes.C6,
+                    Notes.C7,
+                    GeneralMidi2Program.Celesta,
+                    ConfigurationStatus.Locked
+                )
+            },
+            {
+                Instrument.Four,
+                new InstrumentConfiguration(
+                    Instrument.Four,
+                    Notes.C7,
+                    Notes.C8,
+                    GeneralMidi2Program.Celesta,
+                    ConfigurationStatus.Disabled
+                )
+            }
+        };
+
+        _mockInstrumentConfigurationState.Value.Returns(new InstrumentConfigurationState(configurations, configurations));
+
         // act
         _instrumentConfigurationService.Randomize();
 
         // assert
-        _mockDispatcher.Received(3).Dispatch(Arg.Any<UpdateInstrumentConfiguration>());
+        _mockDispatcher.Received(configurations.Count - 2).Dispatch(Arg.Any<UpdateInstrumentConfiguration>());
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/Services/OrnamentationConfigurationServiceTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Configuration/Services/OrnamentationConfigurationServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Configurations.Services;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums;
 using BaroquenMelody.Library.Store.Actions;
 using BaroquenMelody.Library.Store.State;
 using FluentAssertions;
@@ -80,25 +81,25 @@ internal sealed class OrnamentationConfigurationServiceTests
         // arrange
         var configurations = new Dictionary<OrnamentationType, OrnamentationConfiguration>
         {
-            { OrnamentationType.PassingTone, new OrnamentationConfiguration(OrnamentationType.PassingTone, true, 100) },
-            { OrnamentationType.DoublePassingTone, new OrnamentationConfiguration(OrnamentationType.DoublePassingTone, true, 100) },
-            { OrnamentationType.DelayedDoublePassingTone, new OrnamentationConfiguration(OrnamentationType.DelayedDoublePassingTone, true, 100) },
-            { OrnamentationType.DoubleTurn, new OrnamentationConfiguration(OrnamentationType.DoubleTurn, true, 100) },
-            { OrnamentationType.DelayedPassingTone, new OrnamentationConfiguration(OrnamentationType.DelayedPassingTone, true, 100) },
-            { OrnamentationType.DelayedNeighborTone, new OrnamentationConfiguration(OrnamentationType.DelayedNeighborTone, true, 100) },
-            { OrnamentationType.NeighborTone, new OrnamentationConfiguration(OrnamentationType.NeighborTone, true, 100) },
-            { OrnamentationType.Run, new OrnamentationConfiguration(OrnamentationType.Run, true, 100) },
-            { OrnamentationType.DoubleRun, new OrnamentationConfiguration(OrnamentationType.DoubleRun, true, 100) },
-            { OrnamentationType.Turn, new OrnamentationConfiguration(OrnamentationType.Turn, true, 100) },
-            { OrnamentationType.AlternateTurn, new OrnamentationConfiguration(OrnamentationType.AlternateTurn, true, 100) },
-            { OrnamentationType.DelayedRun, new OrnamentationConfiguration(OrnamentationType.DelayedRun, true, 100) },
-            { OrnamentationType.Mordent, new OrnamentationConfiguration(OrnamentationType.Mordent, true, 100) },
-            { OrnamentationType.DecorateInterval, new OrnamentationConfiguration(OrnamentationType.DecorateInterval, true, 100) },
-            { OrnamentationType.Pedal, new OrnamentationConfiguration(OrnamentationType.Pedal, true, 100) },
-            { OrnamentationType.RepeatedNote, new OrnamentationConfiguration(OrnamentationType.RepeatedNote, false, 100) },
-            { OrnamentationType.DelayedRepeatedNote, new OrnamentationConfiguration(OrnamentationType.DelayedRepeatedNote, true, 100) },
-            { OrnamentationType.Pickup, new OrnamentationConfiguration(OrnamentationType.Pickup, true, 100) },
-            { OrnamentationType.DelayedPickup, new OrnamentationConfiguration(OrnamentationType.DelayedPickup, true, 100) }
+            { OrnamentationType.PassingTone, new OrnamentationConfiguration(OrnamentationType.PassingTone, ConfigurationStatus.Enabled, 100) },
+            { OrnamentationType.DoublePassingTone, new OrnamentationConfiguration(OrnamentationType.DoublePassingTone, ConfigurationStatus.Enabled, 100) },
+            { OrnamentationType.DelayedDoublePassingTone, new OrnamentationConfiguration(OrnamentationType.DelayedDoublePassingTone, ConfigurationStatus.Enabled, 100) },
+            { OrnamentationType.DoubleTurn, new OrnamentationConfiguration(OrnamentationType.DoubleTurn, ConfigurationStatus.Enabled, 100) },
+            { OrnamentationType.DelayedPassingTone, new OrnamentationConfiguration(OrnamentationType.DelayedPassingTone, ConfigurationStatus.Enabled, 100) },
+            { OrnamentationType.DelayedNeighborTone, new OrnamentationConfiguration(OrnamentationType.DelayedNeighborTone, ConfigurationStatus.Enabled, 100) },
+            { OrnamentationType.NeighborTone, new OrnamentationConfiguration(OrnamentationType.NeighborTone, ConfigurationStatus.Enabled, 100) },
+            { OrnamentationType.Run, new OrnamentationConfiguration(OrnamentationType.Run, ConfigurationStatus.Enabled, 100) },
+            { OrnamentationType.DoubleRun, new OrnamentationConfiguration(OrnamentationType.DoubleRun, ConfigurationStatus.Enabled, 100) },
+            { OrnamentationType.Turn, new OrnamentationConfiguration(OrnamentationType.Turn, ConfigurationStatus.Enabled, 100) },
+            { OrnamentationType.AlternateTurn, new OrnamentationConfiguration(OrnamentationType.AlternateTurn, ConfigurationStatus.Enabled, 100) },
+            { OrnamentationType.DelayedRun, new OrnamentationConfiguration(OrnamentationType.DelayedRun, ConfigurationStatus.Enabled, 100) },
+            { OrnamentationType.Mordent, new OrnamentationConfiguration(OrnamentationType.Mordent, ConfigurationStatus.Enabled, 100) },
+            { OrnamentationType.DecorateInterval, new OrnamentationConfiguration(OrnamentationType.DecorateInterval, ConfigurationStatus.Enabled, 100) },
+            { OrnamentationType.Pedal, new OrnamentationConfiguration(OrnamentationType.Pedal, ConfigurationStatus.Enabled, 100) },
+            { OrnamentationType.RepeatedNote, new OrnamentationConfiguration(OrnamentationType.RepeatedNote, ConfigurationStatus.Disabled, 100) },
+            { OrnamentationType.DelayedRepeatedNote, new OrnamentationConfiguration(OrnamentationType.DelayedRepeatedNote, ConfigurationStatus.Locked, 100) },
+            { OrnamentationType.Pickup, new OrnamentationConfiguration(OrnamentationType.Pickup, ConfigurationStatus.Enabled, 100) },
+            { OrnamentationType.DelayedPickup, new OrnamentationConfiguration(OrnamentationType.DelayedPickup, ConfigurationStatus.Enabled, 100) }
         };
 
         _mockState.Value.Returns(new CompositionOrnamentationConfigurationState(configurations));
@@ -108,7 +109,7 @@ internal sealed class OrnamentationConfigurationServiceTests
 
         // assert
         _mockDispatcher
-            .Received(configurations.Count - 1)
+            .Received(configurations.Count - 2)
             .Dispatch(Arg.Any<UpdateCompositionOrnamentationConfiguration>());
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Compositions/Rules/CompositionRuleFactoryTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Compositions/Rules/CompositionRuleFactoryTests.cs
@@ -2,6 +2,7 @@
 using BaroquenMelody.Library.Compositions.MusicTheory;
 using BaroquenMelody.Library.Compositions.Rules;
 using BaroquenMelody.Library.Compositions.Rules.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums;
 using BaroquenMelody.Library.Infrastructure.Random;
 using BaroquenMelody.Library.Tests.TestData;
 using FluentAssertions;
@@ -45,7 +46,7 @@ internal sealed class CompositionRuleFactoryTests
     public void Create_returns_expected_rule(CompositionRule rule, int strictness, Type expectedRuleType)
     {
         // arrange
-        var configuration = new CompositionRuleConfiguration(rule, true, strictness);
+        var configuration = new CompositionRuleConfiguration(rule, ConfigurationStatus.Enabled, strictness);
 
         // act
         var result = _factory.Create(configuration);

--- a/tests/BaroquenMelody.Library.Tests/Infrastructure/Configurations/Enums/Extensions/ConfigurationStatusExtensionsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Infrastructure/Configurations/Enums/Extensions/ConfigurationStatusExtensionsTests.cs
@@ -1,0 +1,49 @@
+﻿using BaroquenMelody.Library.Infrastructure.Configuration.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums.Extensions;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Infrastructure.Configurations.Enums.Extensions;
+
+[TestFixture]
+internal sealed class ConfigurationStatusExtensionsTests
+{
+    [Test]
+    [TestCase(ConfigurationStatus.Enabled, ConfigurationStatus.Locked)]
+    [TestCase(ConfigurationStatus.Locked, ConfigurationStatus.Disabled)]
+    [TestCase(ConfigurationStatus.Disabled, ConfigurationStatus.Enabled)]
+    public void Cycle_returns_the_next_value(ConfigurationStatus status, ConfigurationStatus expectedNextStatus)
+    {
+        // act
+        var nextStatus = status.Cycle();
+
+        // assert
+        nextStatus.Should().Be(expectedNextStatus);
+    }
+
+    [Test]
+    [TestCase(ConfigurationStatus.Enabled, true)]
+    [TestCase(ConfigurationStatus.Locked, true)]
+    [TestCase(ConfigurationStatus.Disabled, false)]
+    public void IsEnabled_returns_whether_the_configuration_is_enabled(ConfigurationStatus status, bool expectedIsEnabled)
+    {
+        // act
+        var isEnabled = status.IsEnabled();
+
+        // assert
+        isEnabled.Should().Be(expectedIsEnabled);
+    }
+
+    [Test]
+    [TestCase(ConfigurationStatus.Enabled, false)]
+    [TestCase(ConfigurationStatus.Locked, true)]
+    [TestCase(ConfigurationStatus.Disabled, true)]
+    public void IsFrozen_returns_whether_the_configuration_is_frozen(ConfigurationStatus status, bool expectedIsFrozen)
+    {
+        // act
+        var isFrozen = status.IsFrozen();
+
+        // assert
+        isFrozen.Should().Be(expectedIsFrozen);
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Infrastructure/Configurations/Enums/Extensions/ConfigurationStatusExtensionsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Infrastructure/Configurations/Enums/Extensions/ConfigurationStatusExtensionsTests.cs
@@ -22,6 +22,16 @@ internal sealed class ConfigurationStatusExtensionsTests
     }
 
     [Test]
+    public void Cycle_throws_when_the_source_configuration_status_is_not_a_valid_value()
+    {
+        // act
+        var act = () => ((ConfigurationStatus)byte.MaxValue).Cycle();
+
+        // assert
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
     [TestCase(ConfigurationStatus.Enabled, true)]
     [TestCase(ConfigurationStatus.Locked, true)]
     [TestCase(ConfigurationStatus.Disabled, false)]

--- a/tests/BaroquenMelody.Library.Tests/Infrastructure/FileSystem/CompositionConfigurationPersistenceServiceTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Infrastructure/FileSystem/CompositionConfigurationPersistenceServiceTests.cs
@@ -7,6 +7,7 @@ using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
+using TestDataConfigurations = BaroquenMelody.Library.Tests.TestData.Configurations;
 
 namespace BaroquenMelody.Library.Tests.Infrastructure.FileSystem;
 
@@ -60,7 +61,7 @@ internal sealed class CompositionConfigurationPersistenceServiceTests
             );
 
         var result = await _persistenceService.SaveConfigurationAsync(
-            Configurations.GetCompositionConfiguration(),
+            TestDataConfigurations.GetCompositionConfiguration(),
             "test",
             CancellationToken.None
         );
@@ -77,7 +78,7 @@ internal sealed class CompositionConfigurationPersistenceServiceTests
 
         // act
         var result = await _persistenceService.SaveConfigurationAsync(
-            Configurations.GetCompositionConfiguration(),
+            TestDataConfigurations.GetCompositionConfiguration(),
             "test",
             CancellationToken.None
         );

--- a/tests/BaroquenMelody.Library.Tests/Infrastructure/Serialization/CompositionConfigurationSerializationTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Infrastructure/Serialization/CompositionConfigurationSerializationTests.cs
@@ -1,6 +1,7 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums;
 using BaroquenMelody.Library.Infrastructure.Serialization.JsonSerializerContexts;
 using FluentAssertions;
 using Melanchall.DryWetMidi.Interaction;
@@ -21,7 +22,7 @@ internal sealed class CompositionConfigurationSerializationTests
         var compositionConfiguration = new CompositionConfiguration(
             new HashSet<InstrumentConfiguration>
             {
-                new(Instrument.One, Notes.C4, Notes.G5, GeneralMidi2Program.Accordion, false),
+                new(Instrument.One, Notes.C4, Notes.G5, GeneralMidi2Program.Accordion, ConfigurationStatus.Disabled),
                 new(Instrument.Two, Notes.C3, Notes.G4),
                 new(Instrument.Three, Notes.C2, Notes.G3),
                 new(Instrument.Four, Notes.C1, Notes.G2)

--- a/tests/BaroquenMelody.Library.Tests/Store/Effects/CompositionConfigurationEffectsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Effects/CompositionConfigurationEffectsTests.cs
@@ -1,6 +1,7 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Enums;
 using BaroquenMelody.Library.Compositions.MusicTheory.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums;
 using BaroquenMelody.Library.Store.Actions;
 using BaroquenMelody.Library.Store.Effects;
 using BaroquenMelody.Library.Store.State;
@@ -90,7 +91,7 @@ internal sealed class CompositionConfigurationEffectsTests
                 updateInstrumentConfiguration => updateInstrumentConfiguration.Instrument == Instrument.One &&
                                                  updateInstrumentConfiguration.MinNote == Notes.B3 &&
                                                  updateInstrumentConfiguration.MaxNote == Notes.B4 &&
-                                                 updateInstrumentConfiguration.IsEnabled == true &&
+                                                 updateInstrumentConfiguration.Status == ConfigurationStatus.Enabled &&
                                                  updateInstrumentConfiguration.IsUserApplied == false
             )
         );
@@ -122,7 +123,7 @@ internal sealed class CompositionConfigurationEffectsTests
                                                      updateInstrumentConfiguration.MinNote == instrumentConfiguration.MinNote &&
                                                      updateInstrumentConfiguration.MaxNote == instrumentConfiguration.MaxNote &&
                                                      updateInstrumentConfiguration.MidiProgram == instrumentConfiguration.MidiProgram &&
-                                                     updateInstrumentConfiguration.IsEnabled == instrumentConfiguration.IsEnabled &&
+                                                     updateInstrumentConfiguration.Status == instrumentConfiguration.Status &&
                                                      updateInstrumentConfiguration.IsUserApplied == true
                 )
             );
@@ -133,7 +134,7 @@ internal sealed class CompositionConfigurationEffectsTests
             _mockDispatcher.Received().Dispatch(
                 Arg.Is<UpdateCompositionRuleConfiguration>(
                     updateCompositionRuleConfiguration => updateCompositionRuleConfiguration.CompositionRule == compositionRule.Rule &&
-                                                          updateCompositionRuleConfiguration.IsEnabled == compositionRule.IsEnabled &&
+                                                          updateCompositionRuleConfiguration.Status == compositionRule.Status &&
                                                           updateCompositionRuleConfiguration.Strictness == compositionRule.Strictness
                 )
             );
@@ -144,7 +145,7 @@ internal sealed class CompositionConfigurationEffectsTests
             _mockDispatcher.Received().Dispatch(
                 Arg.Is<UpdateCompositionOrnamentationConfiguration>(
                     updateCompositionOrnamentationConfiguration => updateCompositionOrnamentationConfiguration.OrnamentationType == ornamentation.OrnamentationType &&
-                                                                   updateCompositionOrnamentationConfiguration.IsEnabled == ornamentation.IsEnabled &&
+                                                                   updateCompositionOrnamentationConfiguration.Status == ornamentation.Status &&
                                                                    updateCompositionOrnamentationConfiguration.Probability == ornamentation.Probability
                 )
             );

--- a/tests/BaroquenMelody.Library.Tests/Store/Reducers/CompositionOrnamentationConfigurationReducersTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Reducers/CompositionOrnamentationConfigurationReducersTests.cs
@@ -1,5 +1,6 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Ornamentation.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums;
 using BaroquenMelody.Library.Store.Actions;
 using BaroquenMelody.Library.Store.Reducers;
 using BaroquenMelody.Library.Store.State;
@@ -20,22 +21,22 @@ internal sealed class CompositionOrnamentationConfigurationReducersTests
         // act
         state = CompositionOrnamentationConfigurationReducers.ReduceUpdateCompositionOrnamentationConfiguration(
             state,
-            new UpdateCompositionOrnamentationConfiguration(OrnamentationType.Run, true, 1)
+            new UpdateCompositionOrnamentationConfiguration(OrnamentationType.Run, ConfigurationStatus.Enabled, 1)
         );
 
         state = CompositionOrnamentationConfigurationReducers.ReduceUpdateCompositionOrnamentationConfiguration(
             state,
-            new UpdateCompositionOrnamentationConfiguration(OrnamentationType.Mordent, true, 2)
+            new UpdateCompositionOrnamentationConfiguration(OrnamentationType.Mordent, ConfigurationStatus.Enabled, 2)
         );
 
         state = CompositionOrnamentationConfigurationReducers.ReduceUpdateCompositionOrnamentationConfiguration(
             state,
-            new UpdateCompositionOrnamentationConfiguration(OrnamentationType.Turn, true, 3)
+            new UpdateCompositionOrnamentationConfiguration(OrnamentationType.Turn, ConfigurationStatus.Enabled, 3)
         );
 
         state = CompositionOrnamentationConfigurationReducers.ReduceUpdateCompositionOrnamentationConfiguration(
             state,
-            new UpdateCompositionOrnamentationConfiguration(OrnamentationType.Mordent, true, 4)
+            new UpdateCompositionOrnamentationConfiguration(OrnamentationType.Mordent, ConfigurationStatus.Enabled, 4)
         );
 
         // assert

--- a/tests/BaroquenMelody.Library.Tests/Store/Reducers/CompositionRuleConfigurationReducersTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Reducers/CompositionRuleConfigurationReducersTests.cs
@@ -1,5 +1,6 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Rules.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums;
 using BaroquenMelody.Library.Store.Actions;
 using BaroquenMelody.Library.Store.Reducers;
 using BaroquenMelody.Library.Store.State;
@@ -18,10 +19,10 @@ internal sealed class CompositionRuleConfigurationReducersTests
         var state = new CompositionRuleConfigurationState();
 
         // act
-        state = CompositionRuleConfigurationReducers.ReduceUpdateCompositionRuleConfiguration(state, new UpdateCompositionRuleConfiguration(CompositionRule.AvoidDirectFifths, true, 1));
-        state = CompositionRuleConfigurationReducers.ReduceUpdateCompositionRuleConfiguration(state, new UpdateCompositionRuleConfiguration(CompositionRule.AvoidDissonance, true, 2));
-        state = CompositionRuleConfigurationReducers.ReduceUpdateCompositionRuleConfiguration(state, new UpdateCompositionRuleConfiguration(CompositionRule.AvoidRepeatedChords, true, 3));
-        state = CompositionRuleConfigurationReducers.ReduceUpdateCompositionRuleConfiguration(state, new UpdateCompositionRuleConfiguration(CompositionRule.AvoidDirectFifths, false, 4));
+        state = CompositionRuleConfigurationReducers.ReduceUpdateCompositionRuleConfiguration(state, new UpdateCompositionRuleConfiguration(CompositionRule.AvoidDirectFifths, ConfigurationStatus.Enabled, 1));
+        state = CompositionRuleConfigurationReducers.ReduceUpdateCompositionRuleConfiguration(state, new UpdateCompositionRuleConfiguration(CompositionRule.AvoidDissonance, ConfigurationStatus.Enabled, 2));
+        state = CompositionRuleConfigurationReducers.ReduceUpdateCompositionRuleConfiguration(state, new UpdateCompositionRuleConfiguration(CompositionRule.AvoidRepeatedChords, ConfigurationStatus.Enabled, 3));
+        state = CompositionRuleConfigurationReducers.ReduceUpdateCompositionRuleConfiguration(state, new UpdateCompositionRuleConfiguration(CompositionRule.AvoidDirectFifths, ConfigurationStatus.Disabled, 4));
 
         // assert
         state.Configurations

--- a/tests/BaroquenMelody.Library.Tests/Store/Reducers/InstrumentConfigurationReducersTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Reducers/InstrumentConfigurationReducersTests.cs
@@ -1,5 +1,6 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums;
 using BaroquenMelody.Library.Store.Actions;
 using BaroquenMelody.Library.Store.Reducers;
 using BaroquenMelody.Library.Store.State;
@@ -22,22 +23,22 @@ internal sealed class InstrumentConfigurationReducersTests
         // act
         state = InstrumentConfigurationReducers.ReduceUpdateInstrumentConfiguration(
             state,
-            new UpdateInstrumentConfiguration(Instrument.One, Notes.C4, Notes.C5, GeneralMidi2Program.Accordion, IsEnabled: true, IsUserApplied: true)
+            new UpdateInstrumentConfiguration(Instrument.One, Notes.C4, Notes.C5, GeneralMidi2Program.Accordion, Status: ConfigurationStatus.Enabled, IsUserApplied: true)
         );
 
         state = InstrumentConfigurationReducers.ReduceUpdateInstrumentConfiguration(
             state,
-            new UpdateInstrumentConfiguration(Instrument.Two, Notes.C5, Notes.C6, GeneralMidi2Program.Banjo, IsEnabled: true, IsUserApplied: true)
+            new UpdateInstrumentConfiguration(Instrument.Two, Notes.C5, Notes.C6, GeneralMidi2Program.Banjo, Status: ConfigurationStatus.Enabled, IsUserApplied: true)
         );
 
         state = InstrumentConfigurationReducers.ReduceUpdateInstrumentConfiguration(
             state,
-            new UpdateInstrumentConfiguration(Instrument.Three, Notes.C6, Notes.C7, GeneralMidi2Program.Celesta, IsEnabled: true, IsUserApplied: true)
+            new UpdateInstrumentConfiguration(Instrument.Three, Notes.C6, Notes.C7, GeneralMidi2Program.Celesta, Status: ConfigurationStatus.Enabled, IsUserApplied: true)
         );
 
         state = InstrumentConfigurationReducers.ReduceUpdateInstrumentConfiguration(
             state,
-            new UpdateInstrumentConfiguration(Instrument.One, Notes.C7, Notes.C8, GeneralMidi2Program.Dulcimer, IsEnabled: false, IsUserApplied: false)
+            new UpdateInstrumentConfiguration(Instrument.One, Notes.C7, Notes.C8, GeneralMidi2Program.Dulcimer, Status: ConfigurationStatus.Disabled, IsUserApplied: false)
         );
 
         // assert

--- a/tests/BaroquenMelody.Library.Tests/Store/State/InstrumentConfigurationStateTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/State/InstrumentConfigurationStateTests.cs
@@ -1,5 +1,6 @@
 ﻿using BaroquenMelody.Library.Compositions.Configurations;
 using BaroquenMelody.Library.Compositions.Enums;
+using BaroquenMelody.Library.Infrastructure.Configuration.Enums;
 using BaroquenMelody.Library.Store.State;
 using FluentAssertions;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -12,10 +13,12 @@ namespace BaroquenMelody.Library.Tests.Store.State;
 internal sealed class InstrumentConfigurationStateTests
 {
     [Test]
-    [TestCase(true, true, true)]
-    [TestCase(true, false, true)]
-    [TestCase(false, false, false)]
-    public void IsValid_returns_expected_value(bool isInstrumentOneEnabled, bool isInstrumentTwoEnabled, bool expectedIsValid)
+    [TestCase(ConfigurationStatus.Enabled, ConfigurationStatus.Enabled, true)]
+    [TestCase(ConfigurationStatus.Enabled, ConfigurationStatus.Locked, true)]
+    [TestCase(ConfigurationStatus.Locked, ConfigurationStatus.Locked, true)]
+    [TestCase(ConfigurationStatus.Enabled, ConfigurationStatus.Disabled, true)]
+    [TestCase(ConfigurationStatus.Disabled, ConfigurationStatus.Disabled, false)]
+    public void IsValid_returns_expected_value(ConfigurationStatus instrumentOneStatus, ConfigurationStatus instrumentTwoStatus, bool expectedIsValid)
     {
         // act
         var state = new InstrumentConfigurationState(
@@ -23,11 +26,11 @@ internal sealed class InstrumentConfigurationStateTests
             {
                 {
                     Instrument.One,
-                    new InstrumentConfiguration(Instrument.One, Notes.C4, Notes.C5, GeneralMidi2Program.Dulcimer, isInstrumentOneEnabled)
+                    new InstrumentConfiguration(Instrument.One, Notes.C4, Notes.C5, GeneralMidi2Program.Dulcimer, instrumentOneStatus)
                 },
                 {
                     Instrument.Two,
-                    new InstrumentConfiguration(Instrument.Two, Notes.C4, Notes.C5, GeneralMidi2Program.Dulcimer, isInstrumentTwoEnabled)
+                    new InstrumentConfiguration(Instrument.Two, Notes.C4, Notes.C5, GeneralMidi2Program.Dulcimer, instrumentTwoStatus)
                 }
             },
             new Dictionary<Instrument, InstrumentConfiguration>()


### PR DESCRIPTION
## Description

- Introduce a `ConfigurationStatus` enum, with some helpful extension methods.
- Visually disable configuration inputs when the status is disabled or locked
- Avoid randomizing configurations which are disabled or locked

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
