### PR TITLE
Mobile-Friendly UI

### DIFF
--- a/src/BaroquenMelody.App.Components/IThemeProvider.cs
+++ b/src/BaroquenMelody.App.Components/IThemeProvider.cs
@@ -19,4 +19,6 @@ public interface IThemeProvider
     double TooltipDelay { get; }
 
     double TooltipDuration { get; }
+
+    public int Elevation { get; }
 }

--- a/src/BaroquenMelody.App.Components/Layout/MainLayout.razor
+++ b/src/BaroquenMelody.App.Components/Layout/MainLayout.razor
@@ -11,8 +11,8 @@
     MaxWidth="MaxWidth.Small"/>
 
 <MudLayout>
-    <MudAppBar Elevation="3" Dense="true" Gutters="false">
-        <MudIconButton Class="ml-3" Icon="@Icons.Material.Sharp.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@(_ => _isDrawerOpen = !_isDrawerOpen)"/>
+    <MudAppBar Class="mud-elevation-4" Elevation="ThemeProvider.Elevation" Dense="true" Gutters="false">
+        <MudIconButton Class="ml-2" Icon="@Icons.Material.Sharp.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@(_ => _isDrawerOpen = !_isDrawerOpen)"/>
         <MudSpacer/>
         <MudTooltip Delay="@ThemeProvider.TooltipDelay" Duration="@ThemeProvider.TooltipDuration" Text="source code">
             <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://www.github.com/wbaldoumas/baroquen-melody"/>
@@ -22,7 +22,7 @@
         </MudTooltip>
         <MudTooltip Delay="@ThemeProvider.TooltipDelay" Duration="@ThemeProvider.TooltipDuration" Text="more options" Placement="Placement.Left">
             <MudMenu Icon="@Icons.Material.Sharp.MoreVert"
-                     Class="mr-3"
+                     Class="mr-2"
                      AriaLabel="more options">
                 <MudMenuItem Icon="@Icons.Material.Sharp.Lightbulb" IconColor="Color.Warning" Href="https://github.com/wbaldoumas/baroquen-melody/issues/new?template=FEATURE_REQUEST.md">Feature request</MudMenuItem>
                 <MudMenuItem Icon="@Icons.Material.Sharp.BugReport" IconColor="Color.Tertiary" Href="https://github.com/wbaldoumas/baroquen-melody/issues/new?template=BUG_REPORT.md">Report a bug</MudMenuItem>
@@ -31,7 +31,7 @@
             </MudMenu>
         </MudTooltip>
     </MudAppBar>
-    <MudDrawer @bind-Open="_isDrawerOpen" ClipMode="DrawerClipMode.Never" Variant="DrawerVariant.Temporary" Overlay="true" Elevation="3">
+    <MudDrawer @bind-Open="_isDrawerOpen" ClipMode="DrawerClipMode.Never" Variant="DrawerVariant.Temporary" Class="mud-elevation-4" Overlay="true" Elevation="ThemeProvider.Elevation">
         <MudDrawerHeader Dense="true">
             <MudText Color="Color.Tertiary" Typo="Typo.h6">Baroquen Melody</MudText>
         </MudDrawerHeader>

--- a/src/BaroquenMelody.App.Components/Pages/Home.razor
+++ b/src/BaroquenMelody.App.Components/Pages/Home.razor
@@ -5,7 +5,7 @@
 
 <PageTitle>Baroquen Melody</PageTitle>
 
-<MudContainer Class="mb-3" Gutters="false">
+<MudContainer Class="mb-1 mb-sm-2" Gutters="false" MaxWidth="MaxWidth.False">
     <MudGrid Class="mb-2 d-flex justify-center justify-sm-end flex-grow-1 flex-sm-grow-0" Spacing="2">
         <MudItem>
             @if (!CompositionProgressState.Value.IsLoading)
@@ -48,13 +48,14 @@
     </MudGrid>
     <MudTabs Outlined="true"
              Rounded="true"
-             Elevation="3"
+             Elevation="ThemeProvider.Elevation"
              Centered="true"
              ApplyEffectsToContainer="true"
              IconColor="Color.Secondary"
              Border="true"
              SliderAnimation="true"
