### PR TITLE
Tonal Range Audio Samples

### DIFF
--- a/src/BaroquenMelody.App.Components/Shared/CompositionProgress.razor
+++ b/src/BaroquenMelody.App.Components/Shared/CompositionProgress.razor
@@ -272,10 +272,11 @@ else
 
     private string GetMidiFileAsBase64()
     {
-        var localFilePath = BaroquenMelodyState.Value.Path;
-        var bytes = File.ReadAllBytes(localFilePath);
+        using var stream = new MemoryStream();
 
-        return Convert.ToBase64String(bytes);
+        BaroquenMelodyState.Value.Composition!.MidiFile.Write(stream);
+
+        return Convert.ToBase64String(stream.ToArray());
     }
 
     public new async ValueTask DisposeAsync()

--- a/src/BaroquenMelody.App.Components/Shared/InstrumentConfigurationCard.razor
+++ b/src/BaroquenMelody.App.Components/Shared/InstrumentConfigurationCard.razor
@@ -9,6 +9,10 @@
         </HeaderContent>
     </CardHeaderSwitch>
     <MudCardContent>
+        <InstrumentRangePlayer @ref="_instrumentRangePlayer" 
+                               MidiInstrument="MidiInstrument"
+                               LowNote="LowestPitchNote"
+                               HighNote="HighestPitchNote" />
         <MudGrid Justify="Justify.SpaceBetween">
             <MudItem xs="12" sm="6" md="5" lg="4" xl="3" xxl="2">
                 <AutocompleteWithPopover T="GeneralMidi2Program"
@@ -33,8 +37,10 @@
                 </AutocompleteWithPopover>
             </MudItem>
             <MudFlexBreak/>
-            <MudItem xs="12" Class="d-none d-sm-flex justify-center">
-                <MudText Typo="Typo.button">Tonal Range</MudText>
+            <MudItem xs="12" Class="d-flex justify-center">
+                <MudText Typo="Typo.button">
+                    Tonal Range
+                </MudText>
             </MudItem>
             <MudItem Class="d-none d-sm-flex mb-n8 mt-n8" xs="12" sm="12">
                 <RangeSlider T="int"
@@ -62,9 +68,10 @@
                            @bind-Value="LowestPitchNoteIndex"
                            Label="Lowest Pitch"
                            Variant="Variant.Outlined"
-                           AdornmentIcon="@Icons.Material.Outlined.ArrowCircleDown"
+                           AdornmentIcon="@Icons.Material.Outlined.PlayArrow"
                            Adornment="Adornment.End"
                            AdornmentColor="Color.Secondary"
