### PR TITLE
Add Composition Complete Notification

### DIFF
--- a/src/BaroquenMelody.App.Components/Pages/Home.razor
+++ b/src/BaroquenMelody.App.Components/Pages/Home.razor
@@ -113,9 +113,24 @@
             .ObserveChanges()
             .Subscribe(state =>
             {
-                if (state.Value.CurrentStep == CompositionStep.Failed && _tabs?.ActivePanel != _compositionTab)
+                switch (state.Value.CurrentStep)
                 {
-                    Snackbar.Add("Failed to compose. Try again, or try a different configuration.", Severity.Error);
+                    case CompositionStep.Failed when _tabs?.ActivePanel != _compositionTab:
+                        Snackbar.Add("Failed to compose. Try again, or try a different configuration.", Severity.Error);
+                        break;
+                    case CompositionStep.Complete when _tabs?.ActivePanel != _compositionTab:
+                        Snackbar.Add("Composition complete!", Severity.Success, snackbarOptions =>
+                        {
+                            snackbarOptions.Onclick = _ =>
+                            {
+                                ActivateCompositionTab();
+
+                                return Task.CompletedTask;
+                            };
+
+                            snackbarOptions.Icon = Icons.Material.Filled.MusicNote;
+                        });
+                        break;
                 }
             });
 


### PR DESCRIPTION
## Description

Add a notification indicating that composition has completed, only shown if not currently on the composition tab.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