-             @ref="_tabs">
+             @ref="_tabs"
+             Class="mx-n4 mx-sm-0 mud-elevation-4">
         <MudTabPanel Text="General" Icon="@Icons.Material.Outlined.Settings">
             <CompositionConfigurationPanel/>
         </MudTabPanel>
@@ -114,7 +115,7 @@
             {
                 if (state.Value.CurrentStep == CompositionStep.Failed && _tabs?.ActivePanel != _compositionTab)
                 {
-                    Snackbar.Add("Composition failed! Try again or try a different configuration.", Severity.Error);
+                    Snackbar.Add("Failed to compose. Try again, or try a different configuration.", Severity.Error);
                 }
             });
 

--- a/src/BaroquenMelody.App.Components/Pages/SavedConfigurations.razor
+++ b/src/BaroquenMelody.App.Components/Pages/SavedConfigurations.razor
@@ -2,10 +2,12 @@
 
 <PageTitle>Saved Configurations</PageTitle>
 
-<MudContainer Class="my-3" Gutters="false">
+<MudContainer Class="mb-1 mb-sm-2" Gutters="false" MaxWidth="MaxWidth.False">
     <MudTable Items="@ConfigurationFiles"
               Loading="@Loading"
               Outlined="true"
+              Elevation="ThemeProvider.Elevation"
+              Class="mx-n4 mx-sm-0 mud-elevation-4"
               LoadingProgressColor="Color.Primary"
               Hover="true"
               Filter="configuration => configuration.ConfigurationFile.Name.Contains(Search, StringComparison.OrdinalIgnoreCase)">

--- a/src/BaroquenMelody.App.Components/Shared/AutoClosePopover.razor
+++ b/src/BaroquenMelody.App.Components/Shared/AutoClosePopover.razor
@@ -1,0 +1,30 @@
+﻿<MudOverlay @bind-Visible="IsPopoverOpen" LockScroll="false" AutoClose="true" OnClosed="OnPopoverClosed" />
+<MudPopover AnchorOrigin="AnchorOrigin"
+            TransformOrigin="TransformOrigin"
+            Open="IsPopoverOpen"
+            Class="mud-elevation-4"
+            Elevation="ThemeProvider.Elevation"
+            OverflowBehavior="OverflowBehavior"
+            Delay="ThemeProvider.TooltipDelay"
+            Duration="ThemeProvider.TooltipDuration">
+    <MudCard Class="rounded" Outlined="true" Elevation="ThemeProvider.Elevation">
+        <MudCardContent>
+            @PopoverContent
+        </MudCardContent>
+    </MudCard>
+</MudPopover>
+
+@code
+{
+    [Parameter, EditorRequired] public required RenderFragment PopoverContent { get; set; }
+
+    [Parameter, EditorRequired] public required bool IsPopoverOpen { get; set; }
+
+    [Parameter] public Origin AnchorOrigin { get; set; } = Origin.TopCenter;
+
+    [Parameter] public Origin TransformOrigin { get; set; } = Origin.TopLeft;
+
+    [Parameter] public EventCallback OnPopoverClosed { get; set; }
+
+    [Parameter] public OverflowBehavior OverflowBehavior { get; set; } = OverflowBehavior.FlipNever;
+}

--- a/src/BaroquenMelody.App.Components/Shared/AutocompleteWithPopover.razor
+++ b/src/BaroquenMelody.App.Components/Shared/AutocompleteWithPopover.razor
@@ -1,19 +1,13 @@
 ﻿@typeparam T
 
-<MudOverlay @bind-Visible="IsPopoverOpen" LockScroll="false" AutoClose="true"/>
-<MudPopover AnchorOrigin="AnchorOrigin"
-            TransformOrigin="TransformOrigin"
-            Open="IsPopoverOpen"
-            Elevation="3"
-            OverflowBehavior="OverflowBehavior.FlipNever"
-            Delay="ThemeProvider.TooltipDelay"
-            Duration="ThemeProvider.TooltipDuration">
-    <MudCard Class="rounded" Outlined="true" Elevation="3">
-        <MudCardContent>
-            @PopoverContent
-        </MudCardContent>
-    </MudCard>
-</MudPopover>
+<AutoClosePopover IsPopoverOpen="IsPopoverOpen"
+                  AnchorOrigin="AnchorOrigin"
+                  TransformOrigin="TransformOrigin"
+                  OnPopoverClosed="@(() => IsPopoverOpen = false)">
+    <PopoverContent>
+        @PopoverContent
+    </PopoverContent>
+</AutoClosePopover>
 <MudAutocomplete T="T"
                  SearchFunc="SearchFunc"
                  ToStringFunc="ToStringFunc"

