### PR TITLE
Pre-fill Last Loaded/Saved Config Name

### DIFF
--- a/src/BaroquenMelody.App.Components/Pages/Home.razor
+++ b/src/BaroquenMelody.App.Components/Pages/Home.razor
@@ -107,7 +107,7 @@
 
     private IDisposable? _compositionProgressSubscription;
 
-    protected override Task OnInitializedAsync()
+    protected override async Task OnInitializedAsync()
     {
         _compositionProgressSubscription = CompositionProgressState
             .ObserveChanges()
@@ -134,7 +134,7 @@
                 }
             });
 
-        return base.OnInitializedAsync();
+        await base.OnInitializedAsync();
     }
 
     private async Task Compose()

--- a/src/BaroquenMelody.App.Components/Pages/Home.razor
+++ b/src/BaroquenMelody.App.Components/Pages/Home.razor
@@ -107,7 +107,7 @@
 
     private IDisposable? _compositionProgressSubscription;
 
-    protected override async Task OnInitializedAsync()
+    protected override Task OnInitializedAsync()
     {
         _compositionProgressSubscription = CompositionProgressState
             .ObserveChanges()
@@ -134,7 +134,7 @@
                 }
             });
 
-        await base.OnInitializedAsync();
+        return base.OnInitializedAsync();
     }
 
     private async Task Compose()

--- a/src/BaroquenMelody.App.Components/Pages/SavedConfigurations.razor
+++ b/src/BaroquenMelody.App.Components/Pages/SavedConfigurations.razor
@@ -28,7 +28,7 @@
         </HeaderContent>
         <RowTemplate>
             <MudTd DataLabel="Configuration">
-                <MudLink Color="Color.Tertiary" Class="cursor-pointer" OnClick="_ => LoadConfiguration(context.Configuration)">
+                <MudLink Color="Color.Tertiary" Class="cursor-pointer" OnClick="_ => LoadConfiguration(context)">
                     @(Path.GetFileNameWithoutExtension(context.ConfigurationFile.Name))
                 </MudLink>
             </MudTd>
@@ -41,7 +41,7 @@
                         <MudIconButton Icon="@Icons.Material.Filled.FileOpen"
                                        Color="Color.Primary"
                                        Variant="Variant.Outlined"
-                                       OnClick="_ => LoadConfiguration(context.Configuration)"/>
+                                       OnClick="_ => LoadConfiguration(context)"/>
                     </MudTooltip>
                     <MudTooltip Text="delete configuration" Delay="@ThemeProvider.TooltipDelay" Duration="@ThemeProvider.TooltipDuration">
                         <MudIconButton Icon="@Icons.Material.Filled.Delete"
@@ -115,9 +115,10 @@
         ));
     }
 
-    private void LoadConfiguration(CompositionConfiguration compositionConfiguration)
+    private void LoadConfiguration(SavedCompositionConfiguration savedCompositionConfiguration)
     {
-        Dispatcher.Dispatch(new LoadSavedCompositionConfiguration(compositionConfiguration));
+        Dispatcher.Dispatch(new LoadSavedCompositionConfiguration(savedCompositionConfiguration.Configuration));
+        Dispatcher.Dispatch(new UpdateLastLoadedConfigurationName(Path.GetFileNameWithoutExtension(savedCompositionConfiguration.ConfigurationFile.Name)));
 
         NavigationManager.NavigateTo("");
     }

--- a/src/BaroquenMelody.App.Components/Shared/SaveCompositionConfigurationDialog.razor
+++ b/src/BaroquenMelody.App.Components/Shared/SaveCompositionConfigurationDialog.razor
@@ -29,6 +29,13 @@
 
     [CascadingParameter] private MudDialogInstance? MudDialog { get; set; }
 
+    protected override void OnInitialized()
+    {
+        ConfigurationName = SavedCompositionConfigurationState.Value.LastLoadedConfigurationName;
+
+        base.OnInitialized();
+    }
+
     private async Task SaveCompositionConfiguration()
     {
         var configurationFileExists = await CompositionConfigurationPersistenceService.DoesConfigurationExist(

--- a/src/BaroquenMelody.App.Components/Shared/SaveCompositionConfigurationDialog.razor
+++ b/src/BaroquenMelody.App.Components/Shared/SaveCompositionConfigurationDialog.razor
@@ -77,6 +77,8 @@
             new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token
         );
 
+        Dispatcher.Dispatch(new UpdateLastLoadedConfigurationName(ConfigurationName));
+
         MudDialog?.Close(DialogResult.Ok(isSaved));
     }
 

--- a/src/BaroquenMelody.App.Components/_Imports.razor
+++ b/src/BaroquenMelody.App.Components/_Imports.razor
@@ -43,6 +43,7 @@
 @inject IState<CompositionConfigurationState> CompositionConfigurationState
 @inject IState<CompositionProgressState> CompositionProgressState
 @inject IState<BaroquenMelodyState> BaroquenMelodyState