+                           OnAdornmentClick="async () => await _instrumentRangePlayer!.PlayLowNote()"
                            Disabled="Status.IsFrozen()">
                     @foreach (var noteIndex in LowestPitchNoteIndices)
                     {
@@ -77,9 +84,10 @@
                            Label="Highest Pitch"
                            T="int"
                            Variant="Variant.Outlined"
-                           AdornmentIcon="@Icons.Material.Outlined.ArrowCircleUp"
+                           AdornmentIcon="@Icons.Material.Outlined.PlayArrow"
                            Adornment="Adornment.End"
                            AdornmentColor="Color.Secondary"
+                           OnAdornmentClick="async () => await _instrumentRangePlayer!.PlayHighNote()"
                            Disabled="Status.IsFrozen()">
                     @foreach (var noteIndex in HighestPitchNoteIndices)
                     {
@@ -87,7 +95,7 @@
                     }
                 </MudSelect>
             </MudItem>
-            <MudItem xs="12" Class="d-none d-sm-flex justify-center">
+            <MudItem xs="12" Class="d-flex justify-center">
                 <MudText Typo="Typo.button">Volume Range</MudText>
             </MudItem>
             <MudItem Class="d-none d-sm-flex mb-n8 mt-n8" xs="12" sm="12">
@@ -146,6 +154,8 @@
 @code
 {
     [Parameter, EditorRequired] public required Instrument Instrument { get; set; }
+
+    private InstrumentRangePlayer? _instrumentRangePlayer;
 
     private Note LowestPitchNote => InstrumentConfigurationState.Value[Instrument]?.MinNote ?? Notes.C3;
 

--- a/src/BaroquenMelody.App.Components/Shared/InstrumentRangePlayer.razor
+++ b/src/BaroquenMelody.App.Components/Shared/InstrumentRangePlayer.razor
@@ -1,0 +1,53 @@
+﻿<midi-player id="low-note-player"
+             class="d-none"
+             @ref="_lowNotePlayer"
+             src="data:audio/midi;base64,@(GetLowerPitchExampleMidi())"
+             sound-font>
+</midi-player>
+<midi-player id="high-note-player"
+             class="d-none"
+             @ref="_highNotePlayer"
+             src="data:audio/midi;base64,@(GetHigherPitchExampleMidi())"
+             sound-font>
+</midi-player>
+
+@code {
+
+    [Parameter, EditorRequired] public required Note LowNote { get; set; }
+
+    [Parameter, EditorRequired] public required Note HighNote { get; set; }
+
+    [Parameter, EditorRequired] public required GeneralMidi2Program MidiInstrument { get; set; }
+
+    private ElementReference _lowNotePlayer { get; set; }
+
+    private ElementReference _highNotePlayer { get; set; }
+
+    public Task PlayLowNote() => PlayMidi(_lowNotePlayer);
+
+    public Task PlayHighNote() => PlayMidi(_highNotePlayer);
+
+    private async Task PlayMidi(ElementReference player)
+    {
+        if (!await JsRuntime.InvokeVoidAsyncWithErrorHandling("startMidiPlayer", player))
+        {
+            Snackbar.Add("Failed to play MIDI audio. This may be due to missing MIDI drivers on your device.", Severity.Error);
+        }
+    }
+
+    private string GetLowerPitchExampleMidi() => GetExampleMidi(LowNote);
+
+    private string GetHigherPitchExampleMidi() => GetExampleMidi(HighNote);
+
+    private string GetExampleMidi(Note note)
+    {
+        using var stream = new MemoryStream();
+
+        var midiFile = MidiExampleGenerator.GenerateExampleNoteMidiFile(MidiInstrument, note);
+
+        midiFile.Write(stream);
+
+        return Convert.ToBase64String(stream.ToArray());
+    }
+
+}

--- a/src/BaroquenMelody.App.Components/_Imports.razor
+++ b/src/BaroquenMelody.App.Components/_Imports.razor
@@ -58,3 +58,4 @@
 @inject IMidiInstrumentRepository MidiInstrumentRepository
 @inject IPhysicalDeviceInfo PhysicalDeviceInfo
 @inject IJSRuntime JsRuntime
+@inject IMidiExampleGenerator MidiExampleGenerator

--- a/src/BaroquenMelody.App/wwwroot/index.html
+++ b/src/BaroquenMelody.App/wwwroot/index.html
@@ -32,6 +32,10 @@
     <script src="_content/CodeBeam.MudBlazor.Extensions/MudExtensions.min.js"></script>
     <script src="https://cdn.jsdelivr.net/combine/npm/tone@14.7.58,npm/@magenta/music@1.23.1/es6/core.js,npm/focus-visible@5,npm/html-midi-player@1.5.0"></script>
     <script type="text/javascript">
+        function startMidiPlayer(player) {
+            player.start();
+        }
+
         function stopMidiPlayer(player) {
             player.stop();
         }

--- a/src/BaroquenMelody.Library/Domain/BaroquenScale.cs
+++ b/src/BaroquenMelody.Library/Domain/BaroquenScale.cs
@@ -96,6 +96,11 @@ public sealed class BaroquenScale
     /// </summary>
     public Mode Mode { get; }
 
+    /// <summary>
+    ///     The available notes for use in the composition.
+    /// </summary>
+    public IList<Note> AvailableNotes { get; }
+
     public BaroquenScale(NoteName tonic, Mode mode)
         : this(Scale.Parse($"{tonic} {mode}"))
     {
@@ -134,6 +139,11 @@ public sealed class BaroquenScale
         V = new HashSet<NoteName> { Dominant, LeadingTone, Supertonic }.ToFrozenSet();
         VI = new HashSet<NoteName> { Submediant, Tonic, Mediant }.ToFrozenSet();
         VII = new HashSet<NoteName> { LeadingTone, Supertonic, Subdominant }.ToFrozenSet();
+
+        AvailableNotes = _notes.Where(note =>
+            note.NoteNumber >= Notes.A0.NoteNumber &&
+            note.NoteNumber <= Notes.C8.NoteNumber
+        ).ToList();
     }
 
     /// <summary>

--- a/src/BaroquenMelody.Library/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BaroquenMelody.Library/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using BaroquenMelody.Library.Configurations.Services;
+using BaroquenMelody.Library.Midi;
 using BaroquenMelody.Library.Midi.Repositories;
 using Fluxor;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,5 +26,6 @@ public static class ServiceCollectionExtensions
         .AddSingleton<ICompositionRuleConfigurationService, CompositionRuleConfigurationService>()
         .AddSingleton<IInstrumentConfigurationService, InstrumentConfigurationService>()
         .AddSingleton<ICompositionConfigurationService, CompositionConfigurationService>()
-        .AddSingleton<IMidiInstrumentRepository, MidiInstrumentRepository>();
+        .AddSingleton<IMidiInstrumentRepository, MidiInstrumentRepository>()
+        .AddSingleton<IMidiExampleGenerator, MidiExampleGenerator>();
 }

--- a/src/BaroquenMelody.Library/Midi/Extensions/PatternBuilderExtensions.cs
+++ b/src/BaroquenMelody.Library/Midi/Extensions/PatternBuilderExtensions.cs
@@ -14,7 +14,8 @@ internal static class PatternBuilderExtensions
     /// </summary>
     /// <param name="patternBuilder">The <see cref="PatternBuilder"/> to add the <see cref="BaroquenNote"/> to.</param>
     /// <param name="note">The <see cref="BaroquenNote"/> to add to the <see cref="PatternBuilder"/>.</param>
-    public static void AddNote(this PatternBuilder patternBuilder, BaroquenNote note)
+    /// <returns>The <see cref="PatternBuilder"/> with the <see cref="BaroquenNote"/> and its ornamentations added.</returns>
+    public static PatternBuilder AddNote(this PatternBuilder patternBuilder, BaroquenNote note)
     {
         patternBuilder
             .SetNoteLength(note.MusicalTimeSpan)
@@ -25,6 +26,8 @@ internal static class PatternBuilderExtensions
         {
             patternBuilder.AddNote(ornamentation);
         }
+
+        return patternBuilder;
     }
 
     /// <summary>
@@ -32,5 +35,9 @@ internal static class PatternBuilderExtensions
     /// </summary>
     /// <param name="patternBuilder">The <see cref="PatternBuilder"/> to add the rest to.</param>
     /// <param name="length">The length of the rest to add to the <see cref="PatternBuilder"/>.</param>
-    public static void AddRest(this PatternBuilder patternBuilder, MusicalTimeSpan length) => patternBuilder.StepForward(length);
+    /// <returns>The <see cref="PatternBuilder"/> with the rest added.</returns>
+    public static PatternBuilder AddRest(this PatternBuilder patternBuilder, MusicalTimeSpan length)
+    {
+        return patternBuilder.StepForward(length);
+    }
 }