--- a/src/BaroquenMelody.App.Components/Shared/CardHeaderSwitch.razor
+++ b/src/BaroquenMelody.App.Components/Shared/CardHeaderSwitch.razor
@@ -4,7 +4,7 @@
     </CardHeaderContent>
     <CardHeaderActions>
         <MudTooltip Delay="ThemeProvider.TooltipDelay" Duration="ThemeProvider.TooltipDuration" Text="@TooltipText" Placement="Placement.Left">
-            <MudIconButton Icon="@Icon" OnClick="CycleConfigurationStatus" Color="IconColor" Size="Size.Medium"/>
+            <MudIconButton Icon="@Icon" OnClick="CycleConfigurationStatus" Color="IconColor" Size="Size.Medium" Variant="Variant.Text"/>
         </MudTooltip>
     </CardHeaderActions>
 </MudCardHeader>

--- a/src/BaroquenMelody.App.Components/Shared/CompositionConfigurationCard.razor
+++ b/src/BaroquenMelody.App.Components/Shared/CompositionConfigurationCard.razor
@@ -1,6 +1,6 @@
 ﻿@inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
-<MudCard Class="rounded my-3 mx-3" Elevation="3" Outlined="true">
+<MudCard Class="rounded my-2 mx-2 mud-elevation-4" Elevation="ThemeProvider.Elevation" Outlined="true">
     <MudCardHeader>
         <CardHeaderContent>
             <MudText Typo="Typo.h6">Composition Configuration</MudText>
@@ -16,7 +16,7 @@
                                    ValueChanged="HandleTonicNoteChange"
                                    ConvertToDisplay="noteName => noteName.ToSpaceSeparatedString()">
                     <PopoverContent>
-                        <MudText>The <MudLink Color="Color.Tertiary" Href="https://en.wikipedia.org/wiki/Tonic_(music)">tonic</MudLink> of the scale used in the composition.</MudText>
+                        <MudText>The <MudLink Color="Color.Tertiary" Href="https://en.wikipedia.org/wiki/Tonic_(music)">tonic</MudLink> of the scale used in the composition. This is the "home" note of the scale which is often returned to.</MudText>
                     </PopoverContent>
                 </SelectWithPopover>
             </MudItem>
@@ -28,7 +28,7 @@
                                    ValueChanged="HandleModeChange"
                                    ConvertToDisplay="mode => mode.ToSpaceSeparatedString()">
                     <PopoverContent>
-                        <MudText>The <MudLink Color="Color.Tertiary" Href="https://en.wikipedia.org/wiki/Mode_(music)">mode</MudLink> of the scale used in the composition.</MudText>
+                        <MudText>The <MudLink Color="Color.Tertiary" Href="https://en.wikipedia.org/wiki/Mode_(music)">mode</MudLink> of the scale used in the composition. A musical mode will affect the overall feel of the music.</MudText>
                     </PopoverContent>
                 </SelectWithPopover>
             </MudItem>
@@ -40,7 +40,7 @@
                                    ValueChanged="HandleMeterChange"
                                    ConvertToDisplay="meter => meter.AsString()">
                     <PopoverContent>
-                        <MudText>The <MudLink Color="Color.Tertiary" Href="https://en.wikipedia.org/wiki/Metre_(music)">meter</MudLink> of the composition.</MudText>
+                        <MudText>The <MudLink Color="Color.Tertiary" Href="https://en.wikipedia.org/wiki/Metre_(music)">meter</MudLink> of the composition. The meter will affect the rhythmic feel of the music.</MudText>
                     </PopoverContent>
                 </SelectWithPopover>
             </MudItem>