+@inject IState<SavedCompositionConfigurationState> SavedCompositionConfigurationState
 @inject IDispatcher Dispatcher
 @inject IOrnamentationConfigurationService OrnamentationConfigurationService
 @inject ICompositionRuleConfigurationService CompositionRuleConfigurationService

--- a/src/BaroquenMelody.Library/Store/Actions/UpdateLastLoadedConfigurationName.cs
+++ b/src/BaroquenMelody.Library/Store/Actions/UpdateLastLoadedConfigurationName.cs
@@ -1,0 +1,3 @@
+﻿namespace BaroquenMelody.Library.Store.Actions;
+
+public sealed record UpdateLastLoadedConfigurationName(string LastLoadedConfigurationName);

--- a/src/BaroquenMelody.Library/Store/Reducers/SavedCompositionConfigurationReducers.cs
+++ b/src/BaroquenMelody.Library/Store/Reducers/SavedCompositionConfigurationReducers.cs
@@ -1,0 +1,14 @@
+﻿using BaroquenMelody.Library.Store.Actions;
+using BaroquenMelody.Library.Store.State;
+using Fluxor;
+
+namespace BaroquenMelody.Library.Store.Reducers;
+
+public static class SavedCompositionConfigurationReducers
+{
+    [ReducerMethod]
+    public static SavedCompositionConfigurationState ReduceUpdateLastLoadedConfigurationName(
+        SavedCompositionConfigurationState state,
+        UpdateLastLoadedConfigurationName action
+    ) => new(action.LastLoadedConfigurationName);
+}

--- a/src/BaroquenMelody.Library/Store/State/SavedCompositionConfigurationState.cs
+++ b/src/BaroquenMelody.Library/Store/State/SavedCompositionConfigurationState.cs
@@ -1,0 +1,12 @@
+﻿using Fluxor;
+
+namespace BaroquenMelody.Library.Store.State;
+
+[FeatureState]
+public sealed record SavedCompositionConfigurationState(string LastLoadedConfigurationName)
+{
+    public SavedCompositionConfigurationState()
+        : this(string.Empty)
+    {
+    }
+}

--- a/tests/BaroquenMelody.Library.Tests/Store/Reducers/SavedCompositionConfigurationReducersTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Reducers/SavedCompositionConfigurationReducersTests.cs
@@ -10,7 +10,21 @@ namespace BaroquenMelody.Library.Tests.Store.Reducers;
 internal sealed class SavedCompositionConfigurationReducersTests
 {
     [Test]
-    public void ReduceUpdateLastLoadedConfigurationName()
+    public void ReduceUpdateLastLoadedConfigurationName_with_empty_state_updates_name()
+    {
+        // arrange
+        var state = new SavedCompositionConfigurationState();
+        var action = new UpdateLastLoadedConfigurationName("NewLastLoadedConfigurationName");
+
+        // act
+        var newState = SavedCompositionConfigurationReducers.ReduceUpdateLastLoadedConfigurationName(state, action);
+
+        // assert
+        newState.LastLoadedConfigurationName.Should().Be("NewLastLoadedConfigurationName");
+    }
+
+    [Test]
+    public void ReduceUpdateLastLoadedConfigurationName_with_existing_state_updates_name()
     {
         // arrange
         var state = new SavedCompositionConfigurationState("LastLoadedConfigurationName");

--- a/tests/BaroquenMelody.Library.Tests/Store/Reducers/SavedCompositionConfigurationReducersTests.cs
+++ b/tests/BaroquenMelody.Library.Tests/Store/Reducers/SavedCompositionConfigurationReducersTests.cs
@@ -1,0 +1,25 @@
+﻿using BaroquenMelody.Library.Store.Actions;
+using BaroquenMelody.Library.Store.Reducers;
+using BaroquenMelody.Library.Store.State;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace BaroquenMelody.Library.Tests.Store.Reducers;
+
+[TestFixture]
+internal sealed class SavedCompositionConfigurationReducersTests
+{
+    [Test]
+    public void ReduceUpdateLastLoadedConfigurationName()
+    {
+        // arrange
+        var state = new SavedCompositionConfigurationState("LastLoadedConfigurationName");
+        var action = new UpdateLastLoadedConfigurationName("NewLastLoadedConfigurationName");
+
+        // act
+        var newState = SavedCompositionConfigurationReducers.ReduceUpdateLastLoadedConfigurationName(state, action);
+
+        // assert
+        newState.LastLoadedConfigurationName.Should().Be("NewLastLoadedConfigurationName");
+    }
+}


### PR DESCRIPTION
## Description

Small update to pre-fill the save composition configuration modal with the last loaded / last saved composition configuration name.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/wbaldoumas/baroquen-melody/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
