### PR TITLE
Lock 'enabled' Switch

### DIFF
--- a/src/BaroquenMelody.App.Components/Shared/CardHeaderSwitch.razor
+++ b/src/BaroquenMelody.App.Components/Shared/CardHeaderSwitch.razor
@@ -13,6 +13,7 @@
                                    Color="Color.Tertiary"
                                    LabelPosition="LabelPosition.Start"
                                    ThumbIcon="@IsEnabledIcon"
+                                   Disabled="IsLocked"
                                    ThumbIconColor="Color.Dark"
                                    ValueChanged="IsEnabledChanged"/>
                         <MudSwitch T="bool"
@@ -33,6 +34,7 @@
                                    Color="Color.Tertiary"
                                    LabelPosition="LabelPosition.Start"
                                    ThumbIconColor="Color.Dark"
+                                   Disabled="IsLocked"
                                    ThumbIcon="@IsEnabledIcon"
                                    ValueChanged="IsEnabledChanged"/>
                         <MudSwitch T="bool"


### PR DESCRIPTION
## Description

Lock the 'enabled' switch when the 'lock' switch is toggled.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
