### PR TITLE
Add Search to Ornamentation and Rules Tabs

### DIFF
--- a/src/BaroquenMelody.App.Components/Shared/CompositionRuleConfigurationPanel.razor
+++ b/src/BaroquenMelody.App.Components/Shared/CompositionRuleConfigurationPanel.razor
@@ -1,11 +1,71 @@
-﻿<RandomizeResetButtonGroup OnRandomizeClick="CompositionRuleConfigurationService.Randomize"
-                           OnResetClick="CompositionRuleConfigurationService.ConfigureDefaults"/>
+﻿<div class="d-none d-sm-block">
+    <MudStack Row="true" AlignItems="AlignItems.End" Justify="Justify.SpaceBetween">
+        <RandomizeResetButtonGroup OnRandomizeClick="CompositionRuleConfigurationService.Randomize"
+                                   OnResetClick="CompositionRuleConfigurationService.ConfigureDefaults"/>
+        <MudTextField @bind-Value="Search"
+                      Placeholder="Search"
+                      Immediate="true"
+                      InputMode="InputMode.text"
+                      Class="mr-3"
+                      Adornment="Adornment.Start"
+                      AdornmentIcon="@Icons.Material.Outlined.Search"
+                      AdornmentColor="Color.Secondary"
+                      IconSize="Size.Medium"
+                      Clearable="true"/>
+    </MudStack>
+</div>
+<div class="d-block d-sm-none">
+    <MudStack Row="false" AlignItems="AlignItems.Start" Justify="Justify.SpaceBetween">
+        <RandomizeResetButtonGroup OnRandomizeClick="CompositionRuleConfigurationService.Randomize"
+                                   OnResetClick="CompositionRuleConfigurationService.ConfigureDefaults"/>
+        <MudGrid>
+            <MudItem xs="12" Class="mx-3">
+                <MudTextField @bind-Value="Search"
+                              Placeholder="Search"
+                              Immediate="true"
+                              InputMode="InputMode.text"
+                              FullWidth="true"
+                              Adornment="Adornment.Start"
+                              AdornmentIcon="@Icons.Material.Outlined.Search"
+                              AdornmentColor="Color.Secondary"
+                              IconSize="Size.Medium"
+                              Clearable="true"/>
+            </MudItem>
+        </MudGrid>
+
+    </MudStack>
+</div>
 <MudGrid Spacing="0" Justify="Justify.Center">
-    @foreach (var compositionRule in CompositionRuleConfigurationService.ConfigurableCompositionRules)
+    @foreach (var compositionRule in CompositionRules)
     {
         <MudItem xs="12" sm="12" md="6" lg="6" xl="6" xxl="6">
             <CompositionRuleConfigurationCard CompositionRule="compositionRule"/>
         </MudItem>
     }
 </MudGrid>
-<ScrollToTop />
+@if (!HasCompositionRules)
+{
+    <MudContainer>
+        <div class="d-flex flex-shrink align-center justify-center ma-0" style="height:300px;">
+            <MudAlert Severity="Severity.Normal"
+                      Class="mud-elevation-4"
+                      Variant="Variant.Outlined"
+                      Elevation="ThemeProvider.Elevation"
+                      Dense="true">
+                No composition rules found for current search.
+            </MudAlert>
+        </div>
+    </MudContainer>
+}
+<ScrollToTop/>
+
+@code
+{
+    private string Search = string.Empty;
+
+    private IEnumerable<CompositionRule> CompositionRules => CompositionRuleConfigurationService.ConfigurableCompositionRules.Where(compositionRule =>
+        compositionRule.ToSpaceSeparatedString().Contains(Search, StringComparison.OrdinalIgnoreCase)
+    );
+
+    private bool HasCompositionRules => CompositionRules.Any();
+}

--- a/src/BaroquenMelody.App.Components/Shared/OrnamentationConfigurationPanel.razor
+++ b/src/BaroquenMelody.App.Components/Shared/OrnamentationConfigurationPanel.razor
@@ -1,11 +1,71 @@
-﻿<RandomizeResetButtonGroup OnRandomizeClick="OrnamentationConfigurationService.Randomize"
-                           OnResetClick="OrnamentationConfigurationService.ConfigureDefaults"/>
+﻿<div class="d-none d-sm-block">
+    <MudStack Row="true" AlignItems="AlignItems.End" Justify="Justify.SpaceBetween">
+        <RandomizeResetButtonGroup OnRandomizeClick="OrnamentationConfigurationService.Randomize"
+                                   OnResetClick="OrnamentationConfigurationService.ConfigureDefaults"/>
+        <MudTextField @bind-Value="Search"
+                      Placeholder="Search"
+                      Immediate="true"
+                      InputMode="InputMode.text"
+                      Class="mr-3"
+                      Adornment="Adornment.Start"
+                      AdornmentIcon="@Icons.Material.Outlined.Search"
+                      AdornmentColor="Color.Secondary"
+                      IconSize="Size.Medium"
+                      Clearable="true"/>
+    </MudStack>
+</div>
+<div class="d-block d-sm-none">
+    <MudStack Row="false" AlignItems="AlignItems.Start" Justify="Justify.SpaceBetween">
+        <RandomizeResetButtonGroup OnRandomizeClick="OrnamentationConfigurationService.Randomize"
+                                   OnResetClick="OrnamentationConfigurationService.ConfigureDefaults"/>
+        <MudGrid>
+            <MudItem xs="12" Class="mx-3">
+                <MudTextField @bind-Value="Search"
+                              Placeholder="Search"
+                              Immediate="true"
+                              InputMode="InputMode.text"
+                              FullWidth="true"
+                              Adornment="Adornment.Start"
+                              AdornmentIcon="@Icons.Material.Outlined.Search"
+                              AdornmentColor="Color.Secondary"
+                              IconSize="Size.Medium"
+                              Clearable="true"/>
+            </MudItem>
+        </MudGrid>
+
+    </MudStack>
+</div>
 <MudGrid Spacing="0" Justify="Justify.Center">
-    @foreach (var ornamentation in OrnamentationConfigurationService.ConfigurableOrnamentations)
+    @foreach (var ornamentation in Ornamentations)
     {
         <MudItem xs="12" sm="12" md="6" lg="6" xl="6" xxl="6">
             <OrnamentationConfigurationCard OrnamentationType="ornamentation"/>
         </MudItem>
     }
 </MudGrid>
-<ScrollToTop />
+@if (!HasOrnamentations)
+{
+    <MudContainer>
+        <div class="d-flex flex-shrink align-center justify-center ma-0" style="height:300px;">
+            <MudAlert Severity="Severity.Normal"
+                      Class="mud-elevation-4"
+                      Variant="Variant.Outlined"
+                      Elevation="ThemeProvider.Elevation"
+                      Dense="true">
+                No ornamentations found for current search.
+            </MudAlert>
+        </div>
+    </MudContainer>
+}
+<ScrollToTop/>
+
+@code
+{
+    private string Search = string.Empty;
+
+    private IEnumerable<OrnamentationType> Ornamentations => OrnamentationConfigurationService.ConfigurableOrnamentations.Where(ornamentation =>
+        ornamentation.ToSpaceSeparatedString().Contains(Search, StringComparison.OrdinalIgnoreCase)
+    );
+
+    private bool HasOrnamentations => Ornamentations.Any();
+}


### PR DESCRIPTION
## Description

Add search capability to ornamentation and rules tabs.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
