### PR TITLE
Rename BaroquenMelody Type to Fix Ambiguous Imports

### DIFF
--- a/src/BaroquenMelody.App.Components/Pages/Home.razor
+++ b/src/BaroquenMelody.App.Components/Pages/Home.razor
@@ -124,7 +124,7 @@
 
     private async Task Compose()
     {
-        if (!BaroquenMelodyState.Value.HasBeenSaved && BaroquenMelodyState.Value.BaroquenMelody is not null)
+        if (!BaroquenMelodyState.Value.HasBeenSaved && BaroquenMelodyState.Value.Composition is not null)
         {
             var dialogReference = await DialogService.ShowAsync<ConfirmCompositionDialogue>("Save composition?", new DialogOptions());
             var dialogResult = await dialogReference.Result;
@@ -161,7 +161,7 @@
     private async Task<bool> Save()
     {
         var isSaved = await MidiSaver.SaveAsync(
-            BaroquenMelodyState.Value.BaroquenMelody!,
+            BaroquenMelodyState.Value.Composition!,
             BaroquenMelodyState.Value.Path,
             CancellationToken.None
         ).ConfigureAwait(false);

--- a/src/BaroquenMelody.App.Components/Shared/CompositionProgress.razor
+++ b/src/BaroquenMelody.App.Components/Shared/CompositionProgress.razor
@@ -291,7 +291,7 @@ else
     {
         await StopMidiPlayerAsync();
 
-        if (!BaroquenMelodyState.Value.HasBeenSaved && BaroquenMelodyState.Value.BaroquenMelody is not null)
+        if (!BaroquenMelodyState.Value.HasBeenSaved && BaroquenMelodyState.Value.Composition is not null)
         {
             var dialogReference = await DialogService.ShowAsync<ConfirmCompositionDialogue>("Save composition?", new DialogOptions());
             var dialogResult = await dialogReference.Result;
@@ -325,7 +325,7 @@ else
     private async Task<bool> Save()
     {
         var isSaved = await MidiSaver.SaveAsync(
-            BaroquenMelodyState.Value.BaroquenMelody!,
+            BaroquenMelodyState.Value.Composition!,
             BaroquenMelodyState.Value.Path,
             CancellationToken.None
         ).ConfigureAwait(false);

--- a/src/BaroquenMelody.App/Infrastructure/FileSystem/MauiMidiLauncher.cs
+++ b/src/BaroquenMelody.App/Infrastructure/FileSystem/MauiMidiLauncher.cs
@@ -14,9 +14,9 @@ internal sealed class MauiMidiLauncher(IState<BaroquenMelodyState> state, IDispa
     {
         if (!File.Exists(path))
         {
-            path = await midiSaver.SaveTempAsync(state.Value.BaroquenMelody!, cancellationToken).ConfigureAwait(false);
+            path = await midiSaver.SaveTempAsync(state.Value.Composition!, cancellationToken).ConfigureAwait(false);
 
-            dispatcher.Dispatch(new UpdateBaroquenMelody(state.Value.BaroquenMelody!, path, state.Value.HasBeenSaved));
+            dispatcher.Dispatch(new UpdateBaroquenMelody(state.Value.Composition!, path, state.Value.HasBeenSaved));
         }
 
         await Launcher.Default.OpenAsync(new OpenFileRequest(Title, new ReadOnlyFile(path))).ConfigureAwait(false);

--- a/src/BaroquenMelody.App/Infrastructure/FileSystem/MauiMidiSaver.cs
+++ b/src/BaroquenMelody.App/Infrastructure/FileSystem/MauiMidiSaver.cs
@@ -1,4 +1,5 @@
-﻿using BaroquenMelody.Library.Midi;
+﻿using BaroquenMelody.Library;
+using BaroquenMelody.Library.Midi;
 using CommunityToolkit.Maui.Storage;
 using System.Globalization;
 using MauiFileSystem = Microsoft.Maui.Storage.FileSystem;
@@ -7,7 +8,7 @@ namespace BaroquenMelody.App.Infrastructure.FileSystem;
 
 internal sealed class MauiMidiSaver : IMidiSaver
 {
-    public Task<string> SaveTempAsync(Library.BaroquenMelody baroquenMelody, CancellationToken cancellationToken)
+    public Task<string> SaveTempAsync(MidiFileComposition midiFileComposition, CancellationToken cancellationToken)
     {
         if (cancellationToken.IsCancellationRequested)
         {
@@ -17,12 +18,12 @@ internal sealed class MauiMidiSaver : IMidiSaver
         var timestamp = DateTime.Now.ToString("yyyyMMddHHmmssfff", CultureInfo.InvariantCulture);
         var path = Path.Combine(MauiFileSystem.CacheDirectory, $"baroquen-melody-{timestamp}.mid");
 
-        baroquenMelody.MidiFile.Write(path);
+        midiFileComposition.MidiFile.Write(path);
 
         return Task.FromResult(path);
     }
 
-    public async Task<bool> SaveAsync(Library.BaroquenMelody baroquenMelody, string tempPath, CancellationToken cancellationToken)
+    public async Task<bool> SaveAsync(MidiFileComposition midiFileComposition, string tempPath, CancellationToken cancellationToken)
     {
         if (cancellationToken.IsCancellationRequested)
         {
@@ -31,7 +32,7 @@ internal sealed class MauiMidiSaver : IMidiSaver
 
         if (!File.Exists(tempPath))
         {
-            tempPath = await SaveTempAsync(baroquenMelody, cancellationToken).ConfigureAwait(false);
+            tempPath = await SaveTempAsync(midiFileComposition, cancellationToken).ConfigureAwait(false);
         }
 
         if (cancellationToken.IsCancellationRequested)

--- a/src/BaroquenMelody.Library/BaroquenMelodyComposerConfigurator.cs
+++ b/src/BaroquenMelody.Library/BaroquenMelodyComposerConfigurator.cs
@@ -18,11 +18,11 @@ using Microsoft.Extensions.Logging;
 namespace BaroquenMelody.Library;
 
 /// <summary>
-///     Centralized logic for configuring a <see cref="BaroquenMelodyComposer"/> which can generate a <see cref="BaroquenMelody"/>.
+///     Centralized logic for configuring a <see cref="MidiFileComposer"/> which can generate a <see cref="MidiFileComposition"/>.
 /// </summary>
 /// <param name="logger">A logger to be used throughout the composition process.</param>
 /// <param name="dispatcher">A dispatcher to be used to dispatch actions to the store.</param>
-internal sealed class BaroquenMelodyComposerConfigurator(ILogger<BaroquenMelody> logger, IDispatcher dispatcher) : IBaroquenMelodyComposerConfigurator
+internal sealed class BaroquenMelodyComposerConfigurator(ILogger<MidiFileComposition> logger, IDispatcher dispatcher) : IBaroquenMelodyComposerConfigurator
 {
     private readonly IMusicalTimeSpanCalculator _musicalTimeSpanCalculator = new MusicalTimeSpanCalculator();
 
@@ -32,7 +32,7 @@ internal sealed class BaroquenMelodyComposerConfigurator(ILogger<BaroquenMelody>
 
     private readonly IThemeSplitter _themeSplitter = new ThemeSplitter();
 
-    public IBaroquenMelodyComposer Configure(CompositionConfiguration compositionConfiguration)
+    public IMidiFileComposer Configure(CompositionConfiguration compositionConfiguration)
     {
         var chordNumberIdentifier = new ChordNumberIdentifier(compositionConfiguration);
         var compositionRuleFactory = new CompositionRuleFactory(compositionConfiguration, _weightedRandomBooleanGenerator, chordNumberIdentifier);
@@ -51,6 +51,6 @@ internal sealed class BaroquenMelodyComposerConfigurator(ILogger<BaroquenMelody>
         var composer = new Composer(compositionDecorator, compositionPhraser, chordComposer, themeComposer, endingComposer, dynamicsApplicator, dispatcher, compositionConfiguration);
         var midiGenerator = new MidiGenerator(compositionConfiguration);
 
-        return new BaroquenMelodyComposer(composer, midiGenerator);
+        return new MidiFileComposer(composer, midiGenerator);
     }
 }

--- a/src/BaroquenMelody.Library/Composers/IMidiFileComposer.cs
+++ b/src/BaroquenMelody.Library/Composers/IMidiFileComposer.cs
@@ -3,12 +3,12 @@
 /// <summary>
 ///    A composer that generates Baroquen melodies.
 /// </summary>
-public interface IBaroquenMelodyComposer
+public interface IMidiFileComposer
 {
     /// <summary>
     ///     Compose a Baroquen melody.
     /// </summary>
     /// <param name="cancellationToken">A cancellation token to cooperatively cancel composition.</param>
     /// <returns>The composed Baroquen melody.</returns>
-    BaroquenMelody Compose(CancellationToken cancellationToken);
+    MidiFileComposition Compose(CancellationToken cancellationToken);
 }

--- a/src/BaroquenMelody.Library/Composers/MidiFileComposer.cs
+++ b/src/BaroquenMelody.Library/Composers/MidiFileComposer.cs
@@ -2,16 +2,16 @@
 
 namespace BaroquenMelody.Library.Composers;
 
-internal sealed class BaroquenMelodyComposer(
+internal sealed class MidiFileComposer(
     IComposer composer,
     IMidiGenerator midiGenerator
-) : IBaroquenMelodyComposer
+) : IMidiFileComposer
 {
-    public BaroquenMelody Compose(CancellationToken cancellationToken)
+    public MidiFileComposition Compose(CancellationToken cancellationToken)
     {
         var composition = composer.Compose(cancellationToken);
         var midiFile = midiGenerator.Generate(composition);
 
-        return new BaroquenMelody(midiFile);
+        return new MidiFileComposition(midiFile);
     }
 }

--- a/src/BaroquenMelody.Library/Configurations/Services/CompositionConfigurationPersistenceService.cs
+++ b/src/BaroquenMelody.Library/Configurations/Services/CompositionConfigurationPersistenceService.cs
@@ -12,7 +12,7 @@ internal sealed class CompositionConfigurationPersistenceService(
     IDirectory directory,
     IFile file,
     IFileSystem fileSystem,
-    ILogger<BaroquenMelody> logger
+    ILogger<MidiFileComposition> logger
 ) : ICompositionConfigurationPersistenceService
 {
     public async Task<bool> SaveConfigurationAsync(CompositionConfiguration compositionConfiguration, string name, CancellationToken cancellationToken)

--- a/src/BaroquenMelody.Library/IBaroquenMelodyComposerConfigurator.cs
+++ b/src/BaroquenMelody.Library/IBaroquenMelodyComposerConfigurator.cs
@@ -4,14 +4,14 @@ using BaroquenMelody.Library.Configurations;
 namespace BaroquenMelody.Library;
 
 /// <summary>
-///     Configures a new <see cref="IBaroquenMelodyComposer"/> which can compose a <see cref="BaroquenMelody"/> for the given <see cref="CompositionConfiguration"/>.
+///     Configures a new <see cref="IMidiFileComposer"/> which can compose a <see cref="MidiFileComposition"/> for the given <see cref="CompositionConfiguration"/>.
 /// </summary>
 public interface IBaroquenMelodyComposerConfigurator
 {
     /// <summary>
-    ///     Configure a new <see cref="IBaroquenMelodyComposer"/> with the given <see cref="CompositionConfiguration"/>.
+    ///     Configure a new <see cref="IMidiFileComposer"/> with the given <see cref="CompositionConfiguration"/>.
     /// </summary>
-    /// <param name="compositionConfiguration">The <see cref="CompositionConfiguration"/> to configure the <see cref="IBaroquenMelodyComposer"/> with.</param>
-    /// <returns>The configured <see cref="IBaroquenMelodyComposer"/>.</returns>
-    IBaroquenMelodyComposer Configure(CompositionConfiguration compositionConfiguration);
+    /// <param name="compositionConfiguration">The <see cref="CompositionConfiguration"/> to configure the <see cref="IMidiFileComposer"/> with.</param>
+    /// <returns>The configured <see cref="IMidiFileComposer"/>.</returns>
+    IMidiFileComposer Configure(CompositionConfiguration compositionConfiguration);
 }

--- a/src/BaroquenMelody.Library/Midi/IMidiSaver.cs
+++ b/src/BaroquenMelody.Library/Midi/IMidiSaver.cs
@@ -5,17 +5,17 @@ public interface IMidiSaver
     /// <summary>
     ///     Saves the specified Baroquen melody to a temporary file and returns the path to the file.
     /// </summary>
-    /// <param name="baroquenMelody">The Baroquen melody to save.</param>
+    /// <param name="midiFileComposition">The Baroquen melody to save.</param>
     /// <param name="cancellationToken">A cancellation token to cooperatively cancel the operation.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the path to the saved file.</returns>
-    Task<string> SaveTempAsync(BaroquenMelody baroquenMelody, CancellationToken cancellationToken);
+    Task<string> SaveTempAsync(MidiFileComposition midiFileComposition, CancellationToken cancellationToken);
 
     /// <summary>
     ///     Save the specified Baroquen melody to a file.
     /// </summary>
-    /// <param name="baroquenMelody">The Baroquen melody to save.</param>
+    /// <param name="midiFileComposition">The Baroquen melody to save.</param>
     /// <param name="tempPath">The path of the previously saved temporary file.</param>
     /// <param name="cancellationToken">A cancellation token to cooperatively cancel the operation.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    Task<bool> SaveAsync(BaroquenMelody baroquenMelody, string tempPath, CancellationToken cancellationToken);
+    Task<bool> SaveAsync(MidiFileComposition midiFileComposition, string tempPath, CancellationToken cancellationToken);
 }

--- a/src/BaroquenMelody.Library/MidiFileComposition.cs
+++ b/src/BaroquenMelody.Library/MidiFileComposition.cs
@@ -6,4 +6,4 @@ namespace BaroquenMelody.Library;
 ///     A Baroquen melody.
 /// </summary>
 /// <param name="MidiFile">The MIDI file representing the Baroquen melody.</param>
-public sealed record BaroquenMelody(MidiFile MidiFile);
+public sealed record MidiFileComposition(MidiFile MidiFile);

--- a/src/BaroquenMelody.Library/Store/Actions/UpdateBaroquenMelody.cs
+++ b/src/BaroquenMelody.Library/Store/Actions/UpdateBaroquenMelody.cs
@@ -1,3 +1,3 @@
 ﻿namespace BaroquenMelody.Library.Store.Actions;
 
-public sealed record UpdateBaroquenMelody(BaroquenMelody BaroquenMelody, string Path, bool HasBeenSaved);
+public sealed record UpdateBaroquenMelody(MidiFileComposition MidiFileComposition, string Path, bool HasBeenSaved);

--- a/src/BaroquenMelody.Library/Store/Reducers/BaroquenMelodyReducers.cs
+++ b/src/BaroquenMelody.Library/Store/Reducers/BaroquenMelodyReducers.cs
@@ -7,7 +7,7 @@ namespace BaroquenMelody.Library.Store.Reducers;
 public static class BaroquenMelodyReducers
 {
     [ReducerMethod]
-    public static BaroquenMelodyState ReduceUpdateBaroquenMelody(BaroquenMelodyState state, UpdateBaroquenMelody action) => new(action.BaroquenMelody, action.Path, action.HasBeenSaved);
+    public static BaroquenMelodyState ReduceUpdateBaroquenMelody(BaroquenMelodyState state, UpdateBaroquenMelody action) => new(action.MidiFileComposition, action.Path, action.HasBeenSaved);
 
     [ReducerMethod]
     public static BaroquenMelodyState ReduceMarkCompositionSaved(BaroquenMelodyState state, MarkCompositionSaved _) => state with { HasBeenSaved = true };

--- a/src/BaroquenMelody.Library/Store/State/BaroquenMelodyState.cs
+++ b/src/BaroquenMelody.Library/Store/State/BaroquenMelodyState.cs
@@ -3,7 +3,7 @@
 namespace BaroquenMelody.Library.Store.State;
 
 [FeatureState]
-public sealed record BaroquenMelodyState(BaroquenMelody? BaroquenMelody, string Path, bool HasBeenSaved)
+public sealed record BaroquenMelodyState(MidiFileComposition? Composition, string Path, bool HasBeenSaved)
 {
     public BaroquenMelodyState()
         : this(null, string.Empty, false)

--- a/src/BaroquenMelody/App.cs
+++ b/src/BaroquenMelody/App.cs
@@ -43,7 +43,7 @@ internal sealed class App : IDisposable
             .Subscribe(ReportCompositionProgress);
     }
 
-    public Library.MidiFileComposition Run()
+    public MidiFileComposition Run()
     {
         var compositionConfiguration = new CompositionConfiguration(
             _instrumentConfigurationState.Value.EnabledConfigurations,

--- a/src/BaroquenMelody/App.cs
+++ b/src/BaroquenMelody/App.cs
@@ -43,7 +43,7 @@ internal sealed class App : IDisposable
             .Subscribe(ReportCompositionProgress);
     }
 
-    public Library.BaroquenMelody Run()
+    public Library.MidiFileComposition Run()
     {
         var compositionConfiguration = new CompositionConfiguration(
             _instrumentConfigurationState.Value.EnabledConfigurations,

--- a/src/BaroquenMelody/Infrastructure/FileSystem/StubMidiSaver.cs
+++ b/src/BaroquenMelody/Infrastructure/FileSystem/StubMidiSaver.cs
@@ -1,15 +1,16 @@
-﻿using BaroquenMelody.Library.Midi;
+﻿using BaroquenMelody.Library;
+using BaroquenMelody.Library.Midi;
 
 namespace BaroquenMelody.Infrastructure.FileSystem;
 
 internal sealed class StubMidiSaver : IMidiSaver
 {
-    public Task<string> SaveTempAsync(Library.MidiFileComposition midiFileComposition, CancellationToken cancellationToken)
+    public Task<string> SaveTempAsync(MidiFileComposition midiFileComposition, CancellationToken cancellationToken)
     {
         return Task.FromResult(string.Empty);
     }
 
-    public Task<bool> SaveAsync(Library.MidiFileComposition midiFileComposition, string tempPath, CancellationToken cancellationToken)
+    public Task<bool> SaveAsync(MidiFileComposition midiFileComposition, string tempPath, CancellationToken cancellationToken)
     {
         return Task.FromResult(true);
     }

--- a/src/BaroquenMelody/Infrastructure/FileSystem/StubMidiSaver.cs
+++ b/src/BaroquenMelody/Infrastructure/FileSystem/StubMidiSaver.cs
@@ -4,12 +4,12 @@ namespace BaroquenMelody.Infrastructure.FileSystem;
 
 internal sealed class StubMidiSaver : IMidiSaver
 {
-    public Task<string> SaveTempAsync(Library.BaroquenMelody baroquenMelody, CancellationToken cancellationToken)
+    public Task<string> SaveTempAsync(Library.MidiFileComposition midiFileComposition, CancellationToken cancellationToken)
     {
         return Task.FromResult(string.Empty);
     }
 
-    public Task<bool> SaveAsync(Library.BaroquenMelody baroquenMelody, string tempPath, CancellationToken cancellationToken)
+    public Task<bool> SaveAsync(Library.MidiFileComposition midiFileComposition, string tempPath, CancellationToken cancellationToken)
     {
         return Task.FromResult(true);
     }

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -19,7 +19,7 @@ var serviceProvider = new ServiceCollection()
     .AddScoped<App>()
     .BuildServiceProvider();
 
-var baroquenMelody = new BaroquenMelody.Library.BaroquenMelody(new MidiFile());
+var baroquenMelody = new BaroquenMelody.Library.MidiFileComposition(new MidiFile());
 
 for (var i = 0; i < 10000; i++)
 {

--- a/src/BaroquenMelody/Program.cs
+++ b/src/BaroquenMelody/Program.cs
@@ -1,5 +1,6 @@
 ﻿using BaroquenMelody;
 using BaroquenMelody.Infrastructure.FileSystem;
+using BaroquenMelody.Library;
 using BaroquenMelody.Library.Extensions;
 using BaroquenMelody.Library.Midi;
 using Melanchall.DryWetMidi.Core;
@@ -19,7 +20,7 @@ var serviceProvider = new ServiceCollection()
     .AddScoped<App>()
     .BuildServiceProvider();
 
-var baroquenMelody = new BaroquenMelody.Library.MidiFileComposition(new MidiFile());
+var baroquenMelody = new MidiFileComposition(new MidiFile());
 
 for (var i = 0; i < 10000; i++)
 {

--- a/tests/BaroquenMelody.Library.Tests/BaroquenMelodyComposerConfiguratorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/BaroquenMelodyComposerConfiguratorTests.cs
@@ -14,7 +14,7 @@ internal sealed class BaroquenMelodyComposerConfiguratorTests
     private BaroquenMelodyComposerConfigurator _baroquenMelodyComposerConfigurator = null!;
 
     [SetUp]
-    public void SetUp() => _baroquenMelodyComposerConfigurator = new BaroquenMelodyComposerConfigurator(Substitute.For<ILogger<BaroquenMelody>>(), Substitute.For<IDispatcher>());
+    public void SetUp() => _baroquenMelodyComposerConfigurator = new BaroquenMelodyComposerConfigurator(Substitute.For<ILogger<MidiFileComposition>>(), Substitute.For<IDispatcher>());
 
     [Test]
     [TestCaseSource(nameof(TestCases))]

--- a/tests/BaroquenMelody.Library.Tests/Composers/MidiFileComposerTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Composers/MidiFileComposerTests.cs
@@ -9,13 +9,13 @@ using NUnit.Framework;
 namespace BaroquenMelody.Library.Tests.Composers;
 
 [TestFixture]
-internal sealed class BaroquenMelodyComposerTests
+internal sealed class MidiFileComposerTests
 {
     private IComposer _mockComposer = null!;
 
     private IMidiGenerator _mockMidiGenerator = null!;
 
-    private BaroquenMelodyComposer _baroquenMelodyComposer = null!;
+    private MidiFileComposer _midiFileComposer = null!;
 
     [SetUp]
     public void SetUp()
@@ -23,7 +23,7 @@ internal sealed class BaroquenMelodyComposerTests
         _mockComposer = Substitute.For<IComposer>();
         _mockMidiGenerator = Substitute.For<IMidiGenerator>();
 
-        _baroquenMelodyComposer = new BaroquenMelodyComposer(_mockComposer, _mockMidiGenerator);
+        _midiFileComposer = new MidiFileComposer(_mockComposer, _mockMidiGenerator);
     }
 
     [Test]
@@ -37,7 +37,7 @@ internal sealed class BaroquenMelodyComposerTests
         _mockMidiGenerator.Generate(testComposition).Returns(midiFile);
 
         // act
-        var result = _baroquenMelodyComposer.Compose(CancellationToken.None);
+        var result = _midiFileComposer.Compose(CancellationToken.None);
 
         // assert
         _mockComposer.Received(1).Compose(CancellationToken.None);

--- a/tests/BaroquenMelody.Library.Tests/Configuration/CompositionConfigurationPersistenceServiceTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Configuration/CompositionConfigurationPersistenceServiceTests.cs
@@ -22,7 +22,7 @@ internal sealed class CompositionConfigurationPersistenceServiceTests
 
     private IFileSystem _mockFileSystem = null!;
 
-    private ILogger<BaroquenMelody> _mockLogger = null!;
+    private ILogger<MidiFileComposition> _mockLogger = null!;
 
     private CompositionConfigurationPersistenceService _persistenceService = null!;
 
@@ -33,7 +33,7 @@ internal sealed class CompositionConfigurationPersistenceServiceTests
         _mockDirectory = Substitute.For<IDirectory>();
         _mockFile = Substitute.For<IFile>();
         _mockFileSystem = Substitute.For<IFileSystem>();
-        _mockLogger = Substitute.For<ILogger<BaroquenMelody>>();
+        _mockLogger = Substitute.For<ILogger<MidiFileComposition>>();
 
         _persistenceService = new CompositionConfigurationPersistenceService(
             _mockDeviceDirectoryProvider,

--- a/tests/BaroquenMelody.Library.Tests/Store/Effects/BaroquenMelodyEffectsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Effects/BaroquenMelodyEffectsTests.cs
@@ -25,7 +25,7 @@ internal sealed class BaroquenMelodyEffectsTests
 
     private IBaroquenMelodyComposerConfigurator _mockBaroquenMelodyComposerConfigurator = null!;
 
-    private IBaroquenMelodyComposer _mockComposer = null!;
+    private IMidiFileComposer _mockComposer = null!;
 
     private IDispatcher _mockDispatcher = null!;
 
@@ -41,7 +41,7 @@ internal sealed class BaroquenMelodyEffectsTests
         _mockCompositionRuleConfigurationState = Substitute.For<IState<CompositionRuleConfigurationState>>();
         _mockCompositionOrnamentationConfigurationState = Substitute.For<IState<CompositionOrnamentationConfigurationState>>();
         _mockBaroquenMelodyComposerConfigurator = Substitute.For<IBaroquenMelodyComposerConfigurator>();
-        _mockComposer = Substitute.For<IBaroquenMelodyComposer>();
+        _mockComposer = Substitute.For<IMidiFileComposer>();
         _mockDispatcher = Substitute.For<IDispatcher>();
         _mockMidiSaver = Substitute.For<IMidiSaver>();
 
@@ -65,7 +65,7 @@ internal sealed class BaroquenMelodyEffectsTests
         _mockCompositionConfigurationState.Value.Returns(new CompositionConfigurationState());
         _mockBaroquenMelodyComposerConfigurator.Configure(Arg.Any<CompositionConfiguration>()).Returns(_mockComposer);
 
-        var baroquenMelody = new BaroquenMelody(new MidiFile());
+        var baroquenMelody = new MidiFileComposition(new MidiFile());
 
         _mockComposer.Compose(Arg.Any<CancellationToken>()).Returns(baroquenMelody);
 
@@ -73,7 +73,7 @@ internal sealed class BaroquenMelodyEffectsTests
         await _baroquenMelodyEffects.HandleCompose(new Compose(), _mockDispatcher);
 
         // assert
-        _mockDispatcher.Received().Dispatch(Arg.Is<UpdateBaroquenMelody>(action => action.BaroquenMelody == baroquenMelody));
+        _mockDispatcher.Received().Dispatch(Arg.Is<UpdateBaroquenMelody>(action => action.MidiFileComposition == baroquenMelody));
     }
 
     [Test]

--- a/tests/BaroquenMelody.Library.Tests/Store/Reducers/BaroquenMelodyReducersTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Reducers/BaroquenMelodyReducersTests.cs
@@ -15,13 +15,13 @@ internal sealed class BaroquenMelodyReducersTests
     {
         // arrange
         var state = new BaroquenMelodyState();
-        var action = new UpdateBaroquenMelody(new BaroquenMelody(new MidiFile()), "Test", true);
+        var action = new UpdateBaroquenMelody(new MidiFileComposition(new MidiFile()), "Test", true);
 
         // act
         var newState = BaroquenMelodyReducers.ReduceUpdateBaroquenMelody(state, action);
 
         // assert
-        newState.BaroquenMelody.Should().Be(action.BaroquenMelody);
+        newState.Composition.Should().Be(action.MidiFileComposition);
         newState.Path.Should().Be(action.Path);
         newState.HasBeenSaved.Should().BeTrue();
     }


### PR DESCRIPTION
## Description

Fixes an issue where Razor pages confuse the `BaroquenMelody.App.*` namespace with a static `App` field on the existing `BaroquenMelody` type. Simple rename of `BaroquenMelody` and `BaroquenMelodyComposer`.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