--- a/src/BaroquenMelody.App.Components/Shared/CompositionProgress.razor
+++ b/src/BaroquenMelody.App.Components/Shared/CompositionProgress.razor
@@ -2,7 +2,7 @@
 
 @if (CompositionProgressState.Value.IsWaiting)
 {
-    <MudGrid Class="my-3" Justify="Justify.Center">
+    <MudGrid Class="my-2" Justify="Justify.Center">
         <MudAnimate
             Selector=".compose-button"
             Duration="2"
@@ -24,7 +24,7 @@
                             Delay="ThemeProvider.TooltipDelay"
                             Duration="ThemeProvider.TooltipDuration"
                             Disabled="@InstrumentConfigurationState.Value.IsValid">
-                    <MudButton Class="compose-button d-flex align-center justify-center"
+                    <MudButton Class="compose-button d-flex align-center justify-center mud-elevation-4"
                                Variant="Variant.Filled"
                                StartIcon="@Icons.Material.Filled.ElectricBolt"
                                Color="Color.Tertiary"
@@ -40,7 +40,7 @@
 }
 else if (CompositionProgressState.Value.IsFailed)
 {
-    <MudGrid Class="my-3" Justify="Justify.Center">
+    <MudGrid Class="my-2" Justify="Justify.Center">
         <MudAnimate 
             Selector=".composition-failed"
             Duration="2"
@@ -58,8 +58,9 @@ else if (CompositionProgressState.Value.IsFailed)
         <MudItem xs="12" sm="12" md="12" lg="12" xl="12" xxl="12">
             <div class="d-flex flex-shrink align-center justify-center ma-0" style="height:300px;">
                 <MudAlert Severity="Severity.Error"
-                          Class="composition-failed"
+                          Class="composition-failed mud-elevation-4"
                           Variant="Variant.Outlined"
+                          Elevation="ThemeProvider.Elevation"
                           ShowCloseIcon="true"
                           CloseIconClicked="() => Dispatcher.Dispatch(new ResetCompositionProgress())">
                     Failed to compose. Try again, or try a different configuration.
@@ -70,7 +71,7 @@ else if (CompositionProgressState.Value.IsFailed)
 }
 else
 {
-    <MudCard Class="rounded my-3 mx-3 px-4 py-4" Elevation="3" Outlined="true">
+    <MudCard Class="rounded my-2 mx-2 px-4 py-4 mud-elevation-4" Elevation="ThemeProvider.Elevation" Outlined="true">
         <MudGrid Justify="Justify.Center">
             <MudItem xs="12" sm="12" md="12" lg="12" xl="12" xxl="12">
                 <MudText Typo="Typo.h6">@CompositionProgressState.Value.Message</MudText>

--- a/src/BaroquenMelody.App.Components/Shared/CompositionRuleConfigurationCard.razor
+++ b/src/BaroquenMelody.App.Components/Shared/CompositionRuleConfigurationCard.razor
@@ -1,6 +1,6 @@
 ﻿@inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
-<MudCard Class="rounded mb-3 mx-3" Elevation="3" Outlined="true">
+<MudCard Class="rounded my-2 mx-2 mud-elevation-4" Elevation="ThemeProvider.Elevation" Outlined="true">
     <CardHeaderSwitch HeaderText="@(CompositionRule.ToSpaceSeparatedString())"
                       ConfigurationStatus="@Status"
                       ValueChanged="HandleIsEnabledChange"/>
@@ -27,7 +27,7 @@
                            ValueChanged="HandleStrictnessChange"
                            Size="Size.Medium"
                            Variant="Variant.Filled"
-                           Color="Color.Tertiary"
+                           Color="@(!Status.IsEnabled() ? Color.Dark : Color.Tertiary)"
                            ValueLabel="true"
                            TickMarks="true"
                            Immediate="true"

--- a/src/BaroquenMelody.App.Components/Shared/CompositionRuleConfigurationPanel.razor
+++ b/src/BaroquenMelody.App.Components/Shared/CompositionRuleConfigurationPanel.razor
@@ -1,6 +1,6 @@
 ﻿<RandomizeResetButtonGroup OnRandomizeClick="CompositionRuleConfigurationService.Randomize"
                            OnResetClick="CompositionRuleConfigurationService.ConfigureDefaults"/>
-<MudGrid Spacing="1" Justify="Justify.Center">
+<MudGrid Spacing="0" Justify="Justify.Center">
     @foreach (var compositionRule in CompositionRuleConfigurationService.ConfigurableCompositionRules)
     {
         <MudItem xs="12" sm="12" md="6" lg="6" xl="6" xxl="6">

--- a/src/BaroquenMelody.App.Components/Shared/ConfirmCompositionDialogue.razor
+++ b/src/BaroquenMelody.App.Components/Shared/ConfirmCompositionDialogue.razor
@@ -1,20 +1,17 @@
 ﻿<MudDialog>
     <DialogContent>
-        Previous composition has not yet been saved. Do you want to save it before creating a new one?
+        <MudText>Previous composition has not yet been saved. Do you want to save it before creating a new one?</MudText>
     </DialogContent>
     <DialogActions>
-        <MudButton Color="Color.Tertiary"
-                   Variant="Variant.Outlined"
+        <MudButton Color="Color.Primary"
                    OnClick="SaveComposition">
             Yes
         </MudButton>
         <MudButton Color="Color.Error"
-                   Variant="Variant.Outlined"
                    OnClick="ContinueWithoutSave">
             No
         </MudButton>
-        <MudButton OnClick="Cancel"
-                   Variant="Variant.Outlined">
+        <MudButton OnClick="Cancel">
             Cancel
         </MudButton>
     </DialogActions>

--- a/src/BaroquenMelody.App.Components/Shared/InstrumentConfigurationCard.razor
+++ b/src/BaroquenMelody.App.Components/Shared/InstrumentConfigurationCard.razor
@@ -1,7 +1,7 @@
 ﻿@inherits Fluxor.Blazor.Web.Components.FluxorComponent
 @implements IDisposable
 
-<MudCard Class="rounded my-3 mx-3" Elevation="3" Outlined="true">
+<MudCard Class="rounded my-2 mx-2 mud-elevation-4" Elevation="ThemeProvider.Elevation" Outlined="true">
     <CardHeaderSwitch HeaderText="@($"Instrument {Instrument}")"
                       ConfigurationStatus="@Status"
                       ValueChanged="HandleIsEnabledChange"/>
@@ -36,7 +36,7 @@
                              @bind-UpperValue="HighestPitchNoteIndex"
                              Size="Size.Medium"
                              Variant="Variant.Filled"
-                             Color="Color.Tertiary"
+                             Color="@(!Status.IsEnabled() ? Color.Dark : Color.Tertiary)"
                              ValueLabel="true"
                              Range="true"
                              TickMarks="true"

--- a/src/BaroquenMelody.App.Components/Shared/InstrumentConfigurationPanel.razor
+++ b/src/BaroquenMelody.App.Components/Shared/InstrumentConfigurationPanel.razor
@@ -2,13 +2,24 @@
 
 <RandomizeResetButtonGroup OnRandomizeClick="InstrumentConfigurationService.Randomize"
                            OnResetClick="InstrumentConfigurationService.ConfigureDefaults"/>
-
 @if (!InstrumentConfigurationState.Value.IsValid)
 {
-    <MudAlert Severity="Severity.Warning" Class="mx-3" Variant="Variant.Outlined">Please enable at least one instrument.</MudAlert>
+    <MudAlert Severity="Severity.Warning"
+              Class="mx-2 mt-2 mud-elevation-4"
+              Variant="Variant.Outlined"
+              Elevation="ThemeProvider.Elevation"
+              ContentAlignment="HorizontalAlignment.Center"
+              Dense="true">
+        Invalid instrumentation. Please enable at least one instrument.
+    </MudAlert>
 }
-@foreach (var instrument in InstrumentConfigurationService.ConfigurableInstruments)
-{
-    <InstrumentConfigurationCard Instrument="instrument"/>
-}
+<MudGrid Spacing="0" Justify="Justify.Center">
+    @foreach (var instrument in InstrumentConfigurationService.ConfigurableInstruments)
+    {
+        <MudItem xs="12">
+            <InstrumentConfigurationCard Instrument="instrument"/>
+        </MudItem>
+    }
+</MudGrid>
+
 <ScrollToTop/>

--- a/src/BaroquenMelody.App.Components/Shared/NumericInputWithPopover.razor
+++ b/src/BaroquenMelody.App.Components/Shared/NumericInputWithPopover.razor
@@ -1,29 +1,23 @@
 ﻿@typeparam T
 
-<MudOverlay @bind-Visible="IsPopoverOpen" AutoClose="true"/>
-<MudPopover AnchorOrigin="Origin.TopCenter"
-            Open="IsPopoverOpen"
-            Elevation="3"
-            Delay="ThemeProvider.TooltipDelay"
-            Duration="ThemeProvider.TooltipDuration">
-    <MudCard Class="rounded" Outlined="true" Elevation="3">
-        <MudCardContent>
-            @PopoverContent
-        </MudCardContent>
-    </MudCard>
-</MudPopover>
+<AutoClosePopover IsPopoverOpen="IsPopoverOpen"
+                  OnPopoverClosed="@(() => IsPopoverOpen = false)">
+    <PopoverContent>
+        @PopoverContent
+    </PopoverContent>
+</AutoClosePopover>
 <MudNumericField T="T" 
                  OnAdornmentClick="OpenMeterPopover" 
                  AdornmentIcon="@Icons.Material.Outlined.QuestionMark" 
                  Adornment="Adornment.End" 
                  IconSize="Size.Small" 
-                 Variant="Variant.Outlined" 
+                 Variant="Variant.Outlined"
                  Value="Value" 
                  Label="@Label" 
                  ValueChanged="ValueChanged"
                  Min="Min"
                  Max="Max"
-                 Disabled="IsDisabled" />
+                 Disabled="IsDisabled"/>
 
 @code
 {

--- a/src/BaroquenMelody.App.Components/Shared/OrnamentationConfigurationCard.razor
+++ b/src/BaroquenMelody.App.Components/Shared/OrnamentationConfigurationCard.razor
@@ -1,6 +1,6 @@
 ﻿@inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
-<MudCard Class="rounded mb-3 mx-3" Elevation="3" Outlined="true">
+<MudCard Class="rounded my-2 mx-2 mud-elevation-4" Elevation="ThemeProvider.Elevation" Outlined="true">
     <CardHeaderSwitch HeaderText="@(OrnamentationType.ToSpaceSeparatedString())"
                       ConfigurationStatus="Status"
                       ValueChanged="HandleIsEnabledChange"/>
@@ -19,7 +19,7 @@
                     </PopoverContent>
                 </NumericInputWithPopover>
             </MudItem>
-            <MudFlexBreak/>
+            <MudFlexBreak />
             <MudItem xs="12" sm="12" md="12" lg="12" xl="12" xxl="12" Class="d-none d-sm-flex">
                 <MudSlider T="int"
                            Value="@Probability"
@@ -27,7 +27,7 @@
                            ValueChanged="HandleProbabilityChange"
                            Size="Size.Medium"
                            Variant="Variant.Filled"
-                           Color="Color.Tertiary"
+                           Color="@(!Status.IsEnabled() ? Color.Dark : Color.Tertiary)"
                            ValueLabel="true"
                            TickMarks="true"
                            Immediate="true"

--- a/src/BaroquenMelody.App.Components/Shared/OrnamentationConfigurationPanel.razor
+++ b/src/BaroquenMelody.App.Components/Shared/OrnamentationConfigurationPanel.razor
@@ -1,6 +1,6 @@
 ﻿<RandomizeResetButtonGroup OnRandomizeClick="OrnamentationConfigurationService.Randomize"
                            OnResetClick="OrnamentationConfigurationService.ConfigureDefaults"/>
-<MudGrid Spacing="1" Justify="Justify.Center">
+<MudGrid Spacing="0" Justify="Justify.Center">
     @foreach (var ornamentation in OrnamentationConfigurationService.ConfigurableOrnamentations)
     {
         <MudItem xs="12" sm="12" md="6" lg="6" xl="6" xxl="6">

--- a/src/BaroquenMelody.App.Components/Shared/RandomizeResetButtonGroup.razor
+++ b/src/BaroquenMelody.App.Components/Shared/RandomizeResetButtonGroup.razor
@@ -1,5 +1,5 @@
-﻿<MudGrid Class="my-3" Justify="Justify.FlexStart">
-    <MudItem Class="ml-3">
+﻿<MudGrid Class="mt-2" Justify="Justify.FlexStart" >
+    <MudItem Class="ml-2">
         <MudButton
             Variant="Variant.Filled"
             StartIcon="@RandomizeIcon"

--- a/src/BaroquenMelody.App.Components/Shared/SaveCompositionConfigurationDialog.razor
+++ b/src/BaroquenMelody.App.Components/Shared/SaveCompositionConfigurationDialog.razor
@@ -1,10 +1,13 @@
 ﻿<MudDialog>
     <TitleContent>
-        Save Composition Configuration
+        <MudStack AlignItems="AlignItems.Center" Row="true" Justify="Justify.FlexStart">
+            <MudIcon Icon="@Icons.Material.Outlined.Settings" Color="Color.Secondary" Class="mr-n1"/>
+            <MudText Inline="true" Typo="Typo.button">Save Composition Configuration</MudText>
+        </MudStack>
     </TitleContent>
     <DialogContent>
-        <MudTextField @bind-Value="ConfigurationName" 
-                      Label="Configuration Name" 
+        <MudTextField @bind-Value="ConfigurationName"
+                      Label="Configuration Name"
                       Variant="Variant.Outlined"
                       Validation="ValidateFilename"
                       Immediate="true"/>

--- a/src/BaroquenMelody.App.Components/Shared/ScrollToTop.razor
+++ b/src/BaroquenMelody.App.Components/Shared/ScrollToTop.razor
@@ -1,3 +1,3 @@
 ﻿<MudScrollToTop>
-    <MudFab Color="Color.Tertiary" StartIcon="@Icons.Material.Filled.KeyboardArrowUp" IconSize="Size.Small" />
+    <MudFab Color="Color.Tertiary" StartIcon="@Icons.Material.Filled.KeyboardArrowUp" IconSize="Size.Small"/>
 </MudScrollToTop>

--- a/src/BaroquenMelody.App.Components/Shared/SelectWithPopover.razor
+++ b/src/BaroquenMelody.App.Components/Shared/SelectWithPopover.razor
@@ -1,17 +1,12 @@
 ﻿@typeparam T
 
-<MudOverlay @bind-Visible="IsPopoverOpen" AutoClose="true"/>
-<MudPopover AnchorOrigin="Origin.TopCenter"
-            Open="IsPopoverOpen"
-            Elevation="3"
-            Delay="ThemeProvider.TooltipDelay"
-            Duration="ThemeProvider.TooltipDuration">
-    <MudCard Class="rounded" Outlined="true" Elevation="3">
-        <MudCardContent>
-            @PopoverContent
-        </MudCardContent>
-    </MudCard>
-</MudPopover>
+<AutoClosePopover IsPopoverOpen="IsPopoverOpen"
+                  OnPopoverClosed="@(() => IsPopoverOpen = false)"
+                  OverflowBehavior="OverflowBehavior.FlipOnOpen">
+    <PopoverContent>
+        @PopoverContent
+    </PopoverContent>
+</AutoClosePopover>
 <MudSelect T="T" OnAdornmentClick="OpenPopover" AdornmentIcon="@Icons.Material.Outlined.QuestionMark" Adornment="Adornment.End" IconSize="Size.Small" Variant="Variant.Outlined" AnchorOrigin="Origin.BottomCenter" Label="@Label" Value="Value" ValueChanged="ValueChanged">
     @foreach (var item in Items)
     {

--- a/src/BaroquenMelody.App/Infrastructure/Theme/MauiThemeProvider.cs
+++ b/src/BaroquenMelody.App/Infrastructure/Theme/MauiThemeProvider.cs
@@ -77,4 +77,6 @@ internal sealed class MauiThemeProvider : IThemeProvider
     public double TooltipDuration => 333;
 
     public void ToggleDarkMode() => IsDarkMode = !IsDarkMode;
+
+    public int Elevation => 4;
 }


### PR DESCRIPTION
## Description

- Adjusted margins for small screens
- Consistently apply elevation (shadow)
- Abstract auto-close popover to a separate, shareable razor component

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
