### PR TITLE
Informational Instrumentation Popovers

### DIFF
--- a/src/BaroquenMelody.App.Components/Shared/InstrumentTonalRange.razor
+++ b/src/BaroquenMelody.App.Components/Shared/InstrumentTonalRange.razor
@@ -8,8 +8,18 @@
 <MudGrid Justify="Justify.SpaceBetween">
     <MudItem xs="12" Class="d-flex justify-center">
         <MudText Typo="Typo.button">
-            Tonal Range
+            Tonal Range <MudIconButton Size="Size.Small" Icon="@Icons.Material.Outlined.QuestionMark" OnClick="OpenPopover" />
         </MudText>
+        <AutoClosePopover IsPopoverOpen="IsPopoverOpen"
+                          OnPopoverClosed="@(() => IsPopoverOpen = false)">
+            <PopoverContent>
+                <MudContainer MaxWidth="MaxWidth.ExtraSmall" Gutters="false">
+                    <MudText>
+                        The tonal range of the instrument, defining its lowest and highest playable notes. <br/><br/> Note that some MIDI instruments may not support the full range of notes, so be sure to test them out.
+                    </MudText>
+                </MudContainer>
+            </PopoverContent>
+        </AutoClosePopover>
     </MudItem>
     <MudItem Class="d-none d-sm-flex mb-n8 mt-n8" xs="12" sm="12">
         <RangeSlider T="int"
@@ -70,6 +80,8 @@
     [Parameter, EditorRequired] public required Instrument Instrument { get; set; }
 
     [Parameter, EditorRequired] public required ConfigurationStatus Status { get; set; }
+
+    private bool IsPopoverOpen = false;
 
     private InstrumentRangePlayer? _instrumentRangePlayer;
 
@@ -176,6 +188,8 @@
             CompositionConfigurationState.Value.AvailableNotes[noteIndex]
         )
     );
+
+    private void OpenPopover() => IsPopoverOpen = true;
 
     protected virtual void Dispose(bool disposing)
     {

--- a/src/BaroquenMelody.App.Components/Shared/InstrumentVelocityRange.razor
+++ b/src/BaroquenMelody.App.Components/Shared/InstrumentVelocityRange.razor
@@ -3,8 +3,19 @@
 
 <MudGrid Justify="Justify.SpaceBetween">
     <MudItem xs="12" Class="d-flex justify-center">
-        <MudText Typo="Typo.button">Volume Range</MudText>
-    </MudItem>
+        <MudText Typo="Typo.button">
+            Volume Range <MudIconButton Size="Size.Small" Class="mb-1" Icon="@Icons.Material.Outlined.QuestionMark" OnClick="OpenPopover"/>
+        </MudText>
+        <AutoClosePopover IsPopoverOpen="IsPopoverOpen"
+                          OnPopoverClosed="@(() => IsPopoverOpen = false)">
+            <PopoverContent>
+                <MudContainer MaxWidth="MaxWidth.ExtraSmall" Gutters="false">
+                    <MudText>
+                        The volume range (or <MudLink Color="Color.Tertiary" Href="https://en.wikipedia.org/wiki/Dynamics_(music)">dynamic range</MudLink>) of the instrument, defining its softest and loudest playable notes.
+                    </MudText>
+                </MudContainer>
+            </PopoverContent>
+        </AutoClosePopover>    </MudItem>
     <MudItem Class="d-none d-sm-flex mb-n8 mt-n8" xs="12" sm="12">
         <RangeSlider T="byte"
                      @bind-Value="MinVelocityValue"
@@ -60,6 +71,8 @@
     [Parameter, EditorRequired] public Instrument Instrument { get; set; }
 
     [Parameter, EditorRequired] public ConfigurationStatus Status { get; set; }
+
+    private bool IsPopoverOpen = false;
 
     private const byte VelocityRangeSliderMin = 0;
 
@@ -161,6 +174,8 @@
             new SevenBitNumber(velocity)
         )
     );
+
+    private void OpenPopover() => IsPopoverOpen = true;
 
     protected virtual void Dispose(bool disposing)
     {


### PR DESCRIPTION
## Description

Adds some informational popovers to the instrumentation configuration card.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
