### PR TITLE
Adjust Locked / Enabled Status in UI

### DIFF
--- a/src/BaroquenMelody.App.Components/Shared/CardHeaderSwitch.razor
+++ b/src/BaroquenMelody.App.Components/Shared/CardHeaderSwitch.razor
@@ -1,12 +1,53 @@
 ﻿<MudCardHeader>
     <CardHeaderContent>
-        <MudText Typo="Typo.h6">@HeaderText</MudText>
+        <MudGrid Spacing="1">
+            <MudItem xs="12" sm="8" md="8">
+                <MudText Typo="Typo.h6">@HeaderText</MudText>
+            </MudItem>
+            <MudItem xs="12" sm="4" md="4">
+                <div class="d-none d-sm-flex justify-end">
+                    <MudStack Row="false" Justify="Justify.FlexEnd" Spacing="1">
+                        <MudSwitch T="bool"
+                                   Label="Enable"
+                                   Value="IsEnabled"
+                                   Color="Color.Tertiary"
+                                   LabelPosition="LabelPosition.Start"
+                                   ThumbIcon="@IsEnabledIcon"
+                                   ThumbIconColor="Color.Dark"
+                                   ValueChanged="IsEnabledChanged"/>
+                        <MudSwitch T="bool"
+                                   Label="Lock"
+                                   Value="IsLocked"
+                                   Color="Color.Primary"
+                                   LabelPosition="LabelPosition.Start"
+                                   ThumbIconColor="Color.Dark"
+                                   ThumbIcon="@IsLockedIcon"
+                                   ValueChanged="IsLockedChanged"/>
+                    </MudStack>
+                </div>
+                <div class="d-sm-none">
+                    <MudStack Row="true" Justify="Justify.SpaceEvenly" Spacing="1">
+                        <MudSwitch T="bool"
+                                   Label="Enable"
+                                   Value="IsEnabled"
+                                   Color="Color.Tertiary"
+                                   LabelPosition="LabelPosition.Start"
+                                   ThumbIconColor="Color.Dark"
+                                   ThumbIcon="@IsEnabledIcon"
+                                   ValueChanged="IsEnabledChanged"/>
+                        <MudSwitch T="bool"
+                                   Label="Lock"
+                                   Value="IsLocked"
+                                   Color="Color.Info"
+                                   LabelPosition="LabelPosition.Start"
+                                   ThumbIconColor="Color.Dark"
+                                   ThumbIcon="@IsLockedIcon"
+                                   ValueChanged="IsLockedChanged"/>
+                    </MudStack>
+                </div>
+            </MudItem>
+        </MudGrid>
     </CardHeaderContent>
-    <CardHeaderActions>
-        <MudTooltip Delay="ThemeProvider.TooltipDelay" Duration="ThemeProvider.TooltipDuration" Text="@TooltipText" Placement="Placement.Left">
-            <MudIconButton Icon="@Icon" OnClick="CycleConfigurationStatus" Color="IconColor" Size="Size.Medium" Variant="Variant.Text"/>
-        </MudTooltip>
-    </CardHeaderActions>
 </MudCardHeader>
 
 @code
@@ -17,34 +58,39 @@
 
     [Parameter, EditorRequired] public required EventCallback<ConfigurationStatus> ValueChanged { get; set; }
 
-    private void CycleConfigurationStatus()
+    private bool IsEnabled => ConfigurationStatus.HasFlag(ConfigurationStatus.Enabled);
+
+    private bool IsLocked => ConfigurationStatus.HasFlag(ConfigurationStatus.Locked);
+
+    private string IsEnabledIcon => IsEnabled ? Icons.Material.Sharp.MusicNote : Icons.Material.Sharp.MusicOff;
+
+    private string IsLockedIcon => IsLocked ? Icons.Material.Sharp.Lock : Icons.Material.Sharp.LockOpen;
+
+    private void IsEnabledChanged(bool isEnabled)
     {
-        ConfigurationStatus = ConfigurationStatus.Cycle();
+        if (isEnabled)
+        {
+            ConfigurationStatus |= ConfigurationStatus.Enabled;
+        }
+        else
+        {
+            ConfigurationStatus &= ~ConfigurationStatus.Enabled;
+        }
+
         ValueChanged.InvokeAsync(ConfigurationStatus);
     }
 
-    private string Icon => ConfigurationStatus switch
+    private void IsLockedChanged(bool isLocked)
     {
-        ConfigurationStatus.Enabled => Icons.Material.Outlined.CheckCircle,
-        ConfigurationStatus.Disabled => Icons.Material.Outlined.RemoveCircle,
-        ConfigurationStatus.Locked => Icons.Material.Outlined.Lock,
-        _ => throw new ArgumentOutOfRangeException()
-    };
+        if (isLocked)
+        {
+            ConfigurationStatus |= ConfigurationStatus.Locked;
+        }
+        else
+        {
+            ConfigurationStatus &= ~ConfigurationStatus.Locked;
+        }
 