--- a/src/BaroquenMelody.Library/Midi/IMidiExampleGenerator.cs
+++ b/src/BaroquenMelody.Library/Midi/IMidiExampleGenerator.cs
@@ -1,0 +1,16 @@
+﻿using Melanchall.DryWetMidi.Core;
+using Melanchall.DryWetMidi.MusicTheory;
+using Melanchall.DryWetMidi.Standards;
+
+namespace BaroquenMelody.Library.Midi;
+
+public interface IMidiExampleGenerator
+{
+    /// <summary>
+    ///     Generate a <see cref="MidiFile"/> example for the given <see cref="GeneralMidi2Program"/> and <see cref="Note"/>.
+    /// </summary>
+    /// <param name="midiProgram">The <see cref="GeneralMidi2Program"/> to generate a <see cref="MidiFile"/> example for.</param>
+    /// <param name="note">The <see cref="Note"/> to generate a <see cref="MidiFile"/> example for.</param>
+    /// <returns>A <see cref="MidiFile"/> example for the given <see cref="GeneralMidi2Program"/> and <see cref="Note"/>.</returns>
+    MidiFile GenerateExampleNoteMidiFile(GeneralMidi2Program midiProgram, Note note);
+}

--- a/src/BaroquenMelody.Library/Midi/MidiExampleGenerator.cs
+++ b/src/BaroquenMelody.Library/Midi/MidiExampleGenerator.cs
@@ -1,0 +1,34 @@
+﻿using BaroquenMelody.Library.Domain;
+using BaroquenMelody.Library.Enums;
+using BaroquenMelody.Library.Midi.Extensions;
+using Melanchall.DryWetMidi.Common;
+using Melanchall.DryWetMidi.Composing;
+using Melanchall.DryWetMidi.Core;
+using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.Standards;
+using Note = Melanchall.DryWetMidi.MusicTheory.Note;
+
+namespace BaroquenMelody.Library.Midi;
+
+public sealed class MidiExampleGenerator : IMidiExampleGenerator
+{
+    public MidiFile GenerateExampleNoteMidiFile(GeneralMidi2Program midiProgram, Note note)
+    {
+        var patternBuilder = new PatternBuilder().ProgramChange(midiProgram);
+
+        var baroquenNote = new BaroquenNote(Instrument.One, note, MusicalTimeSpan.Quarter)
+        {
+            Velocity = new SevenBitNumber(100)
+        };
+
+        patternBuilder.AddNote(baroquenNote).AddRest(MusicalTimeSpan.Quarter);
+
+        var tempoMap = TempoMap.Create(Tempo.FromBeatsPerMinute(120));
+        var chunks = patternBuilder.Build().ToTrackChunk(tempoMap, FourBitNumber.Values[0]);
+        var midiFile = new MidiFile(chunks);
+
+        midiFile.ReplaceTempoMap(tempoMap);
+
+        return midiFile;
+    }
+}

