### PR TITLE
Bugfix BaroquenNote.HasOrnamentations

### DIFF
--- a/src/BaroquenMelody.Library/Domain/BaroquenNote.cs
+++ b/src/BaroquenMelody.Library/Domain/BaroquenNote.cs
@@ -48,7 +48,7 @@ public sealed class BaroquenNote(Instrument instrument, Note raw, MusicalTimeSpa
     /// <summary>
     ///     Whether or not this note has any ornamentations.
     /// </summary>
-    public bool HasOrnamentations => Ornamentations.Count > 0 || (OrnamentationType != OrnamentationType.None && OrnamentationType != OrnamentationType.Rest && OrnamentationType != OrnamentationType.Sustain && OrnamentationType != OrnamentationType.MidSustain);
+    public bool HasOrnamentations => Ornamentations.Count > 0 || OrnamentationType != OrnamentationType.None;
 
     /// <summary>
     ///     The type of ornamentation that is applied to this note.

--- a/src/BaroquenMelody.Library/Dynamics/Engine/Utilities/VelocityCalculator.cs
+++ b/src/BaroquenMelody.Library/Dynamics/Engine/Utilities/VelocityCalculator.cs
@@ -13,14 +13,12 @@ internal sealed class VelocityCalculator : IVelocityCalculator
 
         var precedingNote = precedingBeats[^1][instrument];
 
-        return precedingNote.HasOrnamentations ? precedingNote.Ornamentations[^1].Velocity : precedingNote.Velocity;
+        return precedingNote.Ornamentations.Count > 0 ? precedingNote.Ornamentations[^1].Velocity : precedingNote.Velocity;
     }
 
     public IEnumerable<SevenBitNumber> GetPrecedingVelocities(FixedSizeList<Beat> precedingBeats, Instrument instrument, int count = 4)
     {
         Validate(precedingBeats, instrument);
-
-        var test = precedingBeats.TakeLast(count).Reverse().ToList();
 
         return precedingBeats.TakeLast(count)
             .Reverse()


### PR DESCRIPTION
## Description

Revert recent update that caused an issue with `BaroquenNote.HasOrnamentations`, subsequently causing tracks to get offset.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