-    private Color IconColor => ConfigurationStatus switch
-    {
-        ConfigurationStatus.Enabled => Color.Tertiary,
-        ConfigurationStatus.Disabled => Color.Default,
-        ConfigurationStatus.Locked => Color.Primary,
-        _ => throw new ArgumentOutOfRangeException()
-    };
-
-    private string TooltipText => ConfigurationStatus switch
-    {
-        ConfigurationStatus.Enabled => "lock configuration",
-        ConfigurationStatus.Disabled => "enable configuration",
-        ConfigurationStatus.Locked => "disable configuration",
-        _ => throw new ArgumentOutOfRangeException()
-    };
-
+        ValueChanged.InvokeAsync(ConfigurationStatus);
+    }
 }

--- a/src/BaroquenMelody.Library/Configurations/Enums/ConfigurationStatus.cs
+++ b/src/BaroquenMelody.Library/Configurations/Enums/ConfigurationStatus.cs
@@ -1,19 +1,35 @@
 ﻿namespace BaroquenMelody.Library.Configurations.Enums;
 
+[Flags]
 public enum ConfigurationStatus : byte
 {
     /// <summary>
-    ///     The configuration is enabled.
+    ///     No status.
     /// </summary>
-    Enabled,
+    None = 0,
 
     /// <summary>
-    ///     The configuration is locked.
+    ///     The configuration is enabled.
     /// </summary>
-    Locked,
+    Enabled = 1 << 0, // 1
 
     /// <summary>
     ///     The configuration is disabled.
     /// </summary>
-    Disabled
+    Disabled = 1 << 1, // 2
+
+    /// <summary>
+    ///     The configuration is locked.
+    /// </summary>
+    Locked = 1 << 2, // 4
+
+    /// <summary>
+    ///     The configuration is enabled and locked.
+    /// </summary>
+    EnabledAndLocked = Enabled | Locked, // 1 | 4 = 5
+
+    /// <summary>
+    ///     The configuration is disabled and locked.
+    /// </summary>
+    DisabledAndLocked = Disabled | Locked // 2 | 4 = 6
 }

--- a/src/BaroquenMelody.Library/Configurations/Enums/Extensions/ConfigurationStatusExtensions.cs
+++ b/src/BaroquenMelody.Library/Configurations/Enums/Extensions/ConfigurationStatusExtensions.cs
@@ -3,30 +3,20 @@
 public static class ConfigurationStatusExtensions
 {
     /// <summary>
-    ///     Cycle the configuration status.
-    /// </summary>
-    /// <param name="status">The source configuration status.</param>
-    /// <returns>The next configuration status.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when the source configuration status is not a valid value.</exception>
-    public static ConfigurationStatus Cycle(this ConfigurationStatus status) => status switch
-    {
-        ConfigurationStatus.Enabled => ConfigurationStatus.Locked,
-        ConfigurationStatus.Locked => ConfigurationStatus.Disabled,
-        ConfigurationStatus.Disabled => ConfigurationStatus.Enabled,
-        _ => throw new ArgumentOutOfRangeException(nameof(status), status, null)
-    };
-
-    /// <summary>
     ///     Whether the configuration is enabled (enabled or locked).
     /// </summary>
     /// <param name="status">The source configuration status.</param>
     /// <returns>Whether the configuration is enabled.</returns>
-    public static bool IsEnabled(this ConfigurationStatus status) => status is ConfigurationStatus.Enabled or ConfigurationStatus.Locked;
+    public static bool IsEnabled(this ConfigurationStatus status) => status.HasFlag(ConfigurationStatus.Enabled);
 
     /// <summary>
     ///     Whether the configuration is frozen (locked or disabled).
     /// </summary>
     /// <param name="status">The source configuration status.</param>
     /// <returns>Whether the configuration is frozen.</returns>
-    public static bool IsFrozen(this ConfigurationStatus status) => status is ConfigurationStatus.Locked or ConfigurationStatus.Disabled;
+    public static bool IsFrozen(this ConfigurationStatus status) => status.HasFlag(ConfigurationStatus.Locked) || status.HasFlag(ConfigurationStatus.Disabled)
+                                                                                                               || status.HasFlag(ConfigurationStatus.DisabledAndLocked)
+                                                                                                               || status.HasFlag(ConfigurationStatus.EnabledAndLocked)
+                                                                                                               || (status.HasFlag(ConfigurationStatus.None) &&
+                                                                                                                   !status.HasFlag(ConfigurationStatus.Enabled));
 }

--- a/tests/BaroquenMelody.Library.Tests/Configuration/Enums/Extensions/ConfigurationStatusExtensionsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Configuration/Enums/Extensions/ConfigurationStatusExtensionsTests.cs
@@ -35,6 +35,7 @@ internal sealed class ConfigurationStatusExtensionsTests
     [TestCase(ConfigurationStatus.DisabledAndLocked, true)]
     [TestCase(ConfigurationStatus.Enabled | ConfigurationStatus.Locked, true)]
     [TestCase(ConfigurationStatus.Disabled | ConfigurationStatus.Locked, true)]