--- a/src/BaroquenMelody.Library/Midi/MidiGenerator.cs
+++ b/src/BaroquenMelody.Library/Midi/MidiGenerator.cs
@@ -7,9 +7,7 @@ using Melanchall.DryWetMidi.Common;
 using Melanchall.DryWetMidi.Composing;
 using Melanchall.DryWetMidi.Core;
 using Melanchall.DryWetMidi.Interaction;
-using Melanchall.DryWetMidi.Standards;
 using System.Collections.Frozen;
-using Note = Melanchall.DryWetMidi.MusicTheory.Note;
 
 namespace BaroquenMelody.Library.Midi;
 

--- a/src/BaroquenMelody.Library/Midi/MidiGenerator.cs
+++ b/src/BaroquenMelody.Library/Midi/MidiGenerator.cs
@@ -7,7 +7,9 @@ using Melanchall.DryWetMidi.Common;
 using Melanchall.DryWetMidi.Composing;
 using Melanchall.DryWetMidi.Core;
 using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.Standards;
 using System.Collections.Frozen;
+using Note = Melanchall.DryWetMidi.MusicTheory.Note;
 
 namespace BaroquenMelody.Library.Midi;
 

--- a/src/BaroquenMelody.Library/Store/State/CompositionConfigurationState.cs
+++ b/src/BaroquenMelody.Library/Store/State/CompositionConfigurationState.cs
@@ -13,11 +13,7 @@ public sealed record CompositionConfigurationState(NoteName TonicNote, Mode Mode
 {
     public BaroquenScale Scale { get; } = new(TonicNote, Mode);
 
-    public IList<Note> AvailableNotes { get; } = new BaroquenScale(TonicNote, Mode)
-        .GetNotes()
-        .Where(note => note.NoteNumber >= Notes.C0.NoteNumber)
-        .Where(note => note.NoteNumber <= Notes.C8.NoteNumber)
-        .ToList();
+    public IList<Note> AvailableNotes { get; } = new BaroquenScale(TonicNote, Mode).AvailableNotes;
 
     public CompositionConfigurationState()
         : this(NoteName.C, Mode.Ionian, Meter.FourFour)

--- a/tests/BaroquenMelody.Library.Tests/Midi/MidiExampleGeneratorTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Midi/MidiExampleGeneratorTests.cs
@@ -1,0 +1,37 @@
+﻿using BaroquenMelody.Library.Midi;
+using FluentAssertions;
+using Melanchall.DryWetMidi.Interaction;
+using Melanchall.DryWetMidi.MusicTheory;
+using Melanchall.DryWetMidi.Standards;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Midi;
+
+[TestFixture]
+internal sealed class MidiExampleGeneratorTests
+{
+    private MidiExampleGenerator _midiExampleGenerator = null!;
+
+    [SetUp]
+    public void SetUp() => _midiExampleGenerator = new MidiExampleGenerator();
+
+    [Test]
+    public void GenerateExampleMidiFile_WhenGivenValidInput_ReturnsMidiFile()
+    {
+        // arrange
+        const GeneralMidi2Program midiProgram = GeneralMidi2Program.AcousticGrandPiano;
+
+        // act
+        var midiFile = _midiExampleGenerator.GenerateExampleNoteMidiFile(midiProgram, Notes.C4);
+
+        // assert
+        var notes = midiFile.GetNotes();
+
+        notes.Should().HaveCount(1);
+
+        var note = notes.First();
+
+        note.Should().NotBeNull();
+        note.NoteNumber.Should().Be(Notes.C4.NoteNumber);
+    }
+}


### PR DESCRIPTION
## Description

Add the ability to play audio samples of the selected instrument and its highest/lowest note on the instrumentation tab.

Other changes:

- Restrict tonal range to standard grand piano keyboard range
- Play composition from `MemoryStream` rather than from disk

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
