### PR TITLE
Batch Randomization / Reset

### DIFF
--- a/src/BaroquenMelody.Library/Store/Actions/BatchUpdateCompositionOrnamentationConfiguration.cs
+++ b/src/BaroquenMelody.Library/Store/Actions/BatchUpdateCompositionOrnamentationConfiguration.cs
@@ -1,0 +1,6 @@
+﻿using BaroquenMelody.Library.Configurations;
+using BaroquenMelody.Library.Ornamentation.Enums;
+
+namespace BaroquenMelody.Library.Store.Actions;
+
+public sealed record BatchUpdateCompositionOrnamentationConfiguration(IDictionary<OrnamentationType, OrnamentationConfiguration> Configurations);

--- a/src/BaroquenMelody.Library/Store/Actions/BatchUpdateCompositionRuleConfiguration.cs
+++ b/src/BaroquenMelody.Library/Store/Actions/BatchUpdateCompositionRuleConfiguration.cs
@@ -1,0 +1,6 @@
+﻿using BaroquenMelody.Library.Configurations;
+using BaroquenMelody.Library.Rules.Enums;
+
+namespace BaroquenMelody.Library.Store.Actions;
+
+public sealed record BatchUpdateCompositionRuleConfiguration(IDictionary<CompositionRule, CompositionRuleConfiguration> Configurations);

--- a/src/BaroquenMelody.Library/Store/Reducers/CompositionOrnamentationConfigurationReducers.cs
+++ b/src/BaroquenMelody.Library/Store/Reducers/CompositionOrnamentationConfigurationReducers.cs
@@ -20,4 +20,10 @@ public static class CompositionOrnamentationConfigurationReducers
 
         return new CompositionOrnamentationConfigurationState(configurations);
     }
+
+    [ReducerMethod]
+    public static CompositionOrnamentationConfigurationState ReduceBatchUpdateCompositionOrnamentationConfiguration(
+        CompositionOrnamentationConfigurationState state,
+        BatchUpdateCompositionOrnamentationConfiguration action
+    ) => new(action.Configurations);
 }

--- a/src/BaroquenMelody.Library/Store/Reducers/CompositionRuleConfigurationReducers.cs
+++ b/src/BaroquenMelody.Library/Store/Reducers/CompositionRuleConfigurationReducers.cs
@@ -18,4 +18,7 @@ public static class CompositionRuleConfigurationReducers
 
         return new CompositionRuleConfigurationState(configurations);
     }
+
+    [ReducerMethod]
+    public static CompositionRuleConfigurationState ReduceBatchUpdateCompositionRuleConfiguration(CompositionRuleConfigurationState state, BatchUpdateCompositionRuleConfiguration action) => new(action.Configurations);
 }

--- a/tests/BaroquenMelody.Library.Tests/Configuration/Services/CompositionRuleConfigurationServiceTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Configuration/Services/CompositionRuleConfigurationServiceTests.cs
@@ -65,8 +65,8 @@ internal sealed class CompositionRuleConfigurationServiceTests
 
         // assert
         _mockDispatcher
-            .Received(AggregateCompositionRuleConfiguration.Default.Configurations.Count)
-            .Dispatch(Arg.Any<UpdateCompositionRuleConfiguration>());
+            .Received(1)
+            .Dispatch(Arg.Any<BatchUpdateCompositionRuleConfiguration>());
     }
 
     [Test]
@@ -97,7 +97,7 @@ internal sealed class CompositionRuleConfigurationServiceTests
 
         // assert
         _mockDispatcher
-            .Received(configurations.Count - 2)
-            .Dispatch(Arg.Any<UpdateCompositionRuleConfiguration>());
+            .Received(1)
+            .Dispatch(Arg.Any<BatchUpdateCompositionRuleConfiguration>());
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Configuration/Services/OrnamentationConfigurationServiceTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Configuration/Services/OrnamentationConfigurationServiceTests.cs
@@ -71,8 +71,8 @@ internal sealed class OrnamentationConfigurationServiceTests
 
         // assert
         _mockDispatcher
-            .Received(AggregateOrnamentationConfiguration.Default.Configurations.Count)
-            .Dispatch(Arg.Any<UpdateCompositionOrnamentationConfiguration>());
+            .Received(1)
+            .Dispatch(Arg.Any<BatchUpdateCompositionOrnamentationConfiguration>());
     }
 
     [Test]