+    [TestCase(ConfigurationStatus.None | ConfigurationStatus.Enabled, false)]
     public void IsFrozen_returns_whether_the_configuration_is_frozen(ConfigurationStatus status, bool expectedIsFrozen)
     {
         // act

--- a/tests/BaroquenMelody.Library.Tests/Configuration/Enums/Extensions/ConfigurationStatusExtensionsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Configuration/Enums/Extensions/ConfigurationStatusExtensionsTests.cs
@@ -9,32 +9,14 @@ namespace BaroquenMelody.Library.Tests.Configuration.Enums.Extensions;
 internal sealed class ConfigurationStatusExtensionsTests
 {
     [Test]
-    [TestCase(ConfigurationStatus.Enabled, ConfigurationStatus.Locked)]
-    [TestCase(ConfigurationStatus.Locked, ConfigurationStatus.Disabled)]
-    [TestCase(ConfigurationStatus.Disabled, ConfigurationStatus.Enabled)]
-    public void Cycle_returns_the_next_value(ConfigurationStatus status, ConfigurationStatus expectedNextStatus)
-    {
-        // act
-        var nextStatus = status.Cycle();
-
-        // assert
-        nextStatus.Should().Be(expectedNextStatus);
-    }
-
-    [Test]
-    public void Cycle_throws_when_the_source_configuration_status_is_not_a_valid_value()
-    {
-        // act
-        var act = () => ((ConfigurationStatus)byte.MaxValue).Cycle();
-
-        // assert
-        act.Should().Throw<ArgumentOutOfRangeException>();
-    }
-
-    [Test]
+    [TestCase(ConfigurationStatus.None, false)]
     [TestCase(ConfigurationStatus.Enabled, true)]
-    [TestCase(ConfigurationStatus.Locked, true)]
+    [TestCase(ConfigurationStatus.Locked, false)]
     [TestCase(ConfigurationStatus.Disabled, false)]
+    [TestCase(ConfigurationStatus.EnabledAndLocked, true)]
+    [TestCase(ConfigurationStatus.DisabledAndLocked, false)]
+    [TestCase(ConfigurationStatus.Enabled | ConfigurationStatus.Locked, true)]
+    [TestCase(ConfigurationStatus.Disabled | ConfigurationStatus.Locked, false)]
     public void IsEnabled_returns_whether_the_configuration_is_enabled(ConfigurationStatus status, bool expectedIsEnabled)
     {
         // act
@@ -45,9 +27,14 @@ internal sealed class ConfigurationStatusExtensionsTests
     }
 
     [Test]
+    [TestCase(ConfigurationStatus.None, true)]
     [TestCase(ConfigurationStatus.Enabled, false)]
     [TestCase(ConfigurationStatus.Locked, true)]
     [TestCase(ConfigurationStatus.Disabled, true)]
+    [TestCase(ConfigurationStatus.EnabledAndLocked, true)]
+    [TestCase(ConfigurationStatus.DisabledAndLocked, true)]
+    [TestCase(ConfigurationStatus.Enabled | ConfigurationStatus.Locked, true)]
+    [TestCase(ConfigurationStatus.Disabled | ConfigurationStatus.Locked, true)]
     public void IsFrozen_returns_whether_the_configuration_is_frozen(ConfigurationStatus status, bool expectedIsFrozen)
     {
         // act

--- a/tests/BaroquenMelody.Library.Tests/Store/State/InstrumentConfigurationStateTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/State/InstrumentConfigurationStateTests.cs
@@ -15,9 +15,12 @@ internal sealed class InstrumentConfigurationStateTests
     [Test]
     [TestCase(ConfigurationStatus.Enabled, ConfigurationStatus.Enabled, true)]
     [TestCase(ConfigurationStatus.Enabled, ConfigurationStatus.Locked, true)]
-    [TestCase(ConfigurationStatus.Locked, ConfigurationStatus.Locked, true)]
+    [TestCase(ConfigurationStatus.Locked | ConfigurationStatus.Enabled, ConfigurationStatus.Enabled, true)]
     [TestCase(ConfigurationStatus.Enabled, ConfigurationStatus.Disabled, true)]
     [TestCase(ConfigurationStatus.Disabled, ConfigurationStatus.Disabled, false)]
+    [TestCase(ConfigurationStatus.Disabled, ConfigurationStatus.Locked, false)]
+    [TestCase(ConfigurationStatus.Disabled, ConfigurationStatus.EnabledAndLocked, true)]
+    [TestCase(ConfigurationStatus.Disabled, ConfigurationStatus.DisabledAndLocked, false)]
     public void IsValid_returns_expected_value(ConfigurationStatus instrumentOneStatus, ConfigurationStatus instrumentTwoStatus, bool expectedIsValid)
     {
         // act


### PR DESCRIPTION
## Description

Adjust how the "locked" and "enabled" configuration statuses work.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
