### PR TITLE
Refactor Ornamentation

### DIFF
--- a/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
+++ b/src/BaroquenMelody.Library/BaroquenMelody.Library.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atrea.PolicyEngine" Version="4.0.1" />
+    <PackageReference Include="Atrea.PolicyEngine" Version="4.1.0" />
     <PackageReference Include="Atrea.Utilities" Version="1.0.0" />
     <PackageReference Include="LazyCart" Version="0.4.5" />
     <PackageReference Include="Meziantou.Analyzer" Version="2.0.182">

--- a/src/BaroquenMelody.Library/Ornamentation/Cleaning/Engine/Processors/OrnamentationCleaner.cs
+++ b/src/BaroquenMelody.Library/Ornamentation/Cleaning/Engine/Processors/OrnamentationCleaner.cs
@@ -22,8 +22,10 @@ internal sealed class OrnamentationCleaner(
         var notePair = configuration.NotePairSelector.Select(item);
 
         var hasStrongPulseConflicts = configuration.NoteIndexPairs
-            .Where(noteIndexPair => noteIndexPair.OccursOnStrongPulse)
-            .Any(noteIndexPair => notePair.PrimaryNote.Ornamentations[noteIndexPair.PrimaryNoteIndex].IsDissonantWith(notePair.SecondaryNote.Ornamentations[noteIndexPair.SecondaryNoteIndex]));
+            .Any(noteIndexPair =>
+                noteIndexPair.OccursOnStrongPulse &&
+                notePair.PrimaryNote.Ornamentations[noteIndexPair.PrimaryNoteIndex].IsDissonantWith(notePair.SecondaryNote.Ornamentations[noteIndexPair.SecondaryNoteIndex])
+            );
 
         if (hasStrongPulseConflicts)
         {
@@ -33,8 +35,10 @@ internal sealed class OrnamentationCleaner(
         }
 
         var hasWeakPulseConflicts = configuration.NoteIndexPairs
-            .Where(noteIndexPair => !noteIndexPair.OccursOnStrongPulse)
-            .Any(noteIndexPair => notePair.PrimaryNote.Ornamentations[noteIndexPair.PrimaryNoteIndex].IsDissonantWith(notePair.SecondaryNote.Ornamentations[noteIndexPair.SecondaryNoteIndex]));
+            .Any(noteIndexPair =>
+                !noteIndexPair.OccursOnStrongPulse &&
+                notePair.PrimaryNote.Ornamentations[noteIndexPair.PrimaryNoteIndex].IsDissonantWith(notePair.SecondaryNote.Ornamentations[noteIndexPair.SecondaryNoteIndex])
+            );
 
         if (hasWeakPulseConflicts && weightedRandomBooleanGenerator.IsTrue(ChanceOfCleaningWeakConflicts))
         {
@@ -44,8 +48,6 @@ internal sealed class OrnamentationCleaner(
 
     private void CleanConflictingOrnamentation(OrnamentationCleaningItem item)
     {
-        var noteToClean = configuration.NoteTargetSelector.Select(item);
-
-        noteToClean.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
+        item.Note.ResetOrnamentation(compositionConfiguration.DefaultNoteTimeSpan);
     }
 }

--- a/tests/BaroquenMelody.Library.Tests/Ornamentation/Engine/Policies/Output/CleanConflictingOrnamentationsTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Ornamentation/Engine/Policies/Output/CleanConflictingOrnamentationsTests.cs
@@ -54,6 +54,6 @@ internal sealed class CleanConflictingOrnamentationsTests
         _cleanConflictingOrnamentations.Apply(ornamentationItem);
 
         // assert
-        _mockOrnamentationCleaningEngine.Received(6).Process(Arg.Any<OrnamentationCleaningItem>());
+        _mockOrnamentationCleaningEngine.Received(3).Process(Arg.Any<OrnamentationCleaningItem>());
     }
 }


### PR DESCRIPTION
## Description

Refactor how ornamentation is applied - cleaning after each processor pass to increase the likelihood of non-conflicting ornamentations being applied. Shuffle ornamentation processors after each pass to increase variety. 

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