@@ -109,7 +109,7 @@ internal sealed class OrnamentationConfigurationServiceTests
 
         // assert
         _mockDispatcher
-            .Received(configurations.Count - 2)
-            .Dispatch(Arg.Any<UpdateCompositionOrnamentationConfiguration>());
+            .Received(1)
+            .Dispatch(Arg.Any<BatchUpdateCompositionOrnamentationConfiguration>());
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Store/Reducers/CompositionOrnamentationConfigurationReducersTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Reducers/CompositionOrnamentationConfigurationReducersTests.cs
@@ -60,4 +60,29 @@ internal sealed class CompositionOrnamentationConfigurationReducersTests
             state[defaultConfiguration.OrnamentationType]!.Should().BeEquivalentTo(defaultConfiguration);
         }
     }
+
+    [Test]
+    public void ReduceBatchUpdateCompositionOrnamentationConfiguration_updates_composition_ornamentation_configurations_as_expected()
+    {
+        // arrange
+        var state = new CompositionOrnamentationConfigurationState();
+
+        var configurations = new Dictionary<OrnamentationType, OrnamentationConfiguration>
+        {
+            [OrnamentationType.Run] = new(OrnamentationType.Run, ConfigurationStatus.Enabled, 1),
+            [OrnamentationType.Mordent] = new(OrnamentationType.Mordent, ConfigurationStatus.Enabled, 2),
+            [OrnamentationType.Turn] = new(OrnamentationType.Turn, ConfigurationStatus.Enabled, 3)
+        };
+
+        // act
+        state = CompositionOrnamentationConfigurationReducers.ReduceBatchUpdateCompositionOrnamentationConfiguration(
+            state,
+            new BatchUpdateCompositionOrnamentationConfiguration(configurations)
+        );
+
+        // assert
+        state.Configurations
+            .Should()
+            .BeEquivalentTo(configurations);
+    }
 }

--- a/tests/BaroquenMelody.Library.Tests/Store/Reducers/CompositionRuleConfigurationReducersTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Reducers/CompositionRuleConfigurationReducersTests.cs
@@ -48,4 +48,36 @@ internal sealed class CompositionRuleConfigurationReducersTests
             state[defaultConfiguration.Rule]!.Should().BeEquivalentTo(defaultConfiguration);
         }
     }
+
+    [Test]
+    public void ReduceBatchUpdateCompositionRuleConfiguration_updates_composition_rule_configurations_as_expected()
+    {
+        // arrange
+        var state = new CompositionRuleConfigurationState();
+
+        // act
+        state = CompositionRuleConfigurationReducers.ReduceBatchUpdateCompositionRuleConfiguration(
+            state,
+            new BatchUpdateCompositionRuleConfiguration(
+                new Dictionary<CompositionRule, CompositionRuleConfiguration>
+                {
+                    [CompositionRule.AvoidDissonance] = new(CompositionRule.AvoidDissonance, ConfigurationStatus.Enabled, 2),
+                    [CompositionRule.AvoidRepeatedChords] = new(CompositionRule.AvoidRepeatedChords, ConfigurationStatus.Enabled, 3),
+                    [CompositionRule.AvoidDirectFifths] = new(CompositionRule.AvoidDirectFifths, ConfigurationStatus.Disabled, 4)
+                }
+            )
+        );
+
+        // assert
+        state.Configurations
+            .Should()
+            .ContainKeys(CompositionRule.AvoidDirectFifths, CompositionRule.AvoidDissonance, CompositionRule.AvoidRepeatedChords);
+
+        state[CompositionRule.AvoidDirectFifths]!.Strictness.Should().Be(4);
+        state[CompositionRule.AvoidDirectFifths]!.IsEnabled.Should().BeFalse();
+        state[CompositionRule.AvoidDissonance]!.Strictness.Should().Be(2);
+        state[CompositionRule.AvoidDissonance]!.IsEnabled.Should().BeTrue();
+        state[CompositionRule.AvoidRepeatedChords]!.Strictness.Should().Be(3);
+        state[CompositionRule.AvoidRepeatedChords]!.IsEnabled.Should().BeTrue();
+    }
 }


### PR DESCRIPTION
## Description

Batch randomization and reset of composition rules and ornamentation configurations

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
